### PR TITLE
SW-C: source parser, typed resolution, and ownership linker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ test that thesis before any renderer is built.
 ## Status
 
 - **Architecture status:** exploratory and non-authoritative
-- **Implementation status:** workspace, stable IDs, canonical encoding,
-  hashing, and package mechanics implemented (SW-B); no command surface, no
-  parser, no runtime
+- **Implementation status:** workspace foundations (SW-B) plus source schema,
+  parser, typed name resolution, primitive expansion, and ownership linker
+  (SW-C); no command surface or runtime
 - **Contract revision:** 2
 - **Scope:** greenfield / vacuum architecture exercise
 - **Effect on other projects:** none unless separately adopted by an explicit
@@ -38,10 +38,14 @@ it.
    — the reproducible cold-author, cold-debug, and cold-review procedure.
 5. [docs/workspace.md](docs/workspace.md) — the crate map, how to run the
    proof, and the decisions the first implementation slice had to make.
-6. [docs/review/2026-08-21-founding-review.md](docs/review/2026-08-21-founding-review.md)
+6. [docs/authoring.md](docs/authoring.md) — source schema version 1 and the
+   approved Gate K authoring vocabulary.
+7. [docs/compiler.md](docs/compiler.md) — parser/linker stages, schema
+   ownership, proof coverage, and limits.
+8. [docs/review/2026-08-21-founding-review.md](docs/review/2026-08-21-founding-review.md)
    — the condensed primary record of the founding adversarial review, written
    in the originating session, with its provenance limits stated.
-7. [docs/review/2026-08-21-founding-review-synthesis.md](docs/review/2026-08-21-founding-review-synthesis.md)
+9. [docs/review/2026-08-21-founding-review-synthesis.md](docs/review/2026-08-21-founding-review-synthesis.md)
    — the contract-revision-2 edited synthesis of that review.
 
 ## Layout
@@ -51,6 +55,7 @@ README.md          status and reading order
 THESIS.md          the design thesis
 KERNEL.md          the Gate K acceptance contract
 docs/              decisions, evaluation protocols, reviews, workspace notes
+fixtures/          exact Gate K authoring source and later command/replay fixtures
 crates/            the six Gate K kernel crates named in KERNEL.md section 10
 xtask/             workspace tooling; `cargo xtask boundary`
 .github/workflows/ the verification lane

