### PR TITLE
Record SW-C non-author rerun

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,6 +1,6 @@
 # Handoff — state of the repository
 
-Updated 2026-08-21 for the owner disposition on SW-C PR #6. This file orients a
+Updated 2026-08-21 for the deferred SW-C non-author rerun. This file orients a
 fresh session; it is rewritten at each slice boundary and never accumulates
 history (git has that).
 
@@ -16,10 +16,13 @@ history (git has that).
   lattice bindings, parser, distinct typed symbol tables, the sealed
   three-primitive expansion catalog, ownership linker/receipts, and mutation
   tests. The implementation commit is `be5576d`.
-- **Owner disposition:** Peter explicitly authorized merging PR #6 without the
-  required non-author rerun on 2026-08-21. The merge is authorized; SW-C is not
-  green until a later non-author receipt records the commit, commands,
-  environment, result, and reviewer. CI and author proof do not substitute.
+- **Non-author disposition:** Peter explicitly authorized merging PR #6 before
+  its non-author rerun. DeepSeek V4 Pro then reran the complete proof through
+  direct Reasonix at max effort against merge commit `4ec25e5`; all four
+  commands passed with a clean tree before and after. The durable receipt is
+  under `docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/`.
+  SW-C now satisfies the repository's non-author rule. This was not a formal
+  cold-agent run and does not upgrade whole-Gate-K status.
 - **Issue #5 is disposed by PR #6.** Acceptance 3 remains only partially
   covered: IR expansion is proved, but the observable `estate inspect` command
   still requires complete packages and projections.
@@ -31,11 +34,7 @@ history (git has that).
 
 ## What is next
 
-First, obtain the deferred non-author rerun of the merged SW-C commit. Author
-proof and CI do not satisfy the repository's non-author rule; the explicit
-owner merge disposition did not call the slice green.
-
-After SW-C, implement **SW-D — namespace-machine transitions, typed
+Implement **SW-D — namespace-machine transitions, typed
 interactions, deterministic phase order, and atomic transaction preparation**.
 The schemas now contain machine and claim templates; SW-D must add executable
 transition and interaction semantics without moving command-time truth into the
@@ -54,9 +53,10 @@ cargo test --workspace --locked
 cargo xtask boundary
 ```
 
-The SW-C author rerun passed all four commands. Still unproven: Linux aarch64
-release, ten runs per target, the complete `estate` command surface, complete
-package projections, runtime semantics, migration/replay, and cold-agent gates.
+The SW-C author and non-author reruns passed all four commands. Still unproven:
+Linux aarch64 release, ten runs per target, the complete `estate` command
+surface, complete package projections, runtime semantics, migration/replay, and
+formal cold-agent gates.
 
 ## Open owner points
 

--- a/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/RUN.md
+++ b/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/RUN.md
@@ -33,6 +33,12 @@ session identifier. It was not exposed inside the subject's conversational
 context, so the subject correctly reported that limitation rather than
 inventing an identifier.
 
+The client version, build commit/target, maximum-effort launch setting, and
+operator identity come from the operator's launch command and preflight
+`reasonix version --json`; Reasonix did not repeat those fields in this run's
+export. The provider route and exact model are export-backed by `modelRef` and
+the session identifier.
+
 ## Environment
 
 ```text
@@ -80,6 +86,15 @@ machine-local and contains large repetitive token and test-progress events, so
 this durable record preserves the exact prompt, complete final response content
 normalized to Markdown, ordered command ledger, and result/checker metadata
 instead. No secret or credential is included.
+
+Reasonix's final harness-level `completion_summary` was `verdict: uncertain`,
+`mutations: 4`, `checks_passed: 0`, `review: passed`, with gaps
+`stale_verification` and `unverified_change`; `constraint_degraded` was false.
+That heuristic classified proof commands as possible mutations and did not
+recognize them as checks. It is preserved here because omitting an ugly harness
+field would make this receipt dishonest. It does not override the command exit
+statuses or the directly observed clean Git tree before and after, which are the
+declared non-author criteria.
 
 The run used 134,746 input tokens, of which 120,960 were cache reads, and 4,916
 output tokens. Reasonix reported an estimated complete cost of USD 0.02149356.

