### PR TITLE
CI: upgrade checkout to v7

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Disk before
         run: |


### PR DESCRIPTION
## Summary

- upgrades the verification workflow from `actions/checkout@v4` to the current supported `actions/checkout@v7`
- removes reliance on GitHub's Node 20 compatibility override

Official upstream evidence: the checkout README uses `actions/checkout@v7`, and v7 is generally available with safer fork-PR defaults.

## Local proof

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — pass
- `cargo test --workspace --locked` — pass
- `cargo xtask boundary` — pass

The decisive proof is this PR's GitHub Actions run: checkout must execute without the Node 20 deprecation annotation and the complete verification job must pass.

Closes #8.