--- a/crates/estate-compiler/src/catalog.rs
+++ b/crates/estate-compiler/src/catalog.rs
@@ -1,0 +1,136 @@
+//! The sealed three-kind Gate K primitive catalog.
+
+use estate_core::{ClaimRef, EntityId, Ident, NamespaceId, PrimitiveKindId};
+use estate_schema::{
+    CapabilityKind, ClaimActivation, ClaimTemplate, ClaimValue, MachineTemplate, PrimitiveExpansion,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ApprovedKind {
+    Door,
+    Water,
+    Light,
+}
+
+pub(crate) fn lookup(id: &PrimitiveKindId) -> Option<ApprovedKind> {
+    match id.name().as_str() {
+        "iron_barred_door" => Some(ApprovedKind::Door),
+        "shallow_water_region" => Some(ApprovedKind::Water),
+        "extinguishable_light" => Some(ApprovedKind::Light),
+        _ => None,
+    }
+}
+
+pub(crate) fn expand(kind: ApprovedKind, entity: &EntityId) -> PrimitiveExpansion {
+    match kind {
+        ApprovedKind::Door => door(entity),
+        ApprovedKind::Water => water(entity),
+        ApprovedKind::Light => light(entity),
+    }
+}
+
+fn door(entity: &EntityId) -> PrimitiveExpansion {
+    let access = machine(entity, "access", &["locked", "closed", "open"], "locked");
+    let integrity = machine(
+        entity,
+        "integrity",
+        &["intact", "damaged", "destroyed"],
+        "intact",
+    );
+    let ward = machine(entity, "ward", &["sealed", "unsealed"], "sealed");
+    let combustion = machine(entity, "combustion", &["cold", "burning", "spent"], "cold");
+    let portal_open = ClaimActivation::Any(vec![
+        state(entity, "access", "open"),
+        state(entity, "integrity", "destroyed"),
+    ]);
+    let claims = vec![
+        ClaimTemplate::new(
+            claim(entity, "portal", "blocks_ground"),
+            CapabilityKind::BlocksGround,
+            ClaimActivation::Not(Box::new(portal_open)),
+            ClaimValue::Bool(true),
+        ),
+        ClaimTemplate::new(
+            claim(entity, "ward", "blocks_ground"),
+            CapabilityKind::BlocksGround,
+            state(entity, "ward", "sealed"),
+            ClaimValue::Bool(true),
+        ),
+    ];
+    PrimitiveExpansion::new(
+        [
+            CapabilityKind::Boundary,
+            CapabilityKind::Portal,
+            CapabilityKind::BlocksGround,
+            CapabilityKind::Machine,
+            CapabilityKind::Interactable,
+            CapabilityKind::Authority,
+            CapabilityKind::Persisted,
+        ],
+        vec![access, integrity, ward, combustion],
+        claims,
+    )
+}
+
+fn water(entity: &EntityId) -> PrimitiveExpansion {
+    PrimitiveExpansion::new(
+        [
+            CapabilityKind::Region,
+            CapabilityKind::TraversalCostGround,
+            CapabilityKind::Authority,
+            CapabilityKind::Persisted,
+        ],
+        Vec::new(),
+        vec![ClaimTemplate::new(
+            claim(entity, "region", "traversal_cost_ground"),
+            CapabilityKind::TraversalCostGround,
+            ClaimActivation::Always,
+            ClaimValue::Uint(3),
+        )],
+    )
+}
+
+fn light(entity: &EntityId) -> PrimitiveExpansion {
+    PrimitiveExpansion::new(
+        [
+            CapabilityKind::Machine,
+            CapabilityKind::Interactable,
+            CapabilityKind::EmitsLight,
+            CapabilityKind::Authority,
+            CapabilityKind::Persisted,
+        ],
+        vec![machine(entity, "emission", &["lit", "extinguished"], "lit")],
+        vec![ClaimTemplate::new(
+            claim(entity, "emission", "emits_light"),
+            CapabilityKind::EmitsLight,
+            state(entity, "emission", "lit"),
+            ClaimValue::Bool(true),
+        )],
+    )
+}
+
+fn machine(entity: &EntityId, namespace: &str, states: &[&str], initial: &str) -> MachineTemplate {
+    MachineTemplate::new(
+        NamespaceId::new(entity.clone(), ident(namespace)),
+        states.iter().map(|state| ident(state)).collect(),
+        ident(initial),
+    )
+}
+
+fn state(entity: &EntityId, namespace: &str, state: &str) -> ClaimActivation {
+    ClaimActivation::StateEquals {
+        namespace: NamespaceId::new(entity.clone(), ident(namespace)),
+        state: ident(state),
+    }
+}
+
+fn claim(entity: &EntityId, namespace: &str, capability: &str) -> ClaimRef {
+    ClaimRef::new(
+        NamespaceId::new(entity.clone(), ident(namespace)),
+        ident(capability),
+    )
+}
+
+fn ident(literal: &str) -> Ident {
+    Ident::new(literal).expect("the built-in primitive catalog uses legal identifiers")
+}

--- a/crates/estate-compiler/src/diagnostics.rs
+++ b/crates/estate-compiler/src/diagnostics.rs
@@ -1,0 +1,78 @@
+//! Stable diagnostics owned by source parsing and linking.
+
+use estate_core::DiagnosticCode;
+
+/// Source text does not match the published grammar.
+pub const SOURCE_SYNTAX: DiagnosticCode = DiagnosticCode::new("EK0501");
+/// The mandatory source-schema declaration is absent or misplaced.
+pub const SOURCE_SCHEMA_REQUIRED: DiagnosticCode = DiagnosticCode::new("EK0502");
+/// The source declares a schema version this compiler does not consume.
+pub const SOURCE_SCHEMA_UNSUPPORTED: DiagnosticCode = DiagnosticCode::new("EK0503");
+/// A lattice coordinate is not a signed 32-bit decimal integer.
+pub const SOURCE_INTEGER_INVALID: DiagnosticCode = DiagnosticCode::new("EK0504");
+/// A statement or entity field is not part of source schema version 1.
+pub const SOURCE_UNKNOWN_STATEMENT: DiagnosticCode = DiagnosticCode::new("EK0505");
+/// An entity declaration reaches end of file without `end`.
+pub const SOURCE_UNCLOSED_ENTITY: DiagnosticCode = DiagnosticCode::new("EK0506");
+/// The source is too large for the contract's 32-bit byte spans.
+pub const SOURCE_TOO_LARGE: DiagnosticCode = DiagnosticCode::new("EK0507");
+
+/// An entity ID is declared more than once.
+pub const DUPLICATE_ENTITY: DiagnosticCode = DiagnosticCode::new("EK0601");
+/// A catalog value is declared more than once.
+pub const DUPLICATE_CATALOG_VALUE: DiagnosticCode = DiagnosticCode::new("EK0602");
+/// A graph relation references an undeclared entity.
+pub const DANGLING_ENTITY: DiagnosticCode = DiagnosticCode::new("EK0603");
+/// A primitive field references an undeclared catalog value.
+pub const DANGLING_CATALOG_VALUE: DiagnosticCode = DiagnosticCode::new("EK0604");
+/// A primitive kind is not in the sealed Gate K catalog.
+pub const UNAPPROVED_PRIMITIVE: DiagnosticCode = DiagnosticCode::new("EK0605");
+/// An approved primitive is missing one of its required fields.
+pub const REQUIRED_FIELD_MISSING: DiagnosticCode = DiagnosticCode::new("EK0606");
+/// A field or binding kind is not accepted by the selected primitive.
+pub const FIELD_NOT_ALLOWED: DiagnosticCode = DiagnosticCode::new("EK0607");
+/// The same source-owned field is supplied more than once.
+pub const DUPLICATE_FIELD: DiagnosticCode = DiagnosticCode::new("EK0608");
+/// A region's component-wise minimum is greater than its maximum.
+pub const REGION_BOUNDS_INVALID: DiagnosticCode = DiagnosticCode::new("EK0609");
+/// A graph relation was smuggled into lattice/entity properties.
+pub const RELATION_IN_LATTICE: DiagnosticCode = DiagnosticCode::new("EK0610");
+/// Content attempted to author a raw transform.
+pub const RAW_TRANSFORM_AUTHORED: DiagnosticCode = DiagnosticCode::new("EK0611");
+/// Content attempted to supply a compiler-derived fact.
+pub const DERIVED_FACT_AUTHORED: DiagnosticCode = DiagnosticCode::new("EK0612");
+/// Content attempted to add a second canonical owner for a fact class.
+pub const DUPLICATE_FACT_OWNER: DiagnosticCode = DiagnosticCode::new("EK0613");
+/// The same graph relation is declared more than once.
+pub const DUPLICATE_RELATION: DiagnosticCode = DiagnosticCode::new("EK0614");
+/// A typed catalog reference points into the wrong catalog namespace.
+pub const CATALOG_NAMESPACE_MISMATCH: DiagnosticCode = DiagnosticCode::new("EK0615");
+/// A graph relation kind is outside the approved Gate K vocabulary.
+pub const UNAPPROVED_RELATION_KIND: DiagnosticCode = DiagnosticCode::new("EK0616");
+
+/// Every stable code owned by this crate.
+pub const ALL: &[DiagnosticCode] = &[
+    SOURCE_SYNTAX,
+    SOURCE_SCHEMA_REQUIRED,
+    SOURCE_SCHEMA_UNSUPPORTED,
+    SOURCE_INTEGER_INVALID,
+    SOURCE_UNKNOWN_STATEMENT,
+    SOURCE_UNCLOSED_ENTITY,
+    SOURCE_TOO_LARGE,
+    DUPLICATE_ENTITY,
+    DUPLICATE_CATALOG_VALUE,
+    DANGLING_ENTITY,
+    DANGLING_CATALOG_VALUE,
+    UNAPPROVED_PRIMITIVE,
+    REQUIRED_FIELD_MISSING,
+    FIELD_NOT_ALLOWED,
+    DUPLICATE_FIELD,
+    REGION_BOUNDS_INVALID,
+    RELATION_IN_LATTICE,
+    RAW_TRANSFORM_AUTHORED,
+    DERIVED_FACT_AUTHORED,
+    DUPLICATE_FACT_OWNER,
+    DUPLICATE_RELATION,
+    CATALOG_NAMESPACE_MISMATCH,
+    UNAPPROVED_RELATION_KIND,
+];

--- a/crates/estate-compiler/src/lib.rs
+++ b/crates/estate-compiler/src/lib.rs
@@ -1,39 +1,50 @@
-//! The compile-time half of the kernel.
+//! The compile-time half of the Gate K kernel.
 //!
-//! `KERNEL.md` section 10 assigns this crate *parse, link, expand, validate,
-//! migrate, and project*. Section 2 fixes what "compile time" means here: it
-//! prepares claim templates, machines, interaction edges, composition laws,
-//! coherence rules, and a resolver plan. It does **not** decide final subsystem
-//! deltas — amendment A4 exists precisely because opening a door may leave
-//! movement blocked while a ward still claims it.
-//!
-//! This crate is the only place that reads both the Canonical World IR schema
-//! and the projection schemas, because it is the only thing that turns one into
-//! the other.
-//!
-//! # Boundary
-//!
-//! Its three permitted edges all resolve:
-//!
-//! ```
-//! use estate_core::id::SchemaId;
-//! let _: Vec<SchemaId> = estate_compiler::consumed_schemas();
-//! let _: Vec<SchemaId> = estate_compiler::produced_schemas();
-//! ```
-//!
-//! It may not reach `estate-sim`. The compiler produces artifacts; it does not
-//! execute them, and a compiler that could name runtime state would be able to
-//! precompute deltas that section 2 says are not knowable until command time:
-//!
-//! ```compile_fail
-//! let _ = estate_sim::runtime_state_schema();
-//! ```
+//! SW-C implements source schema version 1, parsing, typed name resolution,
+//! approved primitive expansion, and the fact-ownership linker. Command-time
+//! effective-fact resolution remains in `estate-sim`; this crate cannot depend
+//! on it by construction.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
-use estate_core::id::SchemaId;
+mod catalog;
+pub mod diagnostics;
+mod linker;
+mod parser;
+
+use estate_core::{Diagnostic, SchemaId, SourcePath};
+use estate_schema::{SourceDocument, WorldIr};
+
+/// Parses source schema version 1 without resolving cross-references.
+///
+/// # Errors
+///
+/// Returns the first deterministic syntax/schema diagnostic with a source span.
+pub fn parse_source(source: &str, path: SourcePath) -> Result<SourceDocument, Diagnostic> {
+    parser::parse(source, path)
+}
+
+/// Resolves names, enforces ownership, expands approved primitives, and emits
+/// Canonical World IR.
+///
+/// # Errors
+///
+/// Returns the first deterministic linker diagnostic with a source span.
+pub fn link_source(document: &SourceDocument) -> Result<WorldIr, Diagnostic> {
+    linker::link(document)
+}
+
+/// Compiles one `.estate` source file through parsing and ownership linking.
+///
+/// # Errors
+///
+/// Returns a stable source or linker diagnostic. No partial IR is returned.
+pub fn compile_source(source: &str, path: SourcePath) -> Result<WorldIr, Diagnostic> {
+    let document = parse_source(source, path)?;
+    link_source(&document)
+}
 
 /// The schemas this compiler reads.
 #[must_use]
@@ -45,9 +56,6 @@ pub fn consumed_schemas() -> Vec<SchemaId> {
 }
 
 /// The schemas this compiler writes.
-///
-/// The Canonical World IR appears on both sides: the compiler emits it from
-/// source, and the migration path reads a previous version of it.
 #[must_use]
 pub fn produced_schemas() -> Vec<SchemaId> {
     let mut schemas = vec![estate_schema::world_ir_schema()];
@@ -65,14 +73,8 @@ mod tests {
         let produced = produced_schemas();
         assert!(consumed.contains(&estate_schema::source_schema()));
         for projection in estate_projection::all_schemas() {
-            assert!(
-                produced.contains(&projection),
-                "the compiler must produce every projection schema"
-            );
-            assert!(
-                !consumed.contains(&projection),
-                "a projection schema is compiler output, never compiler input"
-            );
+            assert!(produced.contains(&projection));
+            assert!(!consumed.contains(&projection));
         }
     }
 }

--- a/crates/estate-compiler/src/linker.rs
+++ b/crates/estate-compiler/src/linker.rs
@@ -1,0 +1,436 @@
+//! Typed name resolution, primitive expansion, and fact-ownership linking.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use estate_core::{CatalogValueId, Diagnostic, EntityId, Ident, RepairClass, SourceSpan};
+use estate_schema::{
+    Binding, FactOwner, FactOwnershipReceipt, IrEntity, IrRelation, SourceDocument, SourceEntity,
+    SourceField, Spanned, WorldIr,
+};
+
+use crate::catalog::{self, ApprovedKind};
+use crate::diagnostics;
+
+pub(crate) fn link(document: &SourceDocument) -> Result<WorldIr, Diagnostic> {
+    if document.schema().value() != &estate_schema::source_schema() {
+        return Err(Diagnostic::new(
+            diagnostics::SOURCE_SCHEMA_UNSUPPORTED,
+            format!(
+                "source schema `{}` is unsupported; expected `{}`",
+                document.schema().value(),
+                estate_schema::source_schema()
+            ),
+        )
+        .with_span(document.schema().span().clone())
+        .with_repair(RepairClass::FixSourceSyntax));
+    }
+    if let Some(declaration) = document.forbidden_fact_owners().first() {
+        return Err(Diagnostic::new(
+            diagnostics::DUPLICATE_FACT_OWNER,
+            format!(
+                "content cannot assign `{}` to `{}`; canonical fact owners are compiler-defined",
+                declaration.owner(),
+                declaration.fact()
+            ),
+        )
+        .with_span(declaration.span().clone())
+        .with_repair(RepairClass::RestoreCanonicalFactOwner));
+    }
+
+    let catalog_values = declare_catalog_values(document)?;
+    let entity_symbols = declare_entities(document)?;
+    let (relations, mut receipts) = link_relations(document, &entity_symbols)?;
+    let mut entities = Vec::new();
+    for entity in document.entities() {
+        let (linked, entity_receipts) = link_entity(entity, &catalog_values)?;
+        entities.push(linked);
+        receipts.extend(entity_receipts);
+    }
+
+    Ok(WorldIr::new(
+        document.schema().value().clone(),
+        catalog_values.into_iter().collect(),
+        entities,
+        relations,
+        receipts,
+    ))
+}
+
+fn declare_catalog_values(
+    document: &SourceDocument,
+) -> Result<BTreeSet<CatalogValueId>, Diagnostic> {
+    let mut symbols = BTreeSet::new();
+    for declaration in document.catalog_values() {
+        if !symbols.insert(declaration.value().clone()) {
+            return Err(Diagnostic::new(
+                diagnostics::DUPLICATE_CATALOG_VALUE,
+                format!(
+                    "catalog value `{}` is declared more than once",
+                    declaration.value()
+                ),
+            )
+            .with_span(declaration.span().clone())
+            .with_repair(RepairClass::RemoveDuplicateDeclaration));
+        }
+    }
+    Ok(symbols)
+}
+
+fn declare_entities(
+    document: &SourceDocument,
+) -> Result<BTreeMap<EntityId, &SourceEntity>, Diagnostic> {
+    let mut symbols = BTreeMap::new();
+    for entity in document.entities() {
+        if symbols
+            .insert(entity.id().value().clone(), entity)
+            .is_some()
+        {
+            return Err(Diagnostic::new(
+                diagnostics::DUPLICATE_ENTITY,
+                format!(
+                    "entity `{}` is declared more than once",
+                    entity.id().value()
+                ),
+            )
+            .with_span(entity.id().span().clone())
+            .with_repair(RepairClass::RemoveDuplicateDeclaration));
+        }
+    }
+    Ok(symbols)
+}
+
+fn link_relations(
+    document: &SourceDocument,
+    entities: &BTreeMap<EntityId, &SourceEntity>,
+) -> Result<(Vec<IrRelation>, Vec<FactOwnershipReceipt>), Diagnostic> {
+    let mut seen = BTreeSet::new();
+    let mut linked = Vec::new();
+    let mut receipts = Vec::new();
+    for relation in document.relations() {
+        if relation.kind().value().as_str() != "owns" {
+            return Err(Diagnostic::new(
+                diagnostics::UNAPPROVED_RELATION_KIND,
+                format!(
+                    "relation kind `{}` is not in the Gate K vocabulary",
+                    relation.kind().value()
+                ),
+            )
+            .with_span(relation.kind().span().clone())
+            .with_repair(RepairClass::UseApprovedRelationKind));
+        }
+        for reference in [relation.subject(), relation.object()] {
+            if !entities.contains_key(reference.value()) {
+                return Err(Diagnostic::new(
+                    diagnostics::DANGLING_ENTITY,
+                    format!("entity reference `{}` does not resolve", reference.value()),
+                )
+                .with_span(reference.span().clone())
+                .with_repair(RepairClass::DeclareReferencedEntity));
+            }
+        }
+        let key = (
+            relation.subject().value().clone(),
+            relation.kind().value().clone(),
+            relation.object().value().clone(),
+        );
+        if !seen.insert(key.clone()) {
+            return Err(Diagnostic::new(
+                diagnostics::DUPLICATE_RELATION,
+                format!(
+                    "relation `{} {} {}` is declared more than once",
+                    key.0, key.1, key.2
+                ),
+            )
+            .with_span(relation.span().clone())
+            .with_repair(RepairClass::RemoveDuplicateDeclaration));
+        }
+        linked.push(IrRelation::new(
+            key.0.clone(),
+            key.1.clone(),
+            key.2.clone(),
+            relation.span().clone(),
+        ));
+        receipts.push(FactOwnershipReceipt::new(
+            format!("relation.{}.{}.{}", key.0, key.1, key.2),
+            FactOwner::Graph,
+            relation.span().clone(),
+            format!("{} {} {}", key.0, key.1, key.2),
+            idents(&["diagnostics", "persistence", "simulation"]),
+            vec!["source/relation".to_owned()],
+        ));
+    }
+    Ok((linked, receipts))
+}
+
+struct Fields<'a> {
+    anchor: Option<&'a Spanned<Binding>>,
+    credential: Option<&'a Spanned<CatalogValueId>>,
+}
+
+fn collect_fields(entity: &SourceEntity) -> Result<Fields<'_>, Diagnostic> {
+    let mut fields = Fields {
+        anchor: None,
+        credential: None,
+    };
+    for field in entity.fields() {
+        match field {
+            SourceField::Anchor(anchor) => {
+                if fields.anchor.replace(anchor).is_some() {
+                    return Err(duplicate_field("anchor", field.span()));
+                }
+            }
+            SourceField::Credential(credential) => {
+                if fields.credential.replace(credential).is_some() {
+                    return Err(duplicate_field("credential", field.span()));
+                }
+            }
+            SourceField::LatticeRelation {
+                relation,
+                target,
+                span,
+            } => {
+                return Err(Diagnostic::new(
+                    diagnostics::RELATION_IN_LATTICE,
+                    format!(
+                        "relation `{} {}` cannot be encoded as an entity/lattice property",
+                        relation.value(),
+                        target.value()
+                    ),
+                )
+                .with_span(span.clone())
+                .with_repair(RepairClass::MoveRelationToGraph));
+            }
+            SourceField::RawTransform(span) => {
+                return Err(Diagnostic::new(
+                    diagnostics::RAW_TRANSFORM_AUTHORED,
+                    "raw transforms are absent from shippable source; use a typed lattice anchor",
+                )
+                .with_span(span.clone())
+                .with_repair(RepairClass::ReplaceRawTransformWithBinding));
+            }
+            SourceField::DerivedFact { name, span } => {
+                return Err(Diagnostic::new(
+                    diagnostics::DERIVED_FACT_AUTHORED,
+                    format!("derived fact `{name}` belongs to the compiler, not content"),
+                )
+                .with_span(span.clone())
+                .with_repair(RepairClass::RemoveDerivedFact));
+            }
+        }
+    }
+    Ok(fields)
+}
+
+fn duplicate_field(name: &str, span: &SourceSpan) -> Diagnostic {
+    Diagnostic::new(
+        diagnostics::DUPLICATE_FIELD,
+        format!("field `{name}` is supplied more than once"),
+    )
+    .with_span(span.clone())
+    .with_repair(RepairClass::RemoveDuplicateDeclaration)
+}
+
+fn link_entity(
+    source: &SourceEntity,
+    catalog_values: &BTreeSet<CatalogValueId>,
+) -> Result<(IrEntity, Vec<FactOwnershipReceipt>), Diagnostic> {
+    let kind = catalog::lookup(source.primitive().value()).ok_or_else(|| {
+        Diagnostic::new(
+            diagnostics::UNAPPROVED_PRIMITIVE,
+            format!(
+                "primitive kind `{}` is not in the sealed Gate K catalog",
+                source.primitive().value()
+            ),
+        )
+        .with_span(source.primitive().span().clone())
+        .with_repair(RepairClass::UseApprovedPrimitive)
+    })?;
+    let fields = collect_fields(source)?;
+    let anchor = fields.anchor.ok_or_else(|| {
+        Diagnostic::new(
+            diagnostics::REQUIRED_FIELD_MISSING,
+            format!(
+                "entity `{}` requires one `anchor` field",
+                source.id().value()
+            ),
+        )
+        .with_span(source.span().clone())
+        .with_repair(RepairClass::SupplyRequiredField)
+    })?;
+    validate_region(anchor)?;
+    validate_shape(kind, source, &fields)?;
+
+    if let Some(credential) = fields.credential {
+        if credential.value().catalog().as_str() != "credential" {
+            return Err(Diagnostic::new(
+                diagnostics::CATALOG_NAMESPACE_MISMATCH,
+                format!(
+                    "field `credential` requires the `credential` catalog, not `{}`",
+                    credential.value().catalog()
+                ),
+            )
+            .with_span(credential.span().clone())
+            .with_repair(RepairClass::UseExpectedCatalogNamespace));
+        }
+        if !catalog_values.contains(credential.value()) {
+            return Err(Diagnostic::new(
+                diagnostics::DANGLING_CATALOG_VALUE,
+                format!("catalog value `{}` does not resolve", credential.value()),
+            )
+            .with_span(credential.span().clone())
+            .with_repair(RepairClass::DeclareReferencedCatalogValue));
+        }
+    }
+
+    let id = source.id().value().clone();
+    let expansion = catalog::expand(kind, &id);
+    let credential = fields.credential.map(|value| value.value().clone());
+    let receipts = entity_receipts(source, anchor, fields.credential);
+    Ok((
+        IrEntity::new(
+            id,
+            source.primitive().value().clone(),
+            anchor.value().clone(),
+            credential,
+            expansion,
+            source.span().clone(),
+        ),
+        receipts,
+    ))
+}
+
+fn validate_shape(
+    kind: ApprovedKind,
+    entity: &SourceEntity,
+    fields: &Fields<'_>,
+) -> Result<(), Diagnostic> {
+    let anchor = fields.anchor.expect("the required anchor was checked");
+    let expected = match kind {
+        ApprovedKind::Door => "face",
+        ApprovedKind::Water => "region",
+        ApprovedKind::Light => "cell",
+    };
+    if anchor.value().kind() != expected {
+        return Err(Diagnostic::new(
+            diagnostics::FIELD_NOT_ALLOWED,
+            format!(
+                "primitive `{}` requires a `{expected}` anchor, not `{}`",
+                entity.primitive().value(),
+                anchor.value().kind()
+            ),
+        )
+        .with_span(anchor.span().clone())
+        .with_repair(RepairClass::RemoveUnsupportedField));
+    }
+    match (kind, fields.credential) {
+        (ApprovedKind::Door, None) => Err(Diagnostic::new(
+            diagnostics::REQUIRED_FIELD_MISSING,
+            format!(
+                "door `{}` requires one `credential` field",
+                entity.id().value()
+            ),
+        )
+        .with_span(entity.span().clone())
+        .with_repair(RepairClass::SupplyRequiredField)),
+        (ApprovedKind::Water | ApprovedKind::Light, Some(credential)) => Err(Diagnostic::new(
+            diagnostics::FIELD_NOT_ALLOWED,
+            format!(
+                "primitive `{}` does not accept a `credential` field",
+                entity.primitive().value()
+            ),
+        )
+        .with_span(credential.span().clone())
+        .with_repair(RepairClass::RemoveUnsupportedField)),
+        _ => Ok(()),
+    }
+}
+
+fn validate_region(anchor: &Spanned<Binding>) -> Result<(), Diagnostic> {
+    if let Binding::Region { min, max } = anchor.value()
+        && (min.x() > max.x() || min.y() > max.y() || min.z() > max.z())
+    {
+        return Err(Diagnostic::new(
+            diagnostics::REGION_BOUNDS_INVALID,
+            "region minimum must be component-wise less than or equal to its maximum",
+        )
+        .with_span(anchor.span().clone())
+        .with_repair(RepairClass::FixSourceSyntax));
+    }
+    Ok(())
+}
+
+fn entity_receipts(
+    entity: &SourceEntity,
+    anchor: &Spanned<Binding>,
+    credential: Option<&Spanned<CatalogValueId>>,
+) -> Vec<FactOwnershipReceipt> {
+    let id = entity.id().value();
+    let primitive = entity.primitive().value();
+    let resolved = binding_string(anchor.value());
+    let mut receipts = vec![
+        FactOwnershipReceipt::new(
+            format!("entity.{id}.identity"),
+            FactOwner::Graph,
+            entity.id().span().clone(),
+            id.to_string(),
+            idents(&["diagnostics", "persistence", "simulation"]),
+            vec!["source/entity".to_owned()],
+        ),
+        FactOwnershipReceipt::new(
+            format!("entity.{id}.spatial_anchor"),
+            FactOwner::Lattice,
+            anchor.span().clone(),
+            resolved.clone(),
+            idents(&["diagnostics", "navigation", "simulation"]),
+            vec!["source/anchor".to_owned()],
+        ),
+        FactOwnershipReceipt::new(
+            format!("entity.{id}.spatial_binding"),
+            FactOwner::WorldLinker,
+            anchor.span().clone(),
+            resolved,
+            idents(&["diagnostics", "navigation", "persistence", "simulation"]),
+            vec![primitive.to_string(), "binding/typed_lattice".to_owned()],
+        ),
+    ];
+    if let Some(value) = credential {
+        receipts.push(FactOwnershipReceipt::new(
+            format!("entity.{id}.credential"),
+            FactOwner::WorldLinker,
+            value.span().clone(),
+            value.value().to_string(),
+            idents(&["diagnostics", "persistence", "simulation"]),
+            vec![primitive.to_string(), "link/catalog_value".to_owned()],
+        ));
+    }
+    receipts
+}
+
+fn binding_string(binding: &Binding) -> String {
+    match binding {
+        Binding::Cell(cell) => format!("cell({},{},{})", cell.x(), cell.y(), cell.z()),
+        Binding::Face { cell, direction } => format!(
+            "face(cell({},{},{}),{})",
+            cell.x(),
+            cell.y(),
+            cell.z(),
+            direction.as_str()
+        ),
+        Binding::Region { min, max } => format!(
+            "region(cell({},{},{}),cell({},{},{}))",
+            min.x(),
+            min.y(),
+            min.z(),
+            max.x(),
+            max.y(),
+            max.z()
+        ),
+    }
+}
+
+fn idents(values: &[&str]) -> Vec<Ident> {
+    values
+        .iter()
+        .map(|value| Ident::new(value).expect("built-in consumer names are legal identifiers"))
+        .collect()
+}