--- a/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/RUN.md
+++ b/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/RUN.md
@@ -1,0 +1,86 @@
+# SW-C non-author rerun
+
+**Verdict:** pass
+
+**Date:** 2026-08-21
+
+**Issue:** #9
+
+**Evaluated commit:** `4ec25e595f5bcc6052af730d8c830c94749608b2`
+
+**Evaluated branch:** `main`
+
+This receipt satisfies the repository's non-author rerun rule for the merged
+SW-C implementation. It is not a formal cold-author, cold-debug, or whole-Gate-K
+run under `docs/evaluation/COLD_AGENT_PROTOCOL.md`; it upgrades no unrelated
+acceptance claim.
+
+## Reviewer and harness
+
+- Subject reviewer: DeepSeek V4 Pro (`deepseek-v4-pro`), a non-author of SW-C.
+- Provider route: `deepseek-pro/deepseek-v4-pro`.
+- Client: Reasonix 1.29.0, commit `9eaa3b295`, Linux amd64 build.
+- Mode: direct Reasonix execution, maximum reasoning effort, one model turn.
+- Session: `20260821-124238.995035379-deepseek-v4-pro`.
+- Operator: Mira; no substantive hints or interventions after launch.
+- Retrieval and subagent capabilities were ablated. The prompt also forbade
+  web, persisted project memory, other models, mutation, and external writes.
+- The subject reported compliance. The operator inspected the exported event
+  stream and independently confirmed the final commit and clean-tree state.
+
+The exact model identifier was available in Reasonix result metadata and the
+session identifier. It was not exposed inside the subject's conversational
+context, so the subject correctly reported that limitation rather than
+inventing an identifier.
+
+## Environment
+
+```text
+rustc 1.97.1 (8bab26f4f 2026-07-14)
+host: x86_64-unknown-linux-gnu
+LLVM version: 22.1.6
+
+cargo 1.97.1 (c980f4866 2026-06-30)
+host: x86_64-unknown-linux-gnu
+os: Fedora 44.0.0 [64-bit]
+
+Linux Apollo 7.1.8-200.fc44.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Aug 10 03:35:23 UTC 2026 x86_64 GNU/Linux
+```
+
+The worktree was `main` at the exact evaluated commit and clean both before and
+after the proof. Cargo wrote only ignored build artifacts under `target/`; no
+tracked file, Git ref, GitHub object, or external state was changed.
+
+## Proof
+
+| Command | Result |
+| --- | --- |
+| `cargo fmt --all -- --check` | pass, exit 0 |
+| `cargo clippy --workspace --all-targets --locked -- -D warnings` | pass, exit 0, zero warnings |
+| `cargo test --workspace --locked` | pass, exit 0, 72 unit/integration tests plus doctests |
+| `cargo xtask boundary` | pass, exit 0, `boundary: clean` |
+
+The first formatting invocation appended an explicit exit-code echo and passed.
+The harness then rejected an analogous clippy invocation before execution
+because the trailing echo could mask the verifier's exit status. The reviewer
+reran clippy by itself, then reran formatting by itself before the final clean
+status check. `commands.json` records the rejected attempt as `not_run`; it did
+not count as a proof result or a mutation.
+
+No new package or runtime artifact was produced, so there is no package or state
+hash for this rerun. The immutable result identities are the evaluated Git
+commit above and the existing frozen hash asserted by the passing determinism
+test.
+
+## Evidence limits
+
+Reasonix exported the exact prompt, complete event stream, final transcript,
+result metadata, metrics, and empty stderr log. The complete event stream is
+machine-local and contains large repetitive token and test-progress events, so
+this durable record preserves the exact prompt, complete final response content
+normalized to Markdown, ordered command ledger, and result/checker metadata
+instead. No secret or credential is included.
+
+The run used 134,746 input tokens, of which 120,960 were cache reads, and 4,916
+output tokens. Reasonix reported an estimated complete cost of USD 0.02149356.
+The run completed in 88.160 seconds with no restart.

--- a/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/checker.json
+++ b/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/checker.json
@@ -40,6 +40,20 @@
     "tree_clean_before": true,
     "tree_clean_after": true
   },
