### PR TITLE
Bump Rust toolchain to 1.98.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.97.1"
+rust-version = "1.98.0"
 license = "MIT"
 repository = "https://github.com/ConaryLabs/signed-world"
 publish = false

--- a/crates/estate-core/src/hash.rs
+++ b/crates/estate-core/src/hash.rs
@@ -61,7 +61,7 @@ impl Sha256Digest {
             return None;
         }
         let mut digest = [0_u8; 32];
-        for (index, pair) in bytes.chunks_exact(2).enumerate() {
+        for (index, pair) in bytes.as_chunks::<2>().0.iter().enumerate() {
             let high = value_of(pair[0])?;
             let low = value_of(pair[1])?;
             digest[index] = (high << 4) | low;

--- a/crates/estate-core/src/hash/sha256.rs
+++ b/crates/estate-core/src/hash/sha256.rs
@@ -111,7 +111,7 @@ pub fn sha256(input: &[u8]) -> [u8; 32] {
     tail[remainder.len()] = 0x80;
     let tail_len = if remainder.len() < 56 { 64 } else { 128 };
     tail[tail_len - 8..tail_len].copy_from_slice(&bit_length.to_be_bytes());
-    for chunk in tail[..tail_len].chunks_exact(64) {
+    for chunk in tail[..tail_len].as_chunks::<64>().0 {
         block.copy_from_slice(chunk);
         compress(&mut state, &block);
     }
@@ -125,7 +125,7 @@ pub fn sha256(input: &[u8]) -> [u8; 32] {
 
 fn compress(state: &mut [u32; 8], block: &[u8; 64]) {
     let mut schedule = [0_u32; 64];
-    for (index, chunk) in block.chunks_exact(4).enumerate() {
+    for (index, chunk) in block.as_chunks::<4>().0.iter().enumerate() {
         schedule[index] = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
     }
     for index in 16..64 {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # KERNEL.md section 7 requires a pinned toolchain for the determinism proof.
-# This pin records the toolchain the SW-B evidence was produced with.
+# Historical receipts record their exact toolchains; this is the current proof pin.
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

- pin Rust and the workspace MSRV at 1.98.0
- adopt Rust 1.98 Clippy's fixed-size `as_chunks` form in the SHA-256 implementation
- preserve all historical evaluation receipts unchanged

This is a maintenance slice and does not alter the Gate K acceptance contract.

## Author evidence

Environment:

- `rustc 1.98.0 (88d9e12ae 2026-08-18)`
- `cargo 1.98.0 (797e8a9bc 2026-08-05)`
- x86_64 Linux

Passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo xtask boundary`
- debug/release determinism output comparison
- GitHub Actions verify run `32511314284`

The frozen fixture remains `09ef5bc23dd2e47109dec91aea083e4f883b3c0ff8e021f86dd127c06c94faf8`.

## Owner disposition and unresolved limit

On 2026-08-21, the owner instructed that this PR be merged and cleaned up after the author proof and CI passed. That authorizes merge before the non-author rerun; it does not call the slice green.

The repository-required non-author rerun remains pending. Issue #19 stays open until that rerun is recorded and disposed.

Refs #19