--- a/crates/estate-compiler/src/parser.rs
+++ b/crates/estate-compiler/src/parser.rs
@@ -1,0 +1,487 @@
+//! Hand-written parser for `estate.source@1`.
+
+use estate_core::{
+    CatalogValueId, Diagnostic, EntityId, Ident, PrimitiveKindId, RepairClass, SchemaId,
+    SourcePath, SourceSpan,
+};
+use estate_schema::{
+    Binding, Cell, Direction, ForbiddenFactOwner, SourceDocument, SourceEntity, SourceField,
+    SourceRelation, Spanned,
+};
+
+use crate::diagnostics;
+
+#[derive(Clone, Copy, Debug)]
+struct Token<'a> {
+    text: &'a str,
+    byte_start: usize,
+    byte_end: usize,
+    column: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Line<'a> {
+    raw: &'a str,
+    byte_start: usize,
+    byte_end: usize,
+    number: usize,
+}
+
+impl<'a> Line<'a> {
+    fn tokens(self) -> Vec<Token<'a>> {
+        let bytes = self.raw.as_bytes();
+        let mut tokens = Vec::new();
+        let mut cursor = 0;
+        while cursor < bytes.len() {
+            while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t') {
+                cursor += 1;
+            }
+            if cursor == bytes.len() {
+                break;
+            }
+            let start = cursor;
+            while cursor < bytes.len() && !matches!(bytes[cursor], b' ' | b'\t') {
+                cursor += 1;
+            }
+            tokens.push(Token {
+                text: &self.raw[start..cursor],
+                byte_start: self.byte_start + start,
+                byte_end: self.byte_start + cursor,
+                column: start + 1,
+            });
+        }
+        tokens
+    }
+
+    fn is_ignored(self) -> bool {
+        let trimmed = self.raw.trim_start_matches([' ', '\t']);
+        trimmed.is_empty() || trimmed.starts_with('#')
+    }
+}
+
+pub(crate) fn parse(source: &str, path: SourcePath) -> Result<SourceDocument, Diagnostic> {
+    if source.len() > u32::MAX as usize {
+        return Err(Diagnostic::new(
+            diagnostics::SOURCE_TOO_LARGE,
+            "source exceeds the 32-bit byte range used by source spans",
+        ));
+    }
+
+    let lines = split_lines(source);
+    let mut schema = None;
+    let mut catalog_values = Vec::new();
+    let mut entities = Vec::new();
+    let mut relations = Vec::new();
+    let mut forbidden_fact_owners = Vec::new();
+    let mut index = 0;
+
+    while index < lines.len() {
+        let line = lines[index];
+        if line.is_ignored() {
+            index += 1;
+            continue;
+        }
+        let tokens = line.tokens();
+        if schema.is_none() && tokens[0].text != "schema" {
+            return Err(on_line(
+                Diagnostic::new(
+                    diagnostics::SOURCE_SCHEMA_REQUIRED,
+                    "the first declaration must be `schema estate.source@1`",
+                )
+                .with_repair(RepairClass::FixSourceSyntax),
+                &path,
+                line,
+            ));
+        }
+
+        match tokens[0].text {
+            "schema" => {
+                exact_arity(&tokens, 2, &path, line, "schema <schema-id>")?;
+                if schema.is_some() {
+                    return Err(on_line(
+                        Diagnostic::new(
+                            diagnostics::SOURCE_SCHEMA_REQUIRED,
+                            "the source schema may be declared exactly once",
+                        )
+                        .with_repair(RepairClass::RemoveDuplicateDeclaration),
+                        &path,
+                        line,
+                    ));
+                }
+                let parsed =
+                    with_token_span(SchemaId::parse(tokens[1].text), &path, line, tokens[1])?;
+                if parsed != estate_schema::source_schema() {
+                    return Err(Diagnostic::new(
+                        diagnostics::SOURCE_SCHEMA_UNSUPPORTED,
+                        format!(
+                            "source schema `{parsed}` is unsupported; expected `{}`",
+                            estate_schema::source_schema()
+                        ),
+                    )
+                    .with_span(token_span(&path, line, tokens[1]))
+                    .with_repair(RepairClass::FixSourceSyntax));
+                }
+                schema = Some(Spanned::new(parsed, token_span(&path, line, tokens[1])));
+                index += 1;
+            }
+            "catalog" => {
+                exact_arity(&tokens, 2, &path, line, "catalog <catalog>/<value>")?;
+                let value = with_token_span(
+                    CatalogValueId::parse(tokens[1].text),
+                    &path,
+                    line,
+                    tokens[1],
+                )?;
+                catalog_values.push(Spanned::new(value, token_span(&path, line, tokens[1])));
+                index += 1;
+            }
+            "entity" => {
+                let (entity, next) = parse_entity(&lines, index, &path)?;
+                entities.push(entity);
+                index = next;
+            }
+            "relation" => {
+                exact_arity(
+                    &tokens,
+                    4,
+                    &path,
+                    line,
+                    "relation <subject> <kind> <object>",
+                )?;
+                let subject =
+                    with_token_span(EntityId::parse(tokens[1].text), &path, line, tokens[1])?;
+                let kind = with_token_span(Ident::new(tokens[2].text), &path, line, tokens[2])?;
+                let object =
+                    with_token_span(EntityId::parse(tokens[3].text), &path, line, tokens[3])?;
+                relations.push(SourceRelation::new(
+                    Spanned::new(subject, token_span(&path, line, tokens[1])),
+                    Spanned::new(kind, token_span(&path, line, tokens[2])),
+                    Spanned::new(object, token_span(&path, line, tokens[3])),
+                    line_span(&path, line),
+                ));
+                index += 1;
+            }
+            "fact_owner" => {
+                exact_arity(&tokens, 3, &path, line, "fact_owner <fact-class> <owner>")?;
+                forbidden_fact_owners.push(ForbiddenFactOwner::new(
+                    tokens[1].text.to_owned(),
+                    tokens[2].text.to_owned(),
+                    line_span(&path, line),
+                ));
+                index += 1;
+            }
+            "end" => {
+                return Err(on_line(
+                    Diagnostic::new(
+                        diagnostics::SOURCE_SYNTAX,
+                        "`end` has no open entity declaration",
+                    )
+                    .with_repair(RepairClass::FixSourceSyntax),
+                    &path,
+                    line,
+                ));
+            }
+            unknown => {
+                return Err(on_line(
+                    Diagnostic::new(
+                        diagnostics::SOURCE_UNKNOWN_STATEMENT,
+                        format!("unknown top-level statement `{unknown}`"),
+                    )
+                    .with_repair(RepairClass::FixSourceSyntax),
+                    &path,
+                    line,
+                ));
+            }
+        }
+    }
+
+    let schema = schema.ok_or_else(|| {
+        Diagnostic::new(
+            diagnostics::SOURCE_SCHEMA_REQUIRED,
+            "source is empty; expected `schema estate.source@1`",
+        )
+        .with_span(SourceSpan::new(path.clone(), 0, 0, 1, 1).expect("empty span is valid"))
+        .with_repair(RepairClass::FixSourceSyntax)
+    })?;
+
+    Ok(SourceDocument::new(
+        schema,
+        catalog_values,
+        entities,
+        relations,
+        forbidden_fact_owners,
+    ))
+}
+
+fn parse_entity(
+    lines: &[Line<'_>],
+    header_index: usize,
+    path: &SourcePath,
+) -> Result<(SourceEntity, usize), Diagnostic> {
+    let header = lines[header_index];
+    let tokens = header.tokens();
+    exact_arity(
+        &tokens,
+        3,
+        path,
+        header,
+        "entity <entity-id> primitive/<kind>",
+    )?;
+    let id = with_token_span(EntityId::parse(tokens[1].text), path, header, tokens[1])?;
+    let primitive = with_token_span(
+        PrimitiveKindId::parse(tokens[2].text),
+        path,
+        header,
+        tokens[2],
+    )?;
+    let id = Spanned::new(id, token_span(path, header, tokens[1]));
+    let primitive = Spanned::new(primitive, token_span(path, header, tokens[2]));
+
+    let mut fields = Vec::new();
+    let mut index = header_index + 1;
+    while index < lines.len() {
+        let line = lines[index];
+        if line.is_ignored() {
+            index += 1;
+            continue;
+        }
+        let tokens = line.tokens();
+        if tokens[0].text == "end" {
+            exact_arity(&tokens, 1, path, line, "end")?;
+            let span = SourceSpan::new(
+                path.clone(),
+                u32::try_from(header.byte_start).expect("source length was checked"),
+                u32::try_from(line.byte_end).expect("source length was checked"),
+                u32::try_from(header.number).expect("line count fits source length"),
+                1,
+            )
+            .expect("parser creates a forward source span");
+            return Ok((SourceEntity::new(id, primitive, fields, span), index + 1));
+        }
+        fields.push(parse_field(&tokens, path, line)?);
+        index += 1;
+    }
+
+    Err(on_line(
+        Diagnostic::new(
+            diagnostics::SOURCE_UNCLOSED_ENTITY,
+            format!("entity `{}` reaches end of file without `end`", id.value()),
+        )
+        .with_repair(RepairClass::FixSourceSyntax),
+        path,
+        header,
+    ))
+}
+
+fn parse_field(
+    tokens: &[Token<'_>],
+    path: &SourcePath,
+    line: Line<'_>,
+) -> Result<SourceField, Diagnostic> {
+    match tokens[0].text {
+        "anchor" => parse_anchor(tokens, path, line),
+        "credential" => {
+            exact_arity(tokens, 2, path, line, "credential <catalog>/<value>")?;
+            let value =
+                with_token_span(CatalogValueId::parse(tokens[1].text), path, line, tokens[1])?;
+            Ok(SourceField::Credential(Spanned::new(
+                value,
+                line_span(path, line),
+            )))
+        }
+        "lattice_relation" => {
+            exact_arity(tokens, 3, path, line, "lattice_relation <kind> <entity>")?;
+            let relation = with_token_span(Ident::new(tokens[1].text), path, line, tokens[1])?;
+            let target = with_token_span(EntityId::parse(tokens[2].text), path, line, tokens[2])?;
+            Ok(SourceField::LatticeRelation {
+                relation: Spanned::new(relation, token_span(path, line, tokens[1])),
+                target: Spanned::new(target, token_span(path, line, tokens[2])),
+                span: line_span(path, line),
+            })
+        }
+        "transform" => Ok(SourceField::RawTransform(line_span(path, line))),
+        "derived" => {
+            if tokens.len() < 2 {
+                return Err(arity_error(path, line, "derived <fact-name> <value...>"));
+            }
+            Ok(SourceField::DerivedFact {
+                name: tokens[1].text.to_owned(),
+                span: line_span(path, line),
+            })
+        }
+        unknown => Err(on_line(
+            Diagnostic::new(
+                diagnostics::SOURCE_UNKNOWN_STATEMENT,
+                format!("unknown entity field `{unknown}`"),
+            )
+            .with_repair(RepairClass::FixSourceSyntax),
+            path,
+            line,
+        )),
+    }
+}
+
+fn parse_anchor(
+    tokens: &[Token<'_>],
+    path: &SourcePath,
+    line: Line<'_>,
+) -> Result<SourceField, Diagnostic> {
+    let binding = match tokens.get(1).map(|token| token.text) {
+        Some("cell") => {
+            exact_arity(tokens, 5, path, line, "anchor cell <x> <y> <z>")?;
+            Binding::Cell(parse_cell(&tokens[2..5], path, line)?)
+        }
+        Some("face") => {
+            exact_arity(tokens, 6, path, line, "anchor face <x> <y> <z> <direction>")?;
+            let cell = parse_cell(&tokens[2..5], path, line)?;
+            let direction = Direction::parse(tokens[5].text).ok_or_else(|| {
+                on_line(
+                    Diagnostic::new(
+                        diagnostics::SOURCE_SYNTAX,
+                        format!("`{}` is not a lattice face direction", tokens[5].text),
+                    )
+                    .with_repair(RepairClass::FixSourceSyntax),
+                    path,
+                    line,
+                )
+            })?;
+            Binding::Face { cell, direction }
+        }
+        Some("region") => {
+            exact_arity(
+                tokens,
+                8,
+                path,
+                line,
+                "anchor region <min-x> <min-y> <min-z> <max-x> <max-y> <max-z>",
+            )?;
+            Binding::Region {
+                min: parse_cell(&tokens[2..5], path, line)?,
+                max: parse_cell(&tokens[5..8], path, line)?,
+            }
+        }
+        _ => return Err(arity_error(path, line, "anchor <cell|face|region> ...")),
+    };
+    Ok(SourceField::Anchor(Spanned::new(
+        binding,
+        line_span(path, line),
+    )))
+}
+
+fn parse_cell(tokens: &[Token<'_>], path: &SourcePath, line: Line<'_>) -> Result<Cell, Diagnostic> {
+    let mut values = [0_i32; 3];
+    for (index, token) in tokens.iter().enumerate() {
+        if token.text.starts_with('+')
+            || token.text.is_empty()
+            || token.text == "-"
+            || !token
+                .text
+                .trim_start_matches('-')
+                .bytes()
+                .all(|byte| byte.is_ascii_digit())
+        {
+            return Err(integer_error(path, line, *token));
+        }
+        values[index] = token
+            .text
+            .parse::<i32>()
+            .map_err(|_| integer_error(path, line, *token))?;
+    }
+    Ok(Cell::new(values[0], values[1], values[2]))
+}
+
+fn integer_error(path: &SourcePath, line: Line<'_>, token: Token<'_>) -> Diagnostic {
+    with_token_span::<()>(
+        Err(Diagnostic::new(
+            diagnostics::SOURCE_INTEGER_INVALID,
+            format!("`{}` is not a signed 32-bit decimal integer", token.text),
+        )
+        .with_repair(RepairClass::FixSourceSyntax)),
+        path,
+        line,
+        token,
+    )
+    .expect_err("this helper always constructs an error")
+}
+
+fn exact_arity(
+    tokens: &[Token<'_>],
+    expected: usize,
+    path: &SourcePath,
+    line: Line<'_>,
+    shape: &str,
+) -> Result<(), Diagnostic> {
+    if tokens.len() == expected {
+        Ok(())
+    } else {
+        Err(arity_error(path, line, shape))
+    }
+}
+
+fn arity_error(path: &SourcePath, line: Line<'_>, shape: &str) -> Diagnostic {
+    on_line(
+        Diagnostic::new(
+            diagnostics::SOURCE_SYNTAX,
+            format!("statement does not match `{shape}`"),
+        )
+        .with_repair(RepairClass::FixSourceSyntax),
+        path,
+        line,
+    )
+}
+
+fn with_token_span<T>(
+    result: Result<T, Diagnostic>,
+    path: &SourcePath,
+    line: Line<'_>,
+    token: Token<'_>,
+) -> Result<T, Diagnostic> {
+    result.map_err(|diagnostic| diagnostic.with_span(token_span(path, line, token)))
+}
+
+fn on_line(diagnostic: Diagnostic, path: &SourcePath, line: Line<'_>) -> Diagnostic {
+    diagnostic.with_span(line_span(path, line))
+}
+
+fn token_span(path: &SourcePath, line: Line<'_>, token: Token<'_>) -> SourceSpan {
+    SourceSpan::new(
+        path.clone(),
+        u32::try_from(token.byte_start).expect("source length was checked"),
+        u32::try_from(token.byte_end).expect("source length was checked"),
+        u32::try_from(line.number).expect("line count fits source length"),
+        u32::try_from(token.column).expect("column fits source length"),
+    )
+    .expect("parser creates a forward source span")
+}
+
+fn line_span(path: &SourcePath, line: Line<'_>) -> SourceSpan {
+    let leading = line.raw.len() - line.raw.trim_start_matches([' ', '\t']).len();
+    SourceSpan::new(
+        path.clone(),
+        u32::try_from(line.byte_start + leading).expect("source length was checked"),
+        u32::try_from(line.byte_end).expect("source length was checked"),
+        u32::try_from(line.number).expect("line count fits source length"),
+        u32::try_from(leading + 1).expect("column fits source length"),
+    )
+    .expect("parser creates a forward source span")
+}
+
+fn split_lines(source: &str) -> Vec<Line<'_>> {
+    let mut lines = Vec::new();
+    let mut byte_start = 0;
+    for (index, terminated) in source.split_inclusive('\n').enumerate() {
+        let raw = terminated
+            .strip_suffix('\n')
+            .unwrap_or(terminated)
+            .strip_suffix('\r')
+            .unwrap_or_else(|| terminated.strip_suffix('\n').unwrap_or(terminated));
+        lines.push(Line {
+            raw,
+            byte_start,
+            byte_end: byte_start + raw.len(),
+            number: index + 1,
+        });
+        byte_start += terminated.len();
+    }
+    lines
+}

--- a/crates/estate-compiler/tests/compile_fixture.rs
+++ b/crates/estate-compiler/tests/compile_fixture.rs
@@ -1,0 +1,165 @@
+//! SW-C happy-path proof against the exact Gate K base fixture.
+
+use estate_compiler::compile_source;
+use estate_core::canonical::read::is_canonical;
+use estate_core::{SourcePath, id::StableId};
+use estate_schema::{CapabilityKind, ClaimActivation, ClaimValue, FactOwner};
+
+const SOURCE: &str = include_str!("../../../fixtures/gaol.estate");
+const PATH: &str = "fixtures/gaol.estate";
+
+fn compile() -> estate_schema::WorldIr {
+    compile_source(SOURCE, SourcePath::new(PATH).unwrap()).unwrap()
+}
+
+#[test]
+fn the_base_fixture_is_one_screen_and_names_exactly_the_contract_entities() {
+    assert!(SOURCE.lines().count() <= 20);
+    let ir = compile();
+    let ids: Vec<String> = ir
+        .entities()
+        .iter()
+        .map(|entity| entity.id().canonical_string())
+        .collect();
+    assert_eq!(ids, ["brazier_02", "flooded_section", "north_gate"]);
+
+    let kinds: Vec<String> = ir
+        .entities()
+        .iter()
+        .map(|entity| entity.primitive().canonical_string())
+        .collect();
+    assert_eq!(
+        kinds,
+        [
+            "primitive/extinguishable_light",
+            "primitive/shallow_water_region",
+            "primitive/iron_barred_door",
+        ]
+    );
+    assert_eq!(
+        ir.catalog_values()
+            .iter()
+            .map(StableId::canonical_string)
+            .collect::<Vec<_>>(),
+        ["credential/gaoler_key"]
+    );
+}
+
+#[test]
+fn the_catalog_credential_never_becomes_a_fourth_entity() {
+    let ir = compile();
+    assert_eq!(ir.entities().len(), 3);
+    let door = ir
+        .entities()
+        .iter()
+        .find(|entity| entity.id().to_string() == "north_gate")
+        .unwrap();
+    assert_eq!(
+        door.credential().unwrap().to_string(),
+        "credential/gaoler_key"
+    );
+}
+
+#[test]
+fn approved_primitives_expand_into_machines_capabilities_and_claims() {
+    let ir = compile();
+    let door = entity(&ir, "north_gate");
+    let machine_names: Vec<&str> = door
+        .expansion()
+        .machines()
+        .iter()
+        .map(|machine| machine.namespace().local_name().as_str())
+        .collect();
+    assert_eq!(machine_names, ["access", "combustion", "integrity", "ward"]);
+    assert!(
+        door.expansion()
+            .capabilities()
+            .contains(&CapabilityKind::Portal)
+    );
+    assert_eq!(door.expansion().claims().len(), 2);
+    let portal_blocker = door
+        .expansion()
+        .claims()
+        .iter()
+        .find(|claim| claim.id().namespace().local_name().as_str() == "portal")
+        .unwrap();
+    assert!(matches!(
+        portal_blocker.activation(),
+        ClaimActivation::Not(child)
+            if matches!(child.as_ref(), ClaimActivation::Any(children) if children.len() == 2)
+    ));
+
+    let water = entity(&ir, "flooded_section");
+    let cost = &water.expansion().claims()[0];
+    assert_eq!(cost.capability(), CapabilityKind::TraversalCostGround);
+    assert_eq!(cost.value(), &ClaimValue::Uint(3));
+
+    let light = entity(&ir, "brazier_02");
+    assert_eq!(light.expansion().machines().len(), 1);
+    assert_eq!(light.expansion().machines()[0].initial().as_str(), "lit");
+    assert_eq!(
+        light.expansion().claims()[0].capability(),
+        CapabilityKind::EmitsLight
+    );
+}
+
+#[test]
+fn ownership_receipts_name_graph_lattice_and_linker_authority() {
+    let ir = compile();
+    let receipt = |fact: &str| {
+        ir.ownership_receipts()
+            .iter()
+            .find(|receipt| receipt.fact() == fact)
+            .unwrap()
+    };
+    assert_eq!(
+        receipt("entity.north_gate.identity").owner(),
+        FactOwner::Graph
+    );
+    assert_eq!(
+        receipt("entity.north_gate.spatial_anchor").owner(),
+        FactOwner::Lattice
+    );
+    assert_eq!(
+        receipt("entity.north_gate.spatial_binding").owner(),
+        FactOwner::WorldLinker
+    );
+    assert_eq!(
+        receipt("entity.north_gate.credential").owner(),
+        FactOwner::WorldLinker
+    );
+}
+
+#[test]
+fn world_ir_bytes_are_canonical_and_repeatable() {
+    let first = compile().to_canonical_bytes();
+    let second = compile().to_canonical_bytes();
+    assert_eq!(first, second);
+    assert!(is_canonical(&first));
+    assert!(!first.ends_with(b"\n"));
+}
+
+#[test]
+fn source_line_endings_do_not_change_what_resolves() {
+    let crlf = SOURCE.replace('\n', "\r\n");
+    let ir = compile_source(&crlf, SourcePath::new(PATH).unwrap()).unwrap();
+    assert_eq!(ir.entities().len(), 3);
+    assert_eq!(ir.catalog_values().len(), 1);
+}
+
+#[test]
+fn a_valid_graph_relation_links_only_after_both_entities_resolve() {
+    let source = format!("{SOURCE}\nrelation north_gate owns brazier_02\n");
+    let ir = compile_source(&source, SourcePath::new(PATH).unwrap()).unwrap();
+    assert_eq!(ir.relations().len(), 1);
+    assert_eq!(ir.relations()[0].subject().to_string(), "north_gate");
+    assert_eq!(ir.relations()[0].kind().as_str(), "owns");
+    assert_eq!(ir.relations()[0].object().to_string(), "brazier_02");
+}
+
+fn entity<'a>(ir: &'a estate_schema::WorldIr, id: &str) -> &'a estate_schema::IrEntity {
+    ir.entities()
+        .iter()
+        .find(|entity| entity.id().to_string() == id)
+        .unwrap()
+}

--- a/crates/estate-compiler/tests/mutations.rs
+++ b/crates/estate-compiler/tests/mutations.rs
@@ -1,0 +1,219 @@
+//! Planted source and ownership violations required by KERNEL.md section 9.
+
+use estate_compiler::{compile_source, diagnostics, link_source};
+use estate_core::{Diagnostic, SchemaId, SourcePath, SourceSpan};
+use estate_schema::{SourceDocument, Spanned};
+
+const SOURCE: &str = include_str!("../../../fixtures/gaol.estate");
+const PATH: &str = "fixtures/mutated-gaol.estate";
+
+fn reject(source: &str, expected: &str) -> Diagnostic {
+    let diagnostic = compile_source(source, SourcePath::new(PATH).unwrap()).unwrap_err();
+    assert_eq!(diagnostic.code().as_str(), expected, "{diagnostic}");
+    let span = diagnostic.span().expect("source rejection needs a span");
+    assert_eq!(span.path().as_str(), PATH);
+    assert!(span.position().0 > 0);
+    diagnostic
+}
+
+fn in_door(field: &str) -> String {
+    SOURCE.replacen(
+        "  credential credential/gaoler_key\nend",
+        &format!("  credential credential/gaoler_key\n  {field}\nend"),
+        1,
+    )
+}
+
+#[test]
+fn dangling_entity_id_fails_closed() {
+    reject(
+        &format!("{SOURCE}\nrelation north_gate owns missing_gate\n"),
+        diagnostics::DANGLING_ENTITY.as_str(),
+    );
+}
+
+#[test]
+fn unapproved_relation_kind_fails_closed() {
+    reject(
+        &format!("{SOURCE}\nrelation north_gate illuminates brazier_02\n"),
+        diagnostics::UNAPPROVED_RELATION_KIND.as_str(),
+    );
+}
+
+#[test]
+fn dangling_catalog_value_fails_closed() {
+    reject(
+        &SOURCE.replacen(
+            "credential credential/gaoler_key",
+            "credential credential/missing_key",
+            1,
+        ),
+        diagnostics::DANGLING_CATALOG_VALUE.as_str(),
+    );
+}
+
+#[test]
+fn catalog_namespaces_remain_typed() {
+    let source = SOURCE
+        .replacen(
+            "catalog credential/gaoler_key",
+            "catalog credential/gaoler_key\ncatalog material/gaoler_key",
+            1,
+        )
+        .replacen(
+            "credential credential/gaoler_key",
+            "credential material/gaoler_key",
+            1,
+        );
+    reject(&source, diagnostics::CATALOG_NAMESPACE_MISMATCH.as_str());
+}
+
+#[test]
+fn relation_encoded_as_a_lattice_property_fails_closed() {
+    reject(
+        &in_door("lattice_relation owns brazier_02"),
+        diagnostics::RELATION_IN_LATTICE.as_str(),
+    );
+}
+
+#[test]
+fn authored_raw_transform_fails_closed() {
+    reject(
+        &in_door("transform 1 0 0 0 1 0 0 0 1"),
+        diagnostics::RAW_TRANSFORM_AUTHORED.as_str(),
+    );
+}
+
+#[test]
+fn authored_derived_fact_fails_closed() {
+    reject(
+        &in_door("derived movement_disposition_ground traversable"),
+        diagnostics::DERIVED_FACT_AUTHORED.as_str(),
+    );
+}
+
+#[test]
+fn second_canonical_fact_owner_fails_closed() {
+    reject(
+        &format!("{SOURCE}\nfact_owner spatial.anchor graph\n"),
+        diagnostics::DUPLICATE_FACT_OWNER.as_str(),
+    );
+}
+
+#[test]
+fn duplicate_symbols_and_fields_fail_closed() {
+    reject(
+        &format!("catalog credential/gaoler_key\n{SOURCE}"),
+        diagnostics::SOURCE_SCHEMA_REQUIRED.as_str(),
+    );
+    reject(
+        &SOURCE.replacen(
+            "catalog credential/gaoler_key",
+            "catalog credential/gaoler_key\ncatalog credential/gaoler_key",
+            1,
+        ),
+        diagnostics::DUPLICATE_CATALOG_VALUE.as_str(),
+    );
+    reject(
+        &format!(
+            "{SOURCE}\nentity north_gate primitive/extinguishable_light\n  anchor cell 0 0 0\nend\n"
+        ),
+        diagnostics::DUPLICATE_ENTITY.as_str(),
+    );
+    reject(
+        &in_door("anchor face 6 0 0 north"),
+        diagnostics::DUPLICATE_FIELD.as_str(),
+    );
+}
+
+#[test]
+fn primitive_catalog_and_field_shapes_fail_closed() {
+    reject(
+        &SOURCE.replacen(
+            "primitive/extinguishable_light",
+            "primitive/unapproved_torch",
+            1,
+        ),
+        diagnostics::UNAPPROVED_PRIMITIVE.as_str(),
+    );
+    reject(
+        &SOURCE.replacen("  credential credential/gaoler_key\n", "", 1),
+        diagnostics::REQUIRED_FIELD_MISSING.as_str(),
+    );
+    reject(
+        &SOURCE.replacen("anchor cell 3 1 0", "anchor face 3 1 0 north", 1),
+        diagnostics::FIELD_NOT_ALLOWED.as_str(),
+    );
+}
+
+#[test]
+fn inverted_region_bounds_fail_closed() {
+    reject(
+        &SOURCE.replacen("anchor region 2 2 0 4 3 0", "anchor region 4 2 0 2 3 0", 1),
+        diagnostics::REGION_BOUNDS_INVALID.as_str(),
+    );
+}
+
+#[test]
+fn parser_errors_also_carry_stable_codes_and_spans() {
+    reject(
+        &SOURCE.replacen("anchor cell 3 1 0", "anchor cell +3 1 0", 1),
+        diagnostics::SOURCE_INTEGER_INVALID.as_str(),
+    );
+    reject(
+        &in_door("made_up_field oatmeal"),
+        diagnostics::SOURCE_UNKNOWN_STATEMENT.as_str(),
+    );
+    reject(
+        SOURCE.trim_end_matches("end\n"),
+        diagnostics::SOURCE_UNCLOSED_ENTITY.as_str(),
+    );
+}
+
+#[test]
+fn source_schema_is_mandatory_exactly_once() {
+    reject(
+        &SOURCE.replacen("schema estate.source@1\n", "", 1),
+        diagnostics::SOURCE_SCHEMA_REQUIRED.as_str(),
+    );
+    reject(
+        &SOURCE.replacen(
+            "schema estate.source@1",
+            "schema estate.source@1\nschema estate.source@1",
+            1,
+        ),
+        diagnostics::SOURCE_SCHEMA_REQUIRED.as_str(),
+    );
+    reject(
+        &SOURCE.replacen("estate.source@1", "estate.source@2", 1),
+        diagnostics::SOURCE_SCHEMA_UNSUPPORTED.as_str(),
+    );
+}
+
+#[test]
+fn linker_rechecks_schema_for_callers_that_supply_an_ast_directly() {
+    let path = SourcePath::new(PATH).unwrap();
+    let span = SourceSpan::new(path, 0, 23, 1, 1).unwrap();
+    let document = SourceDocument::new(
+        Spanned::new(SchemaId::new("estate.source", 2).unwrap(), span),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let diagnostic = link_source(&document).unwrap_err();
+    assert_eq!(diagnostic.code(), diagnostics::SOURCE_SCHEMA_UNSUPPORTED);
+    assert!(diagnostic.span().is_some());
+}
+
+#[test]
+fn every_compiler_code_is_well_formed_and_globally_unique() {
+    let mut seen = std::collections::BTreeSet::new();
+    for code in estate_core::diagnostic::codes::ALL
+        .iter()
+        .chain(diagnostics::ALL)
+    {
+        assert!(code.is_well_formed(), "`{code}` is malformed");
+        assert!(seen.insert(code.as_str()), "`{code}` is declared twice");
+    }
+}

--- a/crates/estate-core/src/diagnostic.rs
+++ b/crates/estate-core/src/diagnostic.rs
@@ -22,6 +22,8 @@ use crate::canonical::{CanonicalValue, FieldName};
 /// | `EK02xx` | checked arithmetic |
 /// | `EK03xx` | canonical encoding |
 /// | `EK04xx` | world packages |
+/// | `EK05xx` | source parsing |
+/// | `EK06xx` | name resolution and linking |
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct DiagnosticCode(&'static str);
 
@@ -77,6 +79,32 @@ pub enum RepairClass {
     WriteToNewOutputPath,
     /// Rebuild the artifact from its source rather than editing it in place.
     RebuildFromSource,
+    /// Correct the source to match the published `.estate` grammar.
+    FixSourceSyntax,
+    /// Declare the referenced entity before linking it.
+    DeclareReferencedEntity,
+    /// Declare the referenced catalog value before linking it.
+    DeclareReferencedCatalogValue,
+    /// Use one of the approved primitive kinds.
+    UseApprovedPrimitive,
+    /// Move a relational fact into the graph relation syntax.
+    MoveRelationToGraph,
+    /// Remove a source-authored fact that belongs to a compiler projection.
+    RemoveDerivedFact,
+    /// Replace a raw transform with a typed lattice binding.
+    ReplaceRawTransformWithBinding,
+    /// Remove an attempted canonical-owner declaration from content.
+    RestoreCanonicalFactOwner,
+    /// Remove or rename a duplicate declaration.
+    RemoveDuplicateDeclaration,
+    /// Supply the field required by the selected primitive kind.
+    SupplyRequiredField,
+    /// Remove a field the selected primitive kind does not accept.
+    RemoveUnsupportedField,
+    /// Use a value from the catalog namespace required by the field.
+    UseExpectedCatalogNamespace,
+    /// Use a relation kind from the approved relation vocabulary.
+    UseApprovedRelationKind,
 }
 
 impl RepairClass {
@@ -91,6 +119,19 @@ impl RepairClass {
             Self::RemoveUndeclaredMember => "remove_undeclared_member",
             Self::WriteToNewOutputPath => "write_to_new_output_path",
             Self::RebuildFromSource => "rebuild_from_source",
+            Self::FixSourceSyntax => "fix_source_syntax",
+            Self::DeclareReferencedEntity => "declare_referenced_entity",
+            Self::DeclareReferencedCatalogValue => "declare_referenced_catalog_value",
+            Self::UseApprovedPrimitive => "use_approved_primitive",
+            Self::MoveRelationToGraph => "move_relation_to_graph",
+            Self::RemoveDerivedFact => "remove_derived_fact",
+            Self::ReplaceRawTransformWithBinding => "replace_raw_transform_with_binding",
+            Self::RestoreCanonicalFactOwner => "restore_canonical_fact_owner",
+            Self::RemoveDuplicateDeclaration => "remove_duplicate_declaration",
+            Self::SupplyRequiredField => "supply_required_field",
+            Self::RemoveUnsupportedField => "remove_unsupported_field",
+            Self::UseExpectedCatalogNamespace => "use_expected_catalog_namespace",
+            Self::UseApprovedRelationKind => "use_approved_relation_kind",
         }
     }
 }

--- a/crates/estate-core/src/id.rs
+++ b/crates/estate-core/src/id.rs
@@ -125,35 +125,37 @@ impl fmt::Display for CatalogValueId {
     }
 }
 
-/// A namespace-local machine, for example `north_gate.access`.
+/// An entity-local semantic namespace, for example `north_gate.access`.
 ///
-/// Section 7 orders machine collections by canonical namespace ID. The four
-/// door machines therefore hash in the order `access`, `combustion`,
-/// `integrity`, `ward` regardless of the order they were declared in.
+/// State machines live in namespaces, but not every namespace is a machine:
+/// static topology claims use names such as `flooded_section.region`. Section
+/// 7 orders machine collections by these IDs; the broader type also gives
+/// every static claim an honest semantic home instead of inventing a fake
+/// state machine for it.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct NamespaceId {
     entity: EntityId,
-    machine: Ident,
+    local_name: Ident,
 }
 
 impl NamespaceId {
     /// Builds a namespace ID from its parts.
     #[must_use]
-    pub fn new(entity: EntityId, machine: Ident) -> Self {
-        Self { entity, machine }
+    pub fn new(entity: EntityId, local_name: Ident) -> Self {
+        Self { entity, local_name }
     }
 
-    /// Parses `<entity>.<machine>`.
+    /// Parses `<entity>.<namespace>`.
     ///
     /// # Errors
     ///
     /// Returns `EK0104` when the shape is wrong and `EK0101` when a segment is
     /// not a legal identifier.
     pub fn parse(text: &str) -> Result<Self, Diagnostic> {
-        let [entity, machine] = split_exact::<2>(text, b'.', "<entity>.<machine>")?;
+        let [entity, local_name] = split_exact::<2>(text, b'.', "<entity>.<namespace>")?;
         Ok(Self {
             entity: EntityId(entity),
-            machine,
+            local_name,
         })
     }
 
@@ -163,22 +165,22 @@ impl NamespaceId {
         &self.entity
     }
 
-    /// The machine's local name, for example `access`.
+    /// The namespace's entity-local name, for example `access` or `region`.
     #[must_use]
-    pub fn machine(&self) -> &Ident {
-        &self.machine
+    pub fn local_name(&self) -> &Ident {
+        &self.local_name
     }
 }
 
 impl StableId for NamespaceId {
     fn canonical_string(&self) -> String {
-        format!("{}.{}", self.entity, self.machine)
+        format!("{}.{}", self.entity, self.local_name)
     }
 }
 
 impl fmt::Display for NamespaceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}.{}", self.entity, self.machine)
+        write!(f, "{}.{}", self.entity, self.local_name)
     }
 }
 