+  "reasonix_completion_summary": {
+    "verdict": "uncertain",
+    "mutations": 4,
+    "checks_passed": 0,
+    "checks_failed": 0,
+    "checks_suppressed": 0,
+    "review": "passed",
+    "gap_kinds": [
+      "stale_verification",
+      "unverified_change"
+    ],
+    "constraint_degraded": false,
+    "disposition": "Heuristic summary does not override observed command exits and clean tracked tree; disclosed as an evidence limitation."
+  },
   "usage": {
     "duration_ms": 88160,
     "turns": 1,

--- a/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/checker.json
+++ b/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/checker.json
@@ -1,0 +1,54 @@
+{
+  "schema": "signed-world.non-author-checker.v1",
+  "verdict": "pass",
+  "date": "2026-08-21",
+  "evaluated_commit": "4ec25e595f5bcc6052af730d8c830c94749608b2",
+  "evaluated_branch": "main",
+  "reviewer": {
+    "provider_route": "deepseek-pro",
+    "model": "deepseek-v4-pro",
+    "client": "Reasonix",
+    "client_version": "1.29.0",
+    "client_commit": "9eaa3b295",
+    "effort": "max",
+    "session_id": "20260821-124238.995035379-deepseek-v4-pro",
+    "non_author": true
+  },
+  "constraints": {
+    "retrieval_ablated": true,
+    "subagent_ablated": true,
+    "web_used": false,
+    "persisted_project_memory_used": false,
+    "other_model_used": false,
+    "tracked_mutation": false,
+    "operator_substantive_hints": 0,
+    "restarts": 0
+  },
+  "environment": {
+    "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
+    "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)",
+    "host": "x86_64-unknown-linux-gnu",
+    "os": "Fedora 44.0.0 [64-bit]",
+    "kernel": "Linux Apollo 7.1.8-200.fc44.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Aug 10 03:35:23 UTC 2026 x86_64 GNU/Linux"
+  },
+  "proof": {
+    "fmt": "pass",
+    "clippy": "pass",
+    "test": "pass",
+    "boundary": "pass",
+    "commit_unchanged": true,
+    "tree_clean_before": true,
+    "tree_clean_after": true
+  },
+  "usage": {
+    "duration_ms": 88160,
+    "turns": 1,
+    "steps": 10,
+    "input_tokens": 134746,
+    "output_tokens": 4916,
+    "cache_read_input_tokens": 120960,
+    "cache_creation_input_tokens": 13786,
+    "estimated_cost_usd": "0.02149356",
+    "cost_complete": true
+  }
+}

--- a/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/commands.json
+++ b/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/commands.json
@@ -1,0 +1,68 @@
+{
+  "schema": "signed-world.non-author-command-ledger.v1",
+  "commands": [
+    {
+      "sequence": 1,
+      "command": "git rev-parse HEAD; git status --short --branch; echo \"---\"; rustc --version --verbose; echo \"---\"; cargo --version --verbose; echo \"---\"; uname -a",
+      "state": "completed",
+      "exit_code": 0,
+      "result": "Exact target commit; main; clean tree; Rust 1.97.1; Fedora 44 x86_64 environment recorded."
+    },
+    {
+      "sequence": 2,
+      "command": "cargo fmt --all -- --check; echo \"EXIT_CODE=$?\"",
+      "state": "completed",
+      "exit_code": 0,
+      "result": "EXIT_CODE=0"
+    },
+    {
+      "sequence": 3,
+      "command": "cargo clippy --workspace --all-targets --locked -- -D warnings; echo \"EXIT_CODE=$?\"",
+      "state": "not_run",
+      "exit_code": null,
+      "result": "Reasonix preflight rejected the trailing echo because it could mask the verifier exit status."
+    },
+    {
+      "sequence": 4,
+      "command": "cargo clippy --workspace --all-targets --locked -- -D warnings",
+      "state": "completed",
+      "exit_code": 0,
+      "result": "All six kernel crates checked; zero warnings."
+    },
+    {
+      "sequence": 5,
+      "command": "cargo test --workspace --locked",
+      "state": "completed",
+      "exit_code": 0,
+      "result": "All suites passed: 72 unit/integration tests plus doctests; zero failures."
+    },
+    {
+      "sequence": 6,
+      "command": "cargo xtask boundary",
+      "state": "completed",
+      "exit_code": 0,
+      "result": "boundary: clean"
+    },
+    {
+      "sequence": 7,
+      "command": "git rev-parse HEAD; git status --short --branch",
+      "state": "completed",
+      "exit_code": 0,
+      "result": "Target commit unchanged; main; clean tree."
+    },
+    {
+      "sequence": 8,
+      "command": "cargo fmt --all -- --check",
+      "state": "completed",
+      "exit_code": 0,
+      "result": "Standalone formatting proof passed."
+    },
+    {
+      "sequence": 9,
+      "command": "git rev-parse HEAD; git status --short --branch",
+      "state": "completed",
+      "exit_code": 0,
+      "result": "Target commit unchanged; main; clean tree."
+    }
+  ]
+}

--- a/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/prompt.txt
+++ b/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/prompt.txt
@@ -1,0 +1,35 @@
+You are the independent non-author checker for the signed-world SW-C implementation. You did not author this repository change. Work only in /home/peter/signed-world.
+
+This is a verification-only run. Do not edit, create, delete, move, format, commit, push, comment, or otherwise mutate any file, Git ref, GitHub object, configuration, or external state. Do not use web search, persisted project memory, another model, or a subagent. Read repository instructions as needed, then run the proof yourself.
+
+Required target:
+- merged commit must be exactly 4ec25e595f5bcc6052af730d8c830c94749608b2
+- branch must be main
+- worktree must be clean before and after
+
+Record these environment facts from commands:
+- git rev-parse HEAD
+- git status --short --branch
+- rustc --version --verbose
+- cargo --version --verbose
+- uname -a
+
+Run each proof command and observe its exit status:
+1. cargo fmt --all -- --check
+2. cargo clippy --workspace --all-targets --locked -- -D warnings
+3. cargo test --workspace --locked
+4. cargo xtask boundary
+
+Then rerun:
+- git rev-parse HEAD
+- git status --short --branch
+
+Your final response must state:
+- exact Reasonix/provider model identity you were invoked as, to the extent visible;
+- whether you complied with the no-memory/no-web/no-other-model/no-mutation constraints;
+- exact commit, branch, clean-tree result, environment facts;
+- each proof command and pass/fail;
+- final commit/tree state;
+- verdict PASS only if every required fact and command passed exactly; otherwise FAIL or INCONCLUSIVE with the precise reason.
+
+Do not infer success from CI or prior logs. Run the proof.

--- a/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/transcript.md
+++ b/docs/evaluation/runs/gate-k/2026-08-21-deepseek-v4-pro-sw-c-rerun/transcript.md
@@ -1,0 +1,48 @@
+## Verification report — signed-world SW-C (non-author checker)
+
+**Model identity:** I was invoked as the Reasonix coding agent for this session.
+No explicit model-name/version identifier is exposed in the session context, so
+the exact provider model identity is not visible to me; I will not fabricate one.
+
+**Constraint compliance:** COMPLIED. I used no web search, no persisted project
+memory, no other model, no subagent, and none of the suggested MCP tools
+(GitHub, memory, read_post). I made no edits, commits, or other mutations. The
+only writes performed were cargo's own build artifacts under the git-ignored
+`target/` directory, which are inherent to running the required proof commands;
+no tracked file was changed.
+
+**Required environment facts (before):**
+
+- `git rev-parse HEAD` → `4ec25e595f5bcc6052af730d8c830c94749608b2`
+  (matches required target exactly)
+- `git status --short --branch` → `## main...origin/main` (no changes); branch
+  is `main`, tree clean
+- `rustc --version --verbose` → rustc 1.97.1 (8bab26f4f 2026-07-14), host
+  `x86_64-unknown-linux-gnu`, release 1.97.1, LLVM 22.1.6
+- `cargo --version --verbose` → cargo 1.97.1 (c980f4866 2026-06-30), host
+  `x86_64-unknown-linux-gnu`, release 1.97.1
+- `uname -a` → `Linux Apollo 7.1.8-200.fc44.x86_64 #1 SMP PREEMPT_DYNAMIC Mon
+  Aug 10 03:35:23 UTC 2026 x86_64 GNU/Linux`
+
+**Proof commands (all run by me in this session):**
+
+1. `cargo fmt --all -- --check` → **PASS** (exit 0, no output; also run once
+   with an explicit exit-code echo confirming 0)
+2. `cargo clippy --workspace --all-targets --locked -- -D warnings` → **PASS**
+   (exit 0; all 6 kernel crates checked, zero warnings)
+3. `cargo test --workspace --locked` → **PASS** (exit 0; every suite `ok`, 0
+   failed — 72 unit/integration tests plus doctests, including the CLI exit-code,
+   compiler/mutation fail-closed, canonical encoding, package tamper,
+   determinism, and xtask edge-rule suites)
+4. `cargo xtask boundary` → **PASS** (exit 0; `boundary: clean`, membership,
+   permitted-edges, cycles, forbidden-dependency, and tooling-isolation rules
+   all checked)
+
+**Final state (after all proofs):**
+
+- `git rev-parse HEAD` → `4ec25e595f5bcc6052af730d8c830c94749608b2`
+  (unchanged)
+- `git status --short --branch` → `## main...origin/main` (clean)
+
+**Verdict: PASS** — required commit verified exactly, branch `main`, worktree
+clean before and after, and all four proof commands exited 0 with passing output.


### PR DESCRIPTION
## Summary

- records the deferred SW-C non-author rerun against merged commit `4ec25e595f5bcc6052af730d8c830c94749608b2`
- preserves the exact prompt, normalized complete final response, ordered command ledger, and Reasonix checker metadata
- updates the handoff: SW-C now satisfies the repository non-author rule; formal cold-agent and whole-Gate-K claims remain open

## Independent receipt

DeepSeek V4 Pro (`deepseek-pro/deepseek-v4-pro`) ran directly through Reasonix 1.29.0 at max effort with retrieval and subagents ablated. The worktree was `main` at the exact merge commit and clean before and after.

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — pass
- `cargo test --workspace --locked` — pass, 72 unit/integration tests plus doctests
- `cargo xtask boundary` — pass, `boundary: clean`

The receipt records one clippy invocation rejected by Reasonix preflight before execution because a trailing exit-code echo could mask failure. Clippy was then run standalone and passed. No tracked mutation occurred.

## Author verification of this evidence branch

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — pass
- `cargo test --workspace --locked` — pass
- `cargo xtask boundary` — pass
- JSON evidence parsed with `jq empty`

Closes #9.