@@ -226,7 +228,7 @@ impl ClaimRef {
         })
     }
 
-    /// The machine that raises this claim.
+    /// The semantic namespace that raises this claim.
     #[must_use]
     pub fn namespace(&self) -> &NamespaceId {
         &self.namespace
@@ -236,6 +238,52 @@ impl ClaimRef {
     #[must_use]
     pub fn capability(&self) -> &Ident {
         &self.capability
+    }
+}
+
+/// An approved primitive kind, for example `primitive/iron_barred_door`.
+///
+/// Primitive kinds and catalog values deliberately use different Rust types.
+/// A credential cannot satisfy a primitive reference merely because both use
+/// slash-separated symbolic names in source.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct PrimitiveKindId(Ident);
+
+impl PrimitiveKindId {
+    /// Parses `primitive/<name>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0104` when the namespace or shape is wrong and `EK0101`
+    /// when the name is not a supported identifier.
+    pub fn parse(text: &str) -> Result<Self, Diagnostic> {
+        let [namespace, name] = split_exact::<2>(text, b'/', "primitive/<name>")?;
+        if namespace.as_str() != "primitive" {
+            return Err(Diagnostic::new(
+                codes::ID_SHAPE_INVALID,
+                format!("`{text}` is not in the `primitive` namespace"),
+            )
+            .with_repair(RepairClass::UseSupportedIdentifierShape));
+        }
+        Ok(Self(name))
+    }
+
+    /// The primitive's name within the approved catalog.
+    #[must_use]
+    pub fn name(&self) -> &Ident {
+        &self.0
+    }
+}
+
+impl StableId for PrimitiveKindId {
+    fn canonical_string(&self) -> String {
+        format!("primitive/{}", self.0)
+    }
+}
+
+impl fmt::Display for PrimitiveKindId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "primitive/{}", self.0)
     }
 }
 
@@ -311,6 +359,37 @@ pub struct SchemaId {
 }
 
 impl SchemaId {
+    /// Parses `<dotted-name>@<positive-version>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable identifier diagnostic when the shape, name, or
+    /// version is invalid.
+    pub fn parse(text: &str) -> Result<Self, Diagnostic> {
+        let (name, version) = text.split_once('@').ok_or_else(|| {
+            Diagnostic::new(
+                codes::ID_SHAPE_INVALID,
+                format!("`{text}` does not match `<schema-name>@<version>`"),
+            )
+            .with_repair(RepairClass::UseSupportedIdentifierShape)
+        })?;
+        if version.is_empty() || !version.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(Diagnostic::new(
+                codes::ID_SHAPE_INVALID,
+                format!("schema version `{version}` is not an unsigned integer"),
+            )
+            .with_repair(RepairClass::UseSupportedIdentifierShape));
+        }
+        let version = version.parse::<u32>().map_err(|_| {
+            Diagnostic::new(
+                codes::ID_SHAPE_INVALID,
+                format!("schema version `{version}` does not fit a 32-bit unsigned integer"),
+            )
+            .with_repair(RepairClass::UseSupportedIdentifierShape)
+        })?;
+        Self::new(name, version)
+    }
+
     /// Builds a schema ID.
     ///
     /// # Errors

--- a/crates/estate-core/src/lib.rs
+++ b/crates/estate-core/src/lib.rs
@@ -45,5 +45,7 @@ pub mod package;
 pub use canonical::{CanonicalValue, FieldName, to_canonical_bytes};
 pub use diagnostic::{Diagnostic, DiagnosticCode, RepairClass, SourcePath, SourceSpan};
 pub use hash::{Sha256Digest, StateHash};
-pub use id::{CatalogValueId, ClaimRef, EntityId, NamespaceId, SchemaId, SchemaName};
+pub use id::{
+    CatalogValueId, ClaimRef, EntityId, NamespaceId, PrimitiveKindId, SchemaId, SchemaName,
+};
 pub use ident::Ident;

--- a/crates/estate-core/tests/ids.rs
+++ b/crates/estate-core/tests/ids.rs
@@ -1,7 +1,9 @@
 //! Stable identity: typed, non-interchangeable, and ordered the way section 7
 //! requires for hashing.
 
-use estate_core::id::{CatalogValueId, ClaimRef, EntityId, NamespaceId, SchemaId, StableId};
+use estate_core::id::{
+    CatalogValueId, ClaimRef, EntityId, NamespaceId, PrimitiveKindId, SchemaId, StableId,
+};
 use estate_core::ident::{Ident, SEPARATORS};
 
 #[test]
@@ -109,10 +111,10 @@ fn namespace_ids_order_by_canonical_string_and_by_parts_alike() {
 }
 
 #[test]
-fn claim_refs_carry_the_machine_that_raises_them() {
+fn claim_refs_carry_the_semantic_namespace_that_raises_them() {
     let reason = ClaimRef::parse("north_gate.ward#blocks_ground").unwrap();
     assert_eq!(reason.namespace().entity().to_string(), "north_gate");
-    assert_eq!(reason.namespace().machine().as_str(), "ward");
+    assert_eq!(reason.namespace().local_name().as_str(), "ward");
     assert_eq!(reason.capability().as_str(), "blocks_ground");
     assert_eq!(reason.to_string(), "north_gate.ward#blocks_ground");
 
@@ -144,4 +146,23 @@ fn schema_versions_start_at_one() {
         schema.to_canonical().to_canonical_bytes(),
         br#"{"name":"estate.source","version":2}"#.to_vec()
     );
+}
+
+#[test]
+fn primitive_kinds_are_not_catalog_values() {
+    let primitive = PrimitiveKindId::parse("primitive/iron_barred_door").unwrap();
+    assert_eq!(primitive.name().as_str(), "iron_barred_door");
+    assert_eq!(primitive.to_string(), "primitive/iron_barred_door");
+    assert!(PrimitiveKindId::parse("credential/gaoler_key").is_err());
+}
+
+#[test]
+fn schema_ids_parse_their_wire_spelling() {
+    assert_eq!(
+        SchemaId::parse("estate.source@1").unwrap(),
+        SchemaId::new("estate.source", 1).unwrap()
+    );
+    for illegal in ["estate.source", "estate.source@", "estate.source@x"] {
+        assert!(SchemaId::parse(illegal).is_err());
+    }
 }

--- a/crates/estate-schema/src/ir.rs
+++ b/crates/estate-schema/src/ir.rs
@@ -1,0 +1,642 @@
+//! Canonical World IR schema types produced by the ownership linker.
+
+use std::collections::BTreeSet;
+
+use estate_core::canonical::keyed_array;
+use estate_core::id::StableId;
+use estate_core::{
+    CanonicalValue, CatalogValueId, ClaimRef, EntityId, Ident, NamespaceId, PrimitiveKindId,
+    SchemaId, SourceSpan,
+};
+
+use crate::{Binding, world_ir_schema};
+
+/// A capability in the sealed Gate K basis used by the three approved kinds.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum CapabilityKind {
+    /// Lattice boundary/topology.
+    Boundary,
+    /// Openable or breachable portal.
+    Portal,
+    /// Ground movement blocking.
+    BlocksGround,
+    /// Ground traversal cost.
+    TraversalCostGround,
+    /// Namespace-local state machine.
+    Machine,
+    /// Typed interaction surface.
+    Interactable,
+    /// Lattice region.
+    Region,
+    /// Effective light emission.
+    EmitsLight,
+    /// Exactly one authoritative owner.
+    Authority,
+    /// Persistent semantic state.
+    Persisted,
+}
+
+impl CapabilityKind {
+    /// Stable wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Boundary => "boundary",
+            Self::Portal => "portal",
+            Self::BlocksGround => "blocks_ground",
+            Self::TraversalCostGround => "traversal_cost_ground",
+            Self::Machine => "machine",
+            Self::Interactable => "interactable",
+            Self::Region => "region",
+            Self::EmitsLight => "emits_light",
+            Self::Authority => "authority",
+            Self::Persisted => "persisted",
+        }
+    }
+}
+
+/// The value supplied by a capability claim template.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ClaimValue {
+    /// Boolean claim value.
+    Bool(bool),
+    /// Non-negative integer claim value.
+    Uint(u32),
+}
+
+impl ClaimValue {
+    fn to_canonical(&self) -> CanonicalValue {
+        match self {
+            Self::Bool(value) => CanonicalValue::Bool(*value),
+            Self::Uint(value) => CanonicalValue::Uint(u64::from(*value)),
+        }
+    }
+}
+
+/// A typed activation expression for a capability claim template.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ClaimActivation {
+    /// Always active.
+    Always,
+    /// Active when one namespace-local machine equals the given state.
+    StateEquals {
+        /// Machine namespace.
+        namespace: NamespaceId,
+        /// Required state.
+        state: Ident,
+    },
+    /// Active when any child is active.
+    Any(Vec<ClaimActivation>),
+    /// Active when every child is active.
+    All(Vec<ClaimActivation>),
+    /// Logical negation.
+    Not(Box<ClaimActivation>),
+}
+
+impl ClaimActivation {
+    fn to_canonical(&self) -> CanonicalValue {
+        match self {
+            Self::Always => {
+                CanonicalValue::object_declared([("kind", CanonicalValue::text("always"))])
+            }
+            Self::StateEquals { namespace, state } => CanonicalValue::object_declared([
+                ("kind", CanonicalValue::text("state_equals")),
+                ("namespace", namespace.to_canonical()),
+                ("state", CanonicalValue::text(state.as_str())),
+            ]),
+            Self::Any(children) => activation_group("any", children),
+            Self::All(children) => activation_group("all", children),
+            Self::Not(child) => CanonicalValue::object_declared([
+                ("child", child.to_canonical()),
+                ("kind", CanonicalValue::text("not")),
+            ]),
+        }
+    }
+}
+
+fn activation_group(kind: &'static str, children: &[ClaimActivation]) -> CanonicalValue {
+    CanonicalValue::object_declared([
+        (
+            "children",
+            CanonicalValue::Array(children.iter().map(ClaimActivation::to_canonical).collect()),
+        ),
+        ("kind", CanonicalValue::text(kind)),
+    ])
+}
+
+/// A namespace-local state-machine template prepared at compile time.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct MachineTemplate {
+    namespace: NamespaceId,
+    states: Vec<Ident>,
+    initial: Ident,
+}
+
+impl MachineTemplate {
+    /// Builds a state-machine template.
+    #[must_use]
+    pub fn new(namespace: NamespaceId, states: Vec<Ident>, initial: Ident) -> Self {
+        Self {
+            namespace,
+            states,
+            initial,
+        }
+    }
+    /// The machine namespace.
+    #[must_use]
+    pub fn namespace(&self) -> &NamespaceId {
+        &self.namespace
+    }
+    /// States in schema-declared order.
+    #[must_use]
+    pub fn states(&self) -> &[Ident] {
+        &self.states
+    }
+    /// Initial state.
+    #[must_use]
+    pub fn initial(&self) -> &Ident {
+        &self.initial
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            ("initial", CanonicalValue::text(self.initial.as_str())),
+            ("namespace", self.namespace.to_canonical()),
+            (
+                "states",
+                CanonicalValue::Array(
+                    self.states
+                        .iter()
+                        .map(|state| CanonicalValue::text(state.as_str()))
+                        .collect(),
+                ),
+            ),
+        ])
+    }
+}
+
+/// A capability claim prepared for later command-time resolution.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ClaimTemplate {
+    id: ClaimRef,
+    capability: CapabilityKind,
+    activation: ClaimActivation,
+    value: ClaimValue,
+}
+
+impl ClaimTemplate {
+    /// Builds a typed claim template.
+    #[must_use]
+    pub fn new(
+        id: ClaimRef,
+        capability: CapabilityKind,
+        activation: ClaimActivation,
+        value: ClaimValue,
+    ) -> Self {
+        Self {
+            id,
+            capability,
+            activation,
+            value,
+        }
+    }
+    /// Stable claim reference.
+    #[must_use]
+    pub fn id(&self) -> &ClaimRef {
+        &self.id
+    }
+    /// Capability supplied by this claim.
+    #[must_use]
+    pub const fn capability(&self) -> CapabilityKind {
+        self.capability
+    }
+    /// Activation expression.
+    #[must_use]
+    pub fn activation(&self) -> &ClaimActivation {
+        &self.activation
+    }
+    /// Supplied value.
+    #[must_use]
+    pub fn value(&self) -> &ClaimValue {
+        &self.value
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            ("activation", self.activation.to_canonical()),
+            ("capability", CanonicalValue::text(self.capability.as_str())),
+            ("id", self.id.to_canonical()),
+            ("value", self.value.to_canonical()),
+        ])
+    }
+}
+
+/// The approved primitive expansion attached to one entity.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct PrimitiveExpansion {
+    capabilities: BTreeSet<CapabilityKind>,
+    machines: Vec<MachineTemplate>,
+    claims: Vec<ClaimTemplate>,
+}
+
+impl PrimitiveExpansion {
+    /// Builds an expansion and imposes stable namespace/claim ordering.
+    #[must_use]
+    pub fn new(
+        capabilities: impl IntoIterator<Item = CapabilityKind>,
+        mut machines: Vec<MachineTemplate>,
+        mut claims: Vec<ClaimTemplate>,
+    ) -> Self {
+        machines.sort_by(|left, right| left.namespace.cmp(&right.namespace));
+        claims.sort_by(|left, right| left.id.cmp(&right.id));
+        Self {
+            capabilities: capabilities.into_iter().collect(),
+            machines,
+            claims,
+        }
+    }
+    /// Capability bundle in stable order.
+    #[must_use]
+    pub fn capabilities(&self) -> &BTreeSet<CapabilityKind> {
+        &self.capabilities
+    }
+    /// Namespace-local machines in stable namespace order.
+    #[must_use]
+    pub fn machines(&self) -> &[MachineTemplate] {
+        &self.machines
+    }
+    /// Claim templates in stable claim-reference order.
+    #[must_use]
+    pub fn claims(&self) -> &[ClaimTemplate] {
+        &self.claims
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            (
+                "capabilities",
+                CanonicalValue::Array(
+                    self.capabilities
+                        .iter()
+                        .map(|item| CanonicalValue::text(item.as_str()))
+                        .collect(),
+                ),
+            ),
+            (
+                "claims",
+                keyed_array(
+                    self.claims
+                        .iter()
+                        .map(|claim| (claim.id.clone(), claim.to_canonical())),
+                ),
+            ),
+            (
+                "machines",
+                keyed_array(
+                    self.machines
+                        .iter()
+                        .map(|machine| (machine.namespace.clone(), machine.to_canonical())),
+                ),
+            ),
+        ])
+    }
+}
+
+/// One linked and expanded world entity.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct IrEntity {
+    id: EntityId,
+    primitive: PrimitiveKindId,
+    binding: Binding,
+    credential: Option<CatalogValueId>,
+    expansion: PrimitiveExpansion,
+    source_span: SourceSpan,
+}
+
+impl IrEntity {
+    /// Builds one linked entity.
+    #[must_use]
+    pub fn new(
+        id: EntityId,
+        primitive: PrimitiveKindId,
+        binding: Binding,
+        credential: Option<CatalogValueId>,
+        expansion: PrimitiveExpansion,
+        source_span: SourceSpan,
+    ) -> Self {
+        Self {
+            id,
+            primitive,
+            binding,
+            credential,
+            expansion,
+            source_span,
+        }
+    }
+    /// Stable entity ID.
+    #[must_use]
+    pub fn id(&self) -> &EntityId {
+        &self.id
+    }
+    /// Approved primitive kind.
+    #[must_use]
+    pub fn primitive(&self) -> &PrimitiveKindId {
+        &self.primitive
+    }
+    /// Typed lattice binding.
+    #[must_use]
+    pub fn binding(&self) -> &Binding {
+        &self.binding
+    }
+    /// Optional typed credential reference.
+    #[must_use]
+    pub fn credential(&self) -> Option<&CatalogValueId> {
+        self.credential.as_ref()
+    }
+    /// Compiler-owned primitive expansion.
+    #[must_use]
+    pub fn expansion(&self) -> &PrimitiveExpansion {
+        &self.expansion
+    }
+    /// Source declaration span.
+    #[must_use]
+    pub fn source_span(&self) -> &SourceSpan {
+        &self.source_span
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        let credential = self
+            .credential
+            .as_ref()
+            .map_or(CanonicalValue::Null, StableId::to_canonical);
+        CanonicalValue::object_declared([
+            ("binding", self.binding.to_canonical()),
+            ("credential", credential),
+            ("expansion", self.expansion.to_canonical()),
+            ("id", self.id.to_canonical()),
+            ("primitive", self.primitive.to_canonical()),
+            ("source", span_to_canonical(&self.source_span)),
+        ])
+    }
+}
+
+/// One linked graph relation.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct IrRelation {
+    subject: EntityId,
+    kind: Ident,
+    object: EntityId,
+    source_span: SourceSpan,
+}
+
+impl IrRelation {
+    /// Builds a linked relation.
+    #[must_use]
+    pub fn new(subject: EntityId, kind: Ident, object: EntityId, source_span: SourceSpan) -> Self {
+        Self {
+            subject,
+            kind,
+            object,
+            source_span,
+        }
+    }
+    /// Subject entity.
+    #[must_use]
+    pub fn subject(&self) -> &EntityId {
+        &self.subject
+    }
+    /// Relation kind.
+    #[must_use]
+    pub fn kind(&self) -> &Ident {
+        &self.kind
+    }
+    /// Object entity.
+    #[must_use]
+    pub fn object(&self) -> &EntityId {
+        &self.object
+    }
+
+    fn stable_key(&self) -> String {
+        format!("{}#{}#{}", self.subject, self.kind, self.object)
+    }
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            ("kind", CanonicalValue::text(self.kind.as_str())),
+            ("object", self.object.to_canonical()),
+            ("source", span_to_canonical(&self.source_span)),
+            ("subject", self.subject.to_canonical()),
+        ])
+    }
+}
+
+/// Canonical owner of a fact class.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum FactOwner {
+    /// Lattice-owned spatial truth.
+    Lattice,
+    /// Graph-owned identity or relation.
+    Graph,
+    /// Linker-derived cross-domain binding.
+    WorldLinker,
+}
+
+impl FactOwner {
+    /// Stable wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Lattice => "lattice",
+            Self::Graph => "graph",
+            Self::WorldLinker => "world_linker",
+        }
+    }
+}
+
+/// Machine-generated proof of where a semantic fact came from and who owns it.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FactOwnershipReceipt {
+    fact: String,
+    owner: FactOwner,
+    declared_at: SourceSpan,
+    resolved_to: String,
+    consumers: BTreeSet<Ident>,
+    derivation: Vec<String>,
+}
+
+impl FactOwnershipReceipt {
+    /// Builds an ownership receipt.
+    #[must_use]
+    pub fn new(
+        fact: String,
+        owner: FactOwner,
+        declared_at: SourceSpan,
+        resolved_to: String,
+        consumers: impl IntoIterator<Item = Ident>,
+        derivation: Vec<String>,
+    ) -> Self {
+        Self {
+            fact,
+            owner,
+            declared_at,
+            resolved_to,
+            consumers: consumers.into_iter().collect(),
+            derivation,
+        }
+    }
+    /// Stable fact path.
+    #[must_use]
+    pub fn fact(&self) -> &str {
+        &self.fact
+    }
+    /// Canonical owner.
+    #[must_use]
+    pub const fn owner(&self) -> FactOwner {
+        self.owner
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            (
+                "consumers",
+                CanonicalValue::Array(
+                    self.consumers
+                        .iter()
+                        .map(|item| CanonicalValue::text(item.as_str()))
+                        .collect(),
+                ),
+            ),
+            ("declared_at", span_to_canonical(&self.declared_at)),
+            (
+                "derivation",
+                CanonicalValue::Array(self.derivation.iter().map(CanonicalValue::text).collect()),
+            ),
+            ("fact", CanonicalValue::text(&self.fact)),
+            ("owner", CanonicalValue::text(self.owner.as_str())),
+            ("resolved_to", CanonicalValue::text(&self.resolved_to)),
+        ])
+    }
+}
+
+/// Versioned Canonical World IR produced from one linked source file.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct WorldIr {
+    schema: SchemaId,
+    source_schema: SchemaId,
+    catalog_values: Vec<CatalogValueId>,
+    entities: Vec<IrEntity>,
+    relations: Vec<IrRelation>,
+    ownership_receipts: Vec<FactOwnershipReceipt>,
+}
+
+impl WorldIr {
+    /// Builds the IR and imposes every stable collection order.
+    #[must_use]
+    pub fn new(
+        source_schema: SchemaId,
+        mut catalog_values: Vec<CatalogValueId>,
+        mut entities: Vec<IrEntity>,
+        mut relations: Vec<IrRelation>,
+        mut ownership_receipts: Vec<FactOwnershipReceipt>,
+    ) -> Self {
+        catalog_values.sort();
+        entities.sort_by(|left, right| left.id.cmp(&right.id));
+        relations.sort_by_key(IrRelation::stable_key);
+        ownership_receipts.sort_by(|left, right| left.fact.cmp(&right.fact));
+        Self {
+            schema: world_ir_schema(),
+            source_schema,
+            catalog_values,
+            entities,
+            relations,
+            ownership_receipts,
+        }
+    }
+    /// IR schema identity.
+    #[must_use]
+    pub fn schema(&self) -> &SchemaId {
+        &self.schema
+    }
+    /// Source schema identity consumed to produce this IR.
+    #[must_use]
+    pub fn source_schema(&self) -> &SchemaId {
+        &self.source_schema
+    }
+    /// Declared catalog values in stable ID order.
+    #[must_use]
+    pub fn catalog_values(&self) -> &[CatalogValueId] {
+        &self.catalog_values
+    }
+    /// Expanded entities in stable ID order.
+    #[must_use]
+    pub fn entities(&self) -> &[IrEntity] {
+        &self.entities
+    }
+    /// Linked relations in stable order.
+    #[must_use]
+    pub fn relations(&self) -> &[IrRelation] {
+        &self.relations
+    }
+    /// Fact-ownership receipts in stable fact-path order.
+    #[must_use]
+    pub fn ownership_receipts(&self) -> &[FactOwnershipReceipt] {
+        &self.ownership_receipts
+    }
+
+    /// Canonical semantic value for `world-ir.json`.
+    #[must_use]
+    pub fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            (
+                "catalog_values",
+                keyed_array(
+                    self.catalog_values
+                        .iter()
+                        .map(|id| (id.clone(), id.to_canonical())),
+                ),
+            ),
+            (
+                "entities",
+                keyed_array(
+                    self.entities
+                        .iter()
+                        .map(|entity| (entity.id.clone(), entity.to_canonical())),
+                ),
+            ),
+            (
+                "ownership_receipts",
+                keyed_array(
+                    self.ownership_receipts
+                        .iter()
+                        .map(|receipt| (receipt.fact.clone(), receipt.to_canonical())),
+                ),
+            ),
+            (
+                "relations",
+                keyed_array(
+                    self.relations
+                        .iter()
+                        .map(|relation| (relation.stable_key(), relation.to_canonical())),
+                ),
+            ),
+            ("schema", self.schema.to_canonical()),
+            ("source_schema", self.source_schema.to_canonical()),
+        ])
+    }
+    /// Canonical bytes for `world-ir.json`.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        self.to_canonical().to_canonical_bytes()
+    }
+}
+
+fn span_to_canonical(span: &SourceSpan) -> CanonicalValue {
+    let (byte_start, byte_end) = span.byte_range();
+    let (line, column) = span.position();
+    CanonicalValue::object_declared([
+        ("byte_end", CanonicalValue::Uint(u64::from(byte_end))),
+        ("byte_start", CanonicalValue::Uint(u64::from(byte_start))),
+        ("column", CanonicalValue::Uint(u64::from(column))),
+        ("line", CanonicalValue::Uint(u64::from(line))),
+        ("path", CanonicalValue::text(span.path().as_str())),
+    ])
+}

--- a/crates/estate-schema/src/lib.rs
+++ b/crates/estate-schema/src/lib.rs
@@ -1,43 +1,30 @@
 //! Authoring source and Canonical World IR schemas.
 //!
-//! `KERNEL.md` section 10 assigns this crate *authoring and Canonical World IR
-//! schemas*. Section 4 makes the Canonical World IR the single semantic truth,
-//! and section 10 forbids canonical schema types being defined in more than one
-//! crate — so the IR type will be defined here and nowhere else when SW-C lands
-//! it.
-//!
-//! At SW-B this crate carries the two schema identities it owns, so that
-//! versioning exists from the first commit as section 6 requires, and the
-//! boundary is proved before there is anything to put behind it.
-//!
-//! # Boundary
-//!
-//! The only permitted edge out of this crate is `estate-core`:
-//!
-//! ```
-//! use estate_core::id::SchemaId;
-//! let _: SchemaId = estate_schema::source_schema();
-//! ```
-//!
-//! It may not reach `estate-projection`. Projections are derived from the IR by
-//! the compiler; the schema crate must not learn what its consumers look like.
-//!
-//! ```compile_fail
-//! let _ = estate_projection::simulation_schema();
-//! ```
+//! `KERNEL.md` section 4 makes this crate the single owner of the Canonical
+//! World IR type. The compiler consumes [`SourceDocument`] and produces
+//! [`WorldIr`]; projection and runtime crates cannot name either because the
+//! dependency graph denies them access to this crate.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
-use estate_core::id::SchemaId;
+mod ir;
+mod source;
+mod spatial;
+
+use estate_core::SchemaId;
+
+pub use ir::{
+    CapabilityKind, ClaimActivation, ClaimTemplate, ClaimValue, FactOwner, FactOwnershipReceipt,
+    IrEntity, IrRelation, MachineTemplate, PrimitiveExpansion, WorldIr,
+};
+pub use source::{
+    ForbiddenFactOwner, SourceDocument, SourceEntity, SourceField, SourceRelation, Spanned,
+};
+pub use spatial::{Binding, Cell, Direction};
 
 /// The `.estate` authoring source schema.
-///
-/// # Panics
-///
-/// Panics if the built-in literal is not a valid schema id, which this crate's
-/// tests rule out.
 #[must_use]
 pub fn source_schema() -> SchemaId {
     SchemaId::new("estate.source", 1).expect("the source schema id is a valid literal")
@@ -46,12 +33,7 @@ pub fn source_schema() -> SchemaId {
 /// The Canonical World IR schema.
 ///
 /// Section 6 requires one real v1-to-v2 migration of this schema, changing the
-/// movement representation. SW-B records version 1; the migration is SW-F's.
-///
-/// # Panics
-///
-/// Panics if the built-in literal is not a valid schema id, which this crate's
-/// tests rule out.
+/// movement representation. Version 1 remains current until that later slice.
 #[must_use]
 pub fn world_ir_schema() -> SchemaId {
     SchemaId::new("estate.world_ir", 1).expect("the world IR schema id is a valid literal")

--- a/crates/estate-schema/src/source.rs
+++ b/crates/estate-schema/src/source.rs
@@ -1,0 +1,256 @@
+//! Parsed source-schema types. Parsing itself belongs to `estate-compiler`.
+
+use estate_core::{CatalogValueId, EntityId, Ident, PrimitiveKindId, SchemaId, SourceSpan};
+
+use crate::Binding;
+
+/// A typed source value paired with the exact source location that declared it.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Spanned<T> {
+    value: T,
+    span: SourceSpan,
+}
+
+impl<T> Spanned<T> {
+    /// Pairs a value with its source span.
+    #[must_use]
+    pub fn new(value: T, span: SourceSpan) -> Self {
+        Self { value, span }
+    }
+    /// The parsed value.
+    #[must_use]
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+    /// The source span.
+    #[must_use]
+    pub fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+    /// Consumes the wrapper and returns its value.
+    #[must_use]
+    pub fn into_value(self) -> T {
+        self.value
+    }
+}
+
+/// One field in an entity declaration.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum SourceField {
+    /// Typed lattice binding owned by source.
+    Anchor(Spanned<Binding>),
+    /// Typed catalog reference.
+    Credential(Spanned<CatalogValueId>),
+    /// A relation illegally placed in a lattice/entity field.
+    LatticeRelation {
+        /// Relation kind.
+        relation: Spanned<Ident>,
+        /// Referenced entity.
+        target: Spanned<EntityId>,
+        /// Span of the complete rejected field.
+        span: SourceSpan,
+    },
+    /// A raw transform, which source schema version 1 forbids.
+    RawTransform(SourceSpan),
+    /// A source-authored derived fact, which the compiler owns.
+    DerivedFact {
+        /// Attempted fact name.
+        name: String,
+        /// Span of the complete rejected field.
+        span: SourceSpan,
+    },
+}
+
+impl SourceField {
+    /// The complete field span.
+    #[must_use]
+    pub fn span(&self) -> &SourceSpan {
+        match self {
+            Self::Anchor(value) => value.span(),
+            Self::Credential(value) => value.span(),
+            Self::LatticeRelation { span, .. }
+            | Self::RawTransform(span)
+            | Self::DerivedFact { span, .. } => span,
+        }
+    }
+}
+
+/// One primitive instance from source.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SourceEntity {
+    id: Spanned<EntityId>,
+    primitive: Spanned<PrimitiveKindId>,
+    fields: Vec<SourceField>,
+    span: SourceSpan,
+}
+
+impl SourceEntity {
+    /// Builds a parsed entity declaration.
+    #[must_use]
+    pub fn new(
+        id: Spanned<EntityId>,
+        primitive: Spanned<PrimitiveKindId>,
+        fields: Vec<SourceField>,
+        span: SourceSpan,
+    ) -> Self {
+        Self {
+            id,
+            primitive,
+            fields,
+            span,
+        }
+    }
+    /// The stable entity ID.
+    #[must_use]
+    pub fn id(&self) -> &Spanned<EntityId> {
+        &self.id
+    }
+    /// The approved primitive-kind reference.
+    #[must_use]
+    pub fn primitive(&self) -> &Spanned<PrimitiveKindId> {
+        &self.primitive
+    }
+    /// Source fields in declaration order.
+    #[must_use]
+    pub fn fields(&self) -> &[SourceField] {
+        &self.fields
+    }
+    /// The complete declaration span.
+    #[must_use]
+    pub fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+}
+
+/// A graph relation between two world entities.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SourceRelation {
+    subject: Spanned<EntityId>,
+    kind: Spanned<Ident>,
+    object: Spanned<EntityId>,
+    span: SourceSpan,
+}
+
+impl SourceRelation {
+    /// Builds a parsed graph relation.
+    #[must_use]
+    pub fn new(
+        subject: Spanned<EntityId>,
+        kind: Spanned<Ident>,
+        object: Spanned<EntityId>,
+        span: SourceSpan,
+    ) -> Self {
+        Self {
+            subject,
+            kind,
+            object,
+            span,
+        }
+    }
+    /// The subject entity reference.
+    #[must_use]
+    pub fn subject(&self) -> &Spanned<EntityId> {
+        &self.subject
+    }
+    /// The relation kind.
+    #[must_use]
+    pub fn kind(&self) -> &Spanned<Ident> {
+        &self.kind
+    }
+    /// The object entity reference.
+    #[must_use]
+    pub fn object(&self) -> &Spanned<EntityId> {
+        &self.object
+    }
+    /// The complete relation span.
+    #[must_use]
+    pub fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+}
+
+/// A forbidden attempt by content to declare a canonical fact owner.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ForbiddenFactOwner {
+    fact: String,
+    owner: String,
+    span: SourceSpan,
+}
+
+impl ForbiddenFactOwner {
+    /// Records the rejected declaration for the ownership linker.
+    #[must_use]
+    pub fn new(fact: String, owner: String, span: SourceSpan) -> Self {
+        Self { fact, owner, span }
+    }
+    /// The attempted fact class.
+    #[must_use]
+    pub fn fact(&self) -> &str {
+        &self.fact
+    }
+    /// The attempted owner.
+    #[must_use]
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+    /// The complete declaration span.
+    #[must_use]
+    pub fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+}
+
+/// One parsed `.estate` file before name resolution or primitive expansion.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SourceDocument {
+    schema: Spanned<SchemaId>,
+    catalog_values: Vec<Spanned<CatalogValueId>>,
+    entities: Vec<SourceEntity>,
+    relations: Vec<SourceRelation>,
+    forbidden_fact_owners: Vec<ForbiddenFactOwner>,
+}
+
+impl SourceDocument {
+    /// Builds a parsed source document.
+    #[must_use]
+    pub fn new(
+        schema: Spanned<SchemaId>,
+        catalog_values: Vec<Spanned<CatalogValueId>>,
+        entities: Vec<SourceEntity>,
+        relations: Vec<SourceRelation>,
+        forbidden_fact_owners: Vec<ForbiddenFactOwner>,
+    ) -> Self {
+        Self {
+            schema,
+            catalog_values,
+            entities,
+            relations,
+            forbidden_fact_owners,
+        }
+    }
+    /// The declared source schema.
+    #[must_use]
+    pub fn schema(&self) -> &Spanned<SchemaId> {
+        &self.schema
+    }
+    /// Catalog values declared by this source file.
+    #[must_use]
+    pub fn catalog_values(&self) -> &[Spanned<CatalogValueId>] {
+        &self.catalog_values
+    }
+    /// Primitive instances in declaration order.
+    #[must_use]
+    pub fn entities(&self) -> &[SourceEntity] {
+        &self.entities
+    }
+    /// Graph relations in declaration order.
+    #[must_use]
+    pub fn relations(&self) -> &[SourceRelation] {
+        &self.relations
+    }
+    /// Forbidden owner declarations retained for a precise linker rejection.
+    #[must_use]
+    pub fn forbidden_fact_owners(&self) -> &[ForbiddenFactOwner] {
+        &self.forbidden_fact_owners
+    }
+}

--- a/crates/estate-schema/src/spatial.rs
+++ b/crates/estate-schema/src/spatial.rs
@@ -1,0 +1,141 @@
+//! Typed lattice bindings exposed by source schema version 1.
+
+use estate_core::CanonicalValue;
+
+/// One integer lattice cell.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Cell {
+    x: i32,
+    y: i32,
+    z: i32,
+}
+
+impl Cell {
+    /// Builds a cell from integer lattice coordinates.
+    #[must_use]
+    pub const fn new(x: i32, y: i32, z: i32) -> Self {
+        Self { x, y, z }
+    }
+
+    /// The x coordinate.
+    #[must_use]
+    pub const fn x(self) -> i32 {
+        self.x
+    }
+    /// The y coordinate.
+    #[must_use]
+    pub const fn y(self) -> i32 {
+        self.y
+    }
+    /// The z coordinate.
+    #[must_use]
+    pub const fn z(self) -> i32 {
+        self.z
+    }
+
+    pub(crate) fn to_canonical(self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            ("x", CanonicalValue::Int(i64::from(self.x))),
+            ("y", CanonicalValue::Int(i64::from(self.y))),
+            ("z", CanonicalValue::Int(i64::from(self.z))),
+        ])
+    }
+}
+
+/// A face direction in the typed lattice.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum Direction {
+    /// Negative y.
+    North,
+    /// Positive x.
+    East,
+    /// Positive y.
+    South,
+    /// Negative x.
+    West,
+    /// Positive z.
+    Up,
+    /// Negative z.
+    Down,
+}
+
+impl Direction {
+    /// Parses the source spelling of a direction.
+    #[must_use]
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "north" => Some(Self::North),
+            "east" => Some(Self::East),
+            "south" => Some(Self::South),
+            "west" => Some(Self::West),
+            "up" => Some(Self::Up),
+            "down" => Some(Self::Down),
+            _ => None,
+        }
+    }
+
+    /// The stable source and wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::North => "north",
+            Self::East => "east",
+            Self::South => "south",
+            Self::West => "west",
+            Self::Up => "up",
+            Self::Down => "down",
+        }
+    }
+}
+
+/// A source-authored typed lattice binding.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum Binding {
+    /// An entity anchored to a cell.
+    Cell(Cell),
+    /// An entity anchored to one face of a cell.
+    Face {
+        /// The owning cell.
+        cell: Cell,
+        /// The selected face.
+        direction: Direction,
+    },
+    /// A closed axis-aligned cell region.
+    Region {
+        /// Component-wise minimum cell.
+        min: Cell,
+        /// Component-wise maximum cell.
+        max: Cell,
+    },
+}
+
+impl Binding {
+    /// The source spelling of the binding kind.
+    #[must_use]
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Cell(_) => "cell",
+            Self::Face { .. } => "face",
+            Self::Region { .. } => "region",
+        }
+    }
+
+    pub(crate) fn to_canonical(&self) -> CanonicalValue {
+        match self {
+            Self::Cell(cell) => CanonicalValue::object_declared([
+                ("cell", cell.to_canonical()),
+                ("kind", CanonicalValue::text("cell")),
+            ]),
+            Self::Face { cell, direction } => CanonicalValue::object_declared([
+                ("cell", cell.to_canonical()),
+                ("direction", CanonicalValue::text(direction.as_str())),
+                ("kind", CanonicalValue::text("face")),
+            ]),
+            Self::Region { min, max } => CanonicalValue::object_declared([
+                ("kind", CanonicalValue::text("region")),
+                ("max", max.to_canonical()),
+                ("min", min.to_canonical()),
+            ]),
+        }
+    }
+}

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,39 +1,49 @@
 # Handoff — state of the repository
 
-Updated 2026-08-21 at the close of issue #1. This file orients a fresh session;
-it is rewritten at each slice boundary and never accumulates history (git has
+Updated 2026-08-21 for SW-C draft PR #6. This file orients a fresh session; it
+is rewritten at each slice boundary and never accumulates history (git has
 that).
 
 ## Where things stand
 
-- **Contract revision 2** is merged (#2): `THESIS.md`, `KERNEL.md` (Gate K),
-  `docs/decisions/0001-contract-repair.md`,
-  `docs/evaluation/COLD_AGENT_PROTOCOL.md`.
-- **SW-B is merged (#3):** the §10 workspace (six kernel crates + isolated
-  `xtask`), toolchain pinned to 1.97.1, lockfile with zero third-party crates,
-  `estate-core` (typed stable IDs, canonical bytes, in-crate SHA-256, checked
-  arithmetic, structured diagnostics, immutable `WorldPackage`),
-  `cargo xtask boundary`, CI green on main. See `docs/workspace.md`.
-- **Issue #1 is closed.** Its remaining slices are tracked as their own issues.
-- **Issue #4** records four contract underspecifications SW-B resolved in code
-  that KERNEL.md should pin through the amendment process.
+- **Contract revision 2** is merged (#2): `THESIS.md`, `KERNEL.md`, decision
+  0001, and the cold-agent protocol.
+- **SW-B is merged (#3):** six kernel crates plus isolated `xtask`, Rust 1.97.1,
+  zero third-party crates, deterministic core primitives, immutable package
+  mechanics, boundary enforcement, and green CI on main.
+- **SW-C is implemented in draft PR #6:** source-language decision 0002, the
+  exact `fixtures/gaol.estate`, source AST and Canonical World IR schemas, typed
+  lattice bindings, parser, distinct typed symbol tables, the sealed
+  three-primitive expansion catalog, ownership linker/receipts, and mutation
+  tests. The implementation commit is `be5576d`; check the PR for its current
+  head, CI, review, and merge state.
+- **Issue #5 remains open** until owner disposition and merge. Its record states
+  that acceptance 3 is only partially covered: IR expansion is proved, but the
+  observable `estate inspect` command still requires complete packages and
+  projections.
+- **Issue #4 remains open** for the four SW-B contract underspecifications.
+- **Issue #7 records the cold-agent roster problem:** SW-B is Claude-authored
+  and SW-C is GPT-authored, so GPT is no longer eligible as the formal cold
+  author for the SW-C authoring interface. A third family is the cleanest
+  whole-kernel subject unless the owner predeclares slice-specific eligibility.
 
 ## What is next
 
-**SW-C — source schema, parser, name resolution, ownership linker.** Defined
-by KERNEL.md §1 (the exact base fixture), §2 (compile-time phase), §4, §9
-(ownership mutations that must fail closed), and acceptance items 1–3, 11.
-`estate-schema` and `estate-compiler` are empty shells waiting for it.
+First, obtain a non-author rerun of PR #6 at its final head. Author proof and CI
+do not satisfy the repository's non-author rule. Owner review and merge remain
+separate dispositions.
 
-Then, in order: SW-D (namespace machines, interactions, transaction), SW-E
-(effective-fact resolution, `MovementDisposition`, projections), SW-F (runtime
-state, replay, migration v1→v2, `explain-*`), and the cold-author / cold-debug
-evaluations under `docs/evaluation/COLD_AGENT_PROTOCOL.md` — which require a
-model family other than the ones that built the kernel.
+After SW-C, implement **SW-D — namespace-machine transitions, typed
+interactions, deterministic phase order, and atomic transaction preparation**.
+The schemas now contain machine and claim templates; SW-D must add executable
+transition and interaction semantics without moving command-time truth into the
+compiler.
 
-## How to work here
+Then: SW-E (effective-fact resolution, `MovementDisposition`, projections),
+SW-F (runtime state, replay, migration v1→v2, `explain-*`), complete command
+surface/package orchestration, determinism matrix, and formal cold-agent gates.
 
-Read `AGENTS.md`. Run the proof before claiming anything:
+## How to prove the current branch
 
 ```bash
 cargo fmt --all -- --check
@@ -42,10 +52,12 @@ cargo test --workspace --locked
 cargo xtask boundary
 ```
 
-Unproven from §7 and stated as such in CI: Linux aarch64 release, and the
-ten-runs-per-target determinism count.
+The SW-C author rerun passed all four commands. Still unproven: Linux aarch64
+release, ten runs per target, the complete `estate` command surface, complete
+package projections, runtime semantics, migration/replay, and cold-agent gates.
 
-## Open owner points (from #2, standing as proposals until amended)
+## Open owner points
 
-SHA-256 + the canonical JSON profile; the Linux x86_64/aarch64 matrix; the
-cold-agent default budgets and zero-hint rule.
+From #4 / decision 0001: SHA-256 plus the canonical JSON profile; Linux
+x86_64/aarch64 matrix; cold-agent default budgets and zero-hint rule. From #7:
+the eligible cold-family roster after mixed-family implementation authorship.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,8 +1,8 @@
 # Handoff — state of the repository
 
-Updated 2026-08-21 for SW-C draft PR #6. This file orients a fresh session; it
-is rewritten at each slice boundary and never accumulates history (git has
-that).
+Updated 2026-08-21 for the owner disposition on SW-C PR #6. This file orients a
+fresh session; it is rewritten at each slice boundary and never accumulates
+history (git has that).
 
 ## Where things stand
 
@@ -11,16 +11,18 @@ that).
 - **SW-B is merged (#3):** six kernel crates plus isolated `xtask`, Rust 1.97.1,
   zero third-party crates, deterministic core primitives, immutable package
   mechanics, boundary enforcement, and green CI on main.
-- **SW-C is implemented in draft PR #6:** source-language decision 0002, the
+- **SW-C is implemented by PR #6:** source-language decision 0002, the
   exact `fixtures/gaol.estate`, source AST and Canonical World IR schemas, typed
   lattice bindings, parser, distinct typed symbol tables, the sealed
   three-primitive expansion catalog, ownership linker/receipts, and mutation
-  tests. The implementation commit is `be5576d`; check the PR for its current
-  head, CI, review, and merge state.
-- **Issue #5 remains open** until owner disposition and merge. Its record states
-  that acceptance 3 is only partially covered: IR expansion is proved, but the
-  observable `estate inspect` command still requires complete packages and
-  projections.
+  tests. The implementation commit is `be5576d`.
+- **Owner disposition:** Peter explicitly authorized merging PR #6 without the
+  required non-author rerun on 2026-08-21. The merge is authorized; SW-C is not
+  green until a later non-author receipt records the commit, commands,
+  environment, result, and reviewer. CI and author proof do not substitute.
+- **Issue #5 is disposed by PR #6.** Acceptance 3 remains only partially
+  covered: IR expansion is proved, but the observable `estate inspect` command
+  still requires complete packages and projections.
 - **Issue #4 remains open** for the four SW-B contract underspecifications.
 - **Issue #7 records the cold-agent roster problem:** SW-B is Claude-authored
   and SW-C is GPT-authored, so GPT is no longer eligible as the formal cold
@@ -29,9 +31,9 @@ that).
 
 ## What is next
 
-First, obtain a non-author rerun of PR #6 at its final head. Author proof and CI
-do not satisfy the repository's non-author rule. Owner review and merge remain
-separate dispositions.
+First, obtain the deferred non-author rerun of the merged SW-C commit. Author
+proof and CI do not satisfy the repository's non-author rule; the explicit
+owner merge disposition did not call the slice green.
 
 After SW-C, implement **SW-D — namespace-machine transitions, typed
 interactions, deterministic phase order, and atomic transaction preparation**.

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -1,0 +1,63 @@
+# Gate K `.estate` authoring reference
+
+Gate K source schema version 1 is a small line-oriented language. It contains
+primitive instances and source-owned facts only. Machines, capability claims,
+fact ownership, and projections come from the approved primitive catalog and
+compiler.
+
+## Grammar
+
+```text
+schema estate.source@1
+catalog <catalog>/<value>
+
+entity <entity_id> <primitive>/<kind>
+  anchor cell <x> <y> <z>
+  anchor face <x> <y> <z> <north|east|south|west|up|down>
+  anchor region <min_x> <min_y> <min_z> <max_x> <max_y> <max_z>
+  credential <catalog>/<value>
+end
+
+relation <subject_entity> <relation_kind> <object_entity>
+```
+
+Blank lines and lines whose first non-whitespace character is `#` are ignored.
+Indentation is optional. An entity body ends only at `end`. Integers are signed
+32-bit decimal values with no leading `+`.
+
+Identifier segments match `[a-z][a-z0-9_]*`. Entity IDs contain one segment,
+primitive kinds are `primitive/<name>`, catalog values are `<catalog>/<value>`,
+and relation kinds contain one segment. These are different types and do not
+substitute for one another.
+
+Gate K currently approves one relation kind, `owns`. The `credential` field
+accepts only values in the `credential` catalog namespace; declaring an equal
+name in another catalog does not satisfy it.
+
+## Approved Gate K primitives
+
+| Primitive | Required source fields | Compiler-owned expansion |
+| --- | --- | --- |
+| `primitive/iron_barred_door` | face anchor, credential | `access`, `integrity`, `ward`, `combustion`; portal and blocking claims |
+| `primitive/shallow_water_region` | region anchor | traversal cost `3` |
+| `primitive/extinguishable_light` | cell anchor | `emission`; light-emission claim |
+
+Each entity accepts exactly the fields listed. Duplicate fields and extra
+fields fail. The credential must be declared by a `catalog` declaration.
+
+## Facts content cannot author
+
+The compiler recognizes and rejects these mutation forms with dedicated
+diagnostics:
+
+```text
+  lattice_relation <relation_kind> <entity_id>
+  transform <anything...>
+  derived <fact_name> <anything...>
+fact_owner <fact_class> <owner>
+```
+
+They exist in the parser only so a forbidden fact receives the right stable
+diagnostic and source span. They are never accepted into Canonical World IR.
+Relations use the top-level `relation` form. Spatial truth uses `anchor`.
+Derived facts and canonical owners belong to the compiler.

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,0 +1,80 @@
+---
+title: Gate K source compiler
+status: Implementation reference for SW-C
+date: 2026-08-21
+applies_to: KERNEL.md sections 1, 2, 4, 9; acceptance 1-3 and 11
+---
+
+# Gate K source compiler
+
+SW-C turns one `estate.source@1` file into typed Canonical World IR. The public
+library path is:
+
+```rust
+estate_compiler::compile_source(source, repository_relative_path)
+```
+
+The source language and primitive catalog are documented in
+[`docs/authoring.md`](authoring.md); [decision 0002](decisions/0002-source-language.md)
+records why that language was chosen.
+
+## Compile stages implemented
+
+1. Parse the schema declaration, catalog declarations, primitive instances,
+   typed lattice bindings, catalog references, and graph relations.
+2. Build distinct catalog-value and entity symbol tables; duplicates fail.
+3. Resolve relation endpoints and primitive catalog references.
+4. Reject facts content cannot own: lattice relations, raw transforms, derived
+   facts, and canonical-owner declarations.
+5. Enforce primitive-specific field and binding shapes.
+6. Expand the sealed three-kind catalog into capability bundles, typed machine
+   templates, and typed claim activation expressions.
+7. Emit stable fact-ownership receipts and Canonical World IR bytes.
+
+Parser failures use `EK05xx`; linker and ownership failures use `EK06xx`.
+Every source rejection carries a repository-relative span and a legal repair
+class. The mutation suite plants each ownership/cross-reference violation in
+`KERNEL.md` section 9 that belongs to this slice.
+
+## Schema ownership
+
+`estate-schema` exclusively defines:
+
+- source AST types;
+- typed cell, face, and region bindings;
+- Canonical World IR entities and relations;
+- machine and claim templates;
+- fact-ownership receipts.
+
+`estate-compiler` exclusively defines parsing, the sealed primitive catalog,
+name resolution, validation, expansion, and linking. Runtime crates cannot name
+the source or IR types because the workspace graph denies them an
+`estate-schema` edge.
+
+`NamespaceId` means an entity-local semantic namespace. State machines occupy
+such namespaces, but static claims do too (`flooded_section.region`). Treating
+every namespace as a machine would require fake state machines in the IR, so
+SW-C corrected the narrower SW-B naming before it became serialized behavior.
+
+## What SW-C proves
+
+- the exact three-instance fixture is readable on one screen;
+- the credential remains a typed catalog value, never a fourth entity;
+- primitive references resolve only through the approved three-kind catalog;
+- the door, water, and light expand into inspectable typed IR;
+- source maps and ownership receipts survive canonical encoding;
+- repeated compilation of the same bytes produces identical canonical IR;
+- relevant ownership and cross-reference mutations fail with stable codes and
+  source spans.
+
+## Still unproved
+
+The CLI remains intentionally unimplemented. Acceptance item 3's observable
+`estate inspect` command requires a complete package, including projections;
+SW-C proves its expansion/IR half but does not call the criterion satisfied.
+Issue #5 records that scope split.
+
+Typed interactions, resolver plans, composition/coherence rules, projections,
+runtime transactions, package compilation, migration, replay, explanations,
+and cold-agent gates belong to later slices. Canonical World IR will grow those
+contracted fields before Gate K can pass.

--- a/docs/decisions/0002-source-language.md
+++ b/docs/decisions/0002-source-language.md
@@ -1,0 +1,58 @@
+---
+title: Gate K authoring source language
+status: Implementation decision for SW-C; accepted on merge
+number: 0002
+date: 2026-08-21
+issue: 5
+contract_revision: 2
+---
+
+# Gate K authoring source language
+
+## Decision
+
+Gate K uses a small line-oriented `.estate` language with explicit declaration
+terminators and whitespace-separated typed values. SW-C implements source
+schema version `estate.source@1` exactly as documented in `docs/authoring.md`.
+
+This resolves the open source-language question in `THESIS.md` section 21. It
+does not amend or weaken `KERNEL.md`; it chooses a representation for the
+already-required source facts.
+
+## Why this language
+
+The Gate K authoring surface has three jobs: remain readable on one screen,
+preserve source spans without lossy conversion, and prevent content from
+supplying derived facts. A purpose-built grammar makes those boundaries visible
+and rejects forbidden concepts by name.
+
+JSON was rejected because its object shape would expose compiler/schema
+structure as authoring ceremony and would make repeated declarations difficult
+to diagnose before map-key collapse. YAML and TOML were rejected because adding
+a third-party parser would break the zero-third-party, offline workspace, while
+implementing a partial lookalike would create misleading edge semantics. Rust
+or another general scripting language was rejected because arbitrary code is a
+contractual non-goal.
+
+## Grammar properties
+
+- one declaration or field per line;
+- comments and blank lines are ignored;
+- every file declares its source schema;
+- entity, primitive-kind, and catalog-value references are distinct types;
+- relation kinds come from a sealed vocabulary (`owns` in Gate K);
+- primitive parameters name the catalog namespace they accept;
+- lattice bindings use signed integer cells plus closed direction names;
+- entity bodies end with `end`; indentation is presentation only;
+- unknown statements fail closed;
+- raw transforms, derived facts, content-authored fact owners, and lattice
+  relations receive dedicated stable diagnostics rather than becoming unknown
+  extension points.
+
+## Consequences
+
+The parser is intentionally small enough to audit and ship without a parser
+generator. Language growth requires explicit grammar documentation and tests;
+there is no generic property bag for features to smuggle themselves through.
+The source schema versions independently of Canonical World IR and projection
+schemas, as required by `KERNEL.md` section 6.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -90,7 +90,7 @@ That is a property of the source, not of the dependency graph, and
 `cargo metadata` cannot see it. It is enforced structurally instead: the
 Canonical World IR type is defined in `estate-schema`, and every crate that must
 not see it lacks the edge that would let it. The checker proves the missing
-edges; the type itself arrives with SW-C.
+edges; SW-C supplies the type and tests the only permitted compiler crossing.
 
 ## Decisions SW-B made
 

--- a/fixtures/gaol.estate
+++ b/fixtures/gaol.estate
@@ -1,0 +1,15 @@
+schema estate.source@1
+catalog credential/gaoler_key
+
+entity north_gate primitive/iron_barred_door
+  anchor face 5 0 0 north
+  credential credential/gaoler_key
+end
+
+entity flooded_section primitive/shallow_water_region
+  anchor region 2 2 0 4 3 0
+end
+
+entity brazier_02 primitive/extinguishable_light
+  anchor cell 3 1 0
+end


### PR DESCRIPTION
## Scope

Implements SW-C from #5:

- record and document source-language choice before parser implementation
- add exact one-screen `fixtures/gaol.estate`
- define source AST, typed lattice bindings, and Canonical World IR in `estate-schema`
- parse `estate.source@1` with repository-relative source spans
- resolve distinct entity, primitive-kind, catalog-value, and relation namespaces
- expand the sealed door/water/light catalog into typed machine and claim templates
- emit fact-ownership receipts
- reject the six SW-C ownership/cross-reference mutations from KERNEL section 9 with stable codes and repair classes

## Evidence

Author rerun at `e98dd9d`:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo xtask boundary`
- `git diff --check`

All passed locally.

## Limits

- This is author evidence only. A non-author rerun is still required.
- KERNEL acceptance 3 is only partially covered: primitive expansion is observable in canonical World IR and tests, but `estate inspect` remains unimplemented until complete package projections exist. This split is recorded on #5 and in `docs/compiler.md`.
- No command surface, runtime transaction, projection output, replay, migration, aarch64 matrix, ten-run matrix, or cold-agent gate is claimed.
- Mixed Claude/GPT implementation authorship changes the eligible cold-family roster; #7 records the required decision.
- Gate K remains not green.

Closes #5 only after owner disposition and merge.
