### PR TITLE
Seal the world package evidence boundary

### DIFF
--- a/KERNEL.md
+++ b/KERNEL.md
@@ -1,10 +1,10 @@
 ---
 title: The executable semantic kernel
-status: In progress through SW-C
+status: In progress through SW-E
 gate: K
-contract_revision: 4
-supersedes_contract_revision: 3
-decision_record: docs/decisions/0004-world-ir-construction-lineage.md
+contract_revision: 5
+supersedes_contract_revision: 4
+decision_record: docs/decisions/0006-package-evidence-boundary.md
 ---
 
 # The executable semantic kernel
@@ -253,11 +253,30 @@ build/gaol.world/
   persistence.json
   diagnostics.json
   schemas.json
-  receipts/
+  compiler-receipts.json
 ```
 
 A deterministic archive format may come later. Gate K deliberately favors
 `ls`, `cat`, and `diff`.
+
+Every package entry is a regular file at the package root. `manifest.json`
+declares and hashes every other entry, including `compiler-receipts.json`.
+Compiler, linker, validation, and invariant receipts that describe the build
+live in that canonical member. Runtime causal receipts live only in the
+separate run output below. No unmanifested file or directory is permitted
+inside a verified package.
+
+The writer validates all inputs, writes and verifies a complete package in a
+fresh sibling staging directory on the same filesystem, then publishes it with
+one rename. Failure removes the staging directory and leaves the requested
+destination absent; an existing destination is never replaced or merged into.
+This atomic-publication claim is limited to the supported local-filesystem,
+single-publisher boundary.
+
+On open, manifest objects have exact schema-declared fields, member rows are
+unique and strictly ordered, and every declared member is revalidated as
+canonical bytes with the recorded size and digest. Symlinks, special files,
+undeclared files, and directories are refused.
 
 Runtime execution writes a separate run directory:
 

--- a/KERNEL.md
+++ b/KERNEL.md
@@ -278,6 +278,12 @@ unique and strictly ordered, and every declared member is revalidated as
 canonical bytes with the recorded size and digest. Symlinks, special files,
 undeclared files, and directories are refused.
 
+Verification requires a caller-owned, quiescent package tree on the supported
+local filesystem: no external process may replace entries while `open` runs.
+This path-based integrity check is not a race-safe hostile-filesystem sandbox or
+an authenticity mechanism. Existing symlinks are refused without following
+their final component, including root paths spelled with trailing separators.
+
 Runtime execution writes a separate run directory:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ it.
    semantics, causal ordering, and immutable runtime preparation.
 14. [docs/movement.md](docs/movement.md) — compiled claim composition,
    shared simulation/navigation movement semantics, and SW-E evidence.
-15. [docs/review/2026-08-21-founding-review.md](docs/review/2026-08-21-founding-review.md)
+15. [docs/packages.md](docs/packages.md) — atomic package publication, exact
+   manifest/member verification, and the revision-5 evidence boundary.
+16. [docs/review/2026-08-21-founding-review.md](docs/review/2026-08-21-founding-review.md)
    — the condensed primary record of the founding adversarial review, written
    in the originating session, with its provenance limits stated.
-16. [docs/review/2026-08-21-founding-review-synthesis.md](docs/review/2026-08-21-founding-review-synthesis.md)
+17. [docs/review/2026-08-21-founding-review-synthesis.md](docs/review/2026-08-21-founding-review-synthesis.md)
     — the contract-revision-2 edited synthesis of that review.
 
 ## Layout

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ test that thesis before any renderer is built.
   construction IR, compiled transitions, shared simulation/navigation ground
   movement projection, and immutable transaction preparation with effective
   before/after movement facts; no command surface or committed runtime snapshots
-- **Contract revision:** 4, owner-authorized in decision 0004
+- **Contract revision:** 5, owner-authorized in decision 0006
 - **Scope:** greenfield / vacuum architecture exercise
 - **Effect on other projects:** none unless separately adopted by an explicit
   decision in that project's own authority records
@@ -33,35 +33,38 @@ it.
    disagreements, and adoption criteria.
 2. [KERNEL.md](KERNEL.md) — the revisioned acceptance contract for Gate K, the
    renderer-free executable semantic kernel.
-3. [docs/decisions/0003-contract-profile-closure.md](docs/decisions/0003-contract-profile-closure.md)
+3. [docs/decisions/0006-package-evidence-boundary.md](docs/decisions/0006-package-evidence-boundary.md)
+   — the owner-authorized revision-4 to revision-5 repair sealing package
+   receipts, publication, exact manifest decoding, and filesystem entry types.
+4. [docs/decisions/0003-contract-profile-closure.md](docs/decisions/0003-contract-profile-closure.md)
    — the owner-authorized revision-2 to revision-3 closure of the canonical
    profile and workspace-evidence contract gaps.
-4. [docs/decisions/0004-world-ir-construction-lineage.md](docs/decisions/0004-world-ir-construction-lineage.md)
+5. [docs/decisions/0004-world-ir-construction-lineage.md](docs/decisions/0004-world-ir-construction-lineage.md)
    — the owner-authorized revision-3 to revision-4 repair separating incomplete
    construction snapshots from the stable World IR migration line.
-5. [docs/decisions/0005-gate-k-dependency-policy.md](docs/decisions/0005-gate-k-dependency-policy.md)
+6. [docs/decisions/0005-gate-k-dependency-policy.md](docs/decisions/0005-gate-k-dependency-policy.md)
    — the owner-authorized temporary zero-third-party-dependency policy for Gate
    K; it does not amend contract revision 4 or bind later gates.
-6. [docs/decisions/0001-contract-repair.md](docs/decisions/0001-contract-repair.md)
+7. [docs/decisions/0001-contract-repair.md](docs/decisions/0001-contract-repair.md)
    — the owner-authorized revision-1 to revision-2 contract repair.
-7. [docs/evaluation/COLD_AGENT_PROTOCOL.md](docs/evaluation/COLD_AGENT_PROTOCOL.md)
+8. [docs/evaluation/COLD_AGENT_PROTOCOL.md](docs/evaluation/COLD_AGENT_PROTOCOL.md)
    — the reproducible cold-author, cold-debug, and cold-review procedure.
-8. [docs/evaluation/GATE_K_COLD_AGENT_PLAN.md](docs/evaluation/GATE_K_COLD_AGENT_PLAN.md)
+9. [docs/evaluation/GATE_K_COLD_AGENT_PLAN.md](docs/evaluation/GATE_K_COLD_AGENT_PLAN.md)
    — the owner-authorized whole-kernel subject roster and eligibility checks.
-9. [docs/workspace.md](docs/workspace.md) — the crate map, how to run the
+10. [docs/workspace.md](docs/workspace.md) — the crate map, how to run the
    proof, and the decisions the first implementation slice had to make.
-10. [docs/authoring.md](docs/authoring.md) — source schema version 1 and the
+11. [docs/authoring.md](docs/authoring.md) — source schema version 1 and the
    approved Gate K authoring vocabulary.
-11. [docs/compiler.md](docs/compiler.md) — parser/linker stages, schema
+12. [docs/compiler.md](docs/compiler.md) — parser/linker stages, schema
    ownership, proof coverage, and limits.
-12. [docs/transitions.md](docs/transitions.md) — compiled command/event
+13. [docs/transitions.md](docs/transitions.md) — compiled command/event
    semantics, causal ordering, and immutable runtime preparation.
-13. [docs/movement.md](docs/movement.md) — compiled claim composition,
+14. [docs/movement.md](docs/movement.md) — compiled claim composition,
    shared simulation/navigation movement semantics, and SW-E evidence.
-14. [docs/review/2026-08-21-founding-review.md](docs/review/2026-08-21-founding-review.md)
+15. [docs/review/2026-08-21-founding-review.md](docs/review/2026-08-21-founding-review.md)
    — the condensed primary record of the founding adversarial review, written
    in the originating session, with its provenance limits stated.
-15. [docs/review/2026-08-21-founding-review-synthesis.md](docs/review/2026-08-21-founding-review-synthesis.md)
+16. [docs/review/2026-08-21-founding-review-synthesis.md](docs/review/2026-08-21-founding-review-synthesis.md)
     — the contract-revision-2 edited synthesis of that review.
 
 ## Layout

--- a/THESIS.md
+++ b/THESIS.md
@@ -10,8 +10,8 @@ applies_to_the_mortal_estate: No, unless separately adopted by an explicit proje
 authors: Claude Fable 5 and GPT-5.6 Pro, in adversarial review, with Peter Permenter as owner and referee
 date: 2026-08-21
 revision: 2
-contract_revision: 4
-decision_record: docs/decisions/0004-world-ir-construction-lineage.md
+contract_revision: 5
+decision_record: docs/decisions/0006-package-evidence-boundary.md
 ---
 
 # The Signed World
@@ -42,6 +42,8 @@ records the owner-authorized revision 3 closure of the canonical-profile and
 workspace-evidence gaps found by SW-B.
 [docs/decisions/0004-world-ir-construction-lineage.md](docs/decisions/0004-world-ir-construction-lineage.md)
 records the owner-authorized revision 4 construction-lineage repair.
+[docs/decisions/0006-package-evidence-boundary.md](docs/decisions/0006-package-evidence-boundary.md)
+records the owner-authorized revision 5 package-evidence repair.
 
 Contract changes follow `AGENTS.md`. Contradictions and falsified assumptions may
 be repaired explicitly; criteria may not be silently weakened because code
@@ -695,10 +697,10 @@ garbage remains garbage with excellent paperwork.
 
 ### Immutable package, separate state
 
-Commands never edit the package. Runtime snapshots, command logs, causal
-receipts, saves, and replays are separate versioned artifacts. Migration creates
-a new package. This keeps the signed input available as evidence and makes
-reproduction possible.
+Commands never edit the package. Compiler/build receipts are canonical hashed
+package members; runtime snapshots, command logs, causal receipts, saves, and
+replays are separate versioned artifacts. Migration creates a new package. This
+keeps the signed input available as evidence and makes reproduction possible.
 
 ### Development and release binaries
 

--- a/crates/estate-core/src/diagnostic.rs
+++ b/crates/estate-core/src/diagnostic.rs
@@ -412,6 +412,10 @@ pub mod codes {
     pub const PACKAGE_IO: DiagnosticCode = DiagnosticCode::new("EK0407");
     /// A package writer received the same member name more than once.
     pub const PACKAGE_MEMBER_DUPLICATE: DiagnosticCode = DiagnosticCode::new("EK0408");
+    /// A package root, manifest, or member has a forbidden filesystem entry type.
+    pub const PACKAGE_ENTRY_TYPE_INVALID: DiagnosticCode = DiagnosticCode::new("EK0409");
+    /// A manifest-declared member is not canonical semantic bytes.
+    pub const PACKAGE_MEMBER_NON_CANONICAL: DiagnosticCode = DiagnosticCode::new("EK0410");
 
     /// A transition refers to a source machine namespace that does not exist.
     pub const TRANSITION_SOURCE_NAMESPACE_MISSING: DiagnosticCode = DiagnosticCode::new("EK0701");
@@ -488,6 +492,8 @@ pub mod codes {
         PACKAGE_MEMBER_NAME_INVALID,
         PACKAGE_IO,
         PACKAGE_MEMBER_DUPLICATE,
+        PACKAGE_ENTRY_TYPE_INVALID,
+        PACKAGE_MEMBER_NON_CANONICAL,
         TRANSITION_SOURCE_NAMESPACE_MISSING,
         INTERACTION_TARGET_NAMESPACE_MISSING,
         TRANSITION_STATE_MISSING,

--- a/crates/estate-core/src/package.rs
+++ b/crates/estate-core/src/package.rs
@@ -12,7 +12,7 @@
 //!   persistence.json
 //!   diagnostics.json
 //!   schemas.json
-//!   receipts/
+//!   compiler-receipts.json
 //! ```
 //!
 //! # Why this lives in `estate-core`
@@ -37,17 +37,23 @@
 //! - **Immutability (acceptance 12).** [`WorldPackage::write`] refuses to write
 //!   into a path that already exists, of any kind. Nothing here can overwrite,
 //!   merge into, or append to an existing package.
+//! - **Atomic publication.** A complete sibling staging directory is verified
+//!   before one same-filesystem rename publishes it. Failed writes remove their
+//!   staging path and leave the requested destination absent.
 //! - **Canonical members.** Every member is checked against the canonical byte
 //!   profile before the directory is created, so a package cannot hold a member
 //!   that would hash differently after a round trip.
 //! - **Verified reads.** [`WorldPackage::open`] recomputes the manifest digest
-//!   and every member's size and hash, and refuses any file in the package root
-//!   that the manifest does not declare.
+//!   and every member's size and hash, revalidates canonical bytes, and refuses
+//!   unknown fields, non-regular entries, or anything the manifest does not
+//!   declare.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
+use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::canonical::read::parse_canonical;
 use crate::canonical::{CanonicalValue, FieldName};
@@ -58,8 +64,10 @@ use crate::id::SchemaId;
 /// The manifest file name.
 pub const MANIFEST_FILE: &str = "manifest.json";
 
-/// The receipts subdirectory required by section 5.
-pub const RECEIPTS_DIR: &str = "receipts";
+/// The canonical, manifest-hashed compiler/build receipt member from section 5.
+pub const COMPILER_RECEIPTS_FILE: &str = "compiler-receipts.json";
+
+static STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// The name and version of the manifest schema itself.
 ///
@@ -84,7 +92,7 @@ impl MemberName {
     /// # Errors
     ///
     /// Returns `EK0406` when the name is not `[a-z0-9]([a-z0-9-]*[a-z0-9])?.json`,
-    /// or when it collides with the manifest or receipts entries.
+    /// or when it collides with the manifest entry.
     pub fn new(name: &str) -> Result<Self, Diagnostic> {
         let reject = |reason: &str| {
             Err(Diagnostic::new(
@@ -227,9 +235,10 @@ pub struct WorldPackage {
 impl WorldPackage {
     /// Writes a new package directory.
     ///
-    /// Members are validated as canonical bytes first, then the directory is
-    /// created. `receipts/` is created empty; its contents belong to the
-    /// runtime slice that produces receipts.
+    /// Members are validated as canonical bytes before filesystem mutation. A
+    /// complete sibling staging directory is written and verified before one
+    /// same-filesystem rename publishes it. The supported atomicity boundary is
+    /// a local filesystem with one publisher for the requested destination.
     ///
     /// # Errors
     ///
@@ -242,18 +251,15 @@ impl WorldPackage {
         root: &Path,
         members: impl IntoIterator<Item = (MemberName, Vec<u8>)>,
     ) -> Result<Self, Diagnostic> {
-        if root.exists() {
-            return Err(Diagnostic::new(
-                codes::PACKAGE_OUTPUT_EXISTS,
-                format!(
-                    "`{}` already exists; compiled packages are immutable evidence \
-                     and are never written over",
-                    root.display()
-                ),
-            )
-            .with_repair(RepairClass::WriteToNewOutputPath));
-        }
+        Self::write_internal(root, members, None)
+    }
 
+    fn write_internal(
+        root: &Path,
+        members: impl IntoIterator<Item = (MemberName, Vec<u8>)>,
+        fail_after_member_writes: Option<usize>,
+    ) -> Result<Self, Diagnostic> {
+        require_absent_destination(root)?;
         let mut unique_members = BTreeMap::new();
         for (name, bytes) in members {
             if unique_members.insert(name.clone(), bytes).is_some() {
@@ -291,22 +297,46 @@ impl WorldPackage {
             digest,
         };
 
-        fs::create_dir_all(root).map_err(|error| io_failure(root, &error))?;
-        fs::create_dir(root.join(RECEIPTS_DIR))
-            .map_err(|error| io_failure(&root.join(RECEIPTS_DIR), &error))?;
-        for (name, bytes) in &members {
-            let path = root.join(name.as_str());
-            fs::write(&path, bytes).map_err(|error| io_failure(&path, &error))?;
-        }
-        let manifest_path = root.join(MANIFEST_FILE);
-        fs::write(&manifest_path, manifest.to_canonical().to_canonical_bytes())
-            .map_err(|error| io_failure(&manifest_path, &error))?;
+        let parent = package_parent(root);
+        fs::create_dir_all(parent).map_err(|error| io_failure(parent, &error))?;
+        let staging = create_staging_directory(root)?;
+        let staged_result = (|| {
+            for (written, (name, bytes)) in members.iter().enumerate() {
+                if fail_after_member_writes == Some(written) {
+                    return Err(io_failure(
+                        &staging.join(name.as_str()),
+                        &io::Error::other("injected package-write failure"),
+                    ));
+                }
+                let path = staging.join(name.as_str());
+                fs::write(&path, bytes).map_err(|error| io_failure(&path, &error))?;
+            }
+            let manifest_path = staging.join(MANIFEST_FILE);
+            fs::write(&manifest_path, manifest.to_canonical().to_canonical_bytes())
+                .map_err(|error| io_failure(&manifest_path, &error))?;
 
-        Ok(Self {
-            root: root.to_path_buf(),
-            manifest,
-            members,
-        })
+            let mut verified = Self::open(&staging)?;
+            require_absent_destination(root)?;
+            fs::rename(&staging, root).map_err(|error| publication_failure(root, &error))?;
+            verified.root = root.to_path_buf();
+            Ok(verified)
+        })();
+
+        match staged_result {
+            Ok(package) => Ok(package),
+            Err(diagnostic) => {
+                cleanup_staging(&staging).map_err(|cleanup| {
+                    Diagnostic::new(
+                        codes::PACKAGE_IO,
+                        format!(
+                            "package write failed ({diagnostic}); staging cleanup also failed: {}",
+                            cleanup.message()
+                        ),
+                    )
+                })?;
+                Err(diagnostic)
+            }
+        }
     }
 
     /// Opens a package, verifying the manifest digest and every member.
@@ -320,8 +350,13 @@ impl WorldPackage {
     /// - `EK0404` when the package root holds a file the manifest does not
     ///   declare.
     /// - `EK0407` when the filesystem refuses the read.
+    /// - `EK0409` when the root, manifest, or a member is not the required
+    ///   directory/regular-file entry type.
+    /// - `EK0410` when a hash-valid member is not canonical semantic bytes.
     pub fn open(root: &Path) -> Result<Self, Diagnostic> {
+        require_package_root(root)?;
         let manifest_path = root.join(MANIFEST_FILE);
+        require_manifest_file(&manifest_path)?;
         let manifest_bytes =
             fs::read(&manifest_path).map_err(|error| io_failure(&manifest_path, &error))?;
         let manifest = decode_manifest(&manifest_bytes)?;
@@ -336,11 +371,26 @@ impl WorldPackage {
         for entry in entries {
             let entry = entry.map_err(|error| io_failure(root, &error))?;
             let file_name = entry.file_name();
-            let name = file_name.to_string_lossy();
-            if name == MANIFEST_FILE || name == RECEIPTS_DIR {
+            let Some(name) = file_name.to_str() else {
+                return Err(Diagnostic::new(
+                    codes::PACKAGE_MEMBER_UNDECLARED,
+                    "package entry name is not valid UTF-8",
+                )
+                .with_repair(RepairClass::RemoveUndeclaredMember));
+            };
+            let file_type = entry
+                .file_type()
+                .map_err(|error| io_failure(&entry.path(), &error))?;
+            if !file_type.is_file() {
+                return Err(entry_type_invalid(
+                    &entry.path(),
+                    "package entries must be regular files",
+                ));
+            }
+            if name == MANIFEST_FILE {
                 continue;
             }
-            let declared_here = MemberName::new(&name)
+            let declared_here = MemberName::new(name)
                 .ok()
                 .is_some_and(|member| declared.contains_key(&member));
             if !declared_here {
@@ -355,15 +405,20 @@ impl WorldPackage {
         let mut members = BTreeMap::new();
         for record in &manifest.members {
             let path = root.join(record.name.as_str());
-            let bytes = fs::read(&path).map_err(|_| {
-                Diagnostic::new(
-                    codes::PACKAGE_MEMBER_MISSING,
-                    format!(
-                        "member `{}` is declared by the manifest but could not be read",
-                        record.name
-                    ),
-                )
-                .with_repair(RepairClass::RebuildFromSource)
+            require_member_file(&path, &record.name)?;
+            let bytes = fs::read(&path).map_err(|error| {
+                if error.kind() == ErrorKind::NotFound {
+                    Diagnostic::new(
+                        codes::PACKAGE_MEMBER_MISSING,
+                        format!(
+                            "member `{}` is declared by the manifest but could not be read",
+                            record.name
+                        ),
+                    )
+                    .with_repair(RepairClass::RebuildFromSource)
+                } else {
+                    io_failure(&path, &error)
+                }
             })?;
             if bytes.len() as u64 != record.size || Sha256Digest::of_bytes(&bytes) != record.digest
             {
@@ -381,6 +436,17 @@ impl WorldPackage {
                 .with_repair(RepairClass::RebuildFromSource),
                 );
             }
+            parse_canonical(&bytes).map_err(|diagnostic| {
+                Diagnostic::new(
+                    codes::PACKAGE_MEMBER_NON_CANONICAL,
+                    format!(
+                        "member `{}` is hash-valid but not canonical: {}",
+                        record.name,
+                        diagnostic.message()
+                    ),
+                )
+                .with_repair(RepairClass::RebuildFromSource)
+            })?;
             members.insert(record.name.clone(), bytes);
         }
 
@@ -426,6 +492,139 @@ impl WorldPackage {
     }
 }
 
+fn require_absent_destination(root: &Path) -> Result<(), Diagnostic> {
+    match fs::symlink_metadata(root) {
+        Ok(_) => Err(Diagnostic::new(
+            codes::PACKAGE_OUTPUT_EXISTS,
+            format!(
+                "`{}` already exists; compiled packages are immutable evidence and are never written over",
+                root.display()
+            ),
+        )
+        .with_repair(RepairClass::WriteToNewOutputPath)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_failure(root, &error)),
+    }
+}
+
+fn package_parent(root: &Path) -> &Path {
+    root.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn create_staging_directory(root: &Path) -> Result<PathBuf, Diagnostic> {
+    let Some(file_name) = root.file_name() else {
+        return Err(Diagnostic::new(
+            codes::PACKAGE_IO,
+            format!("`{}` has no package directory name", root.display()),
+        ));
+    };
+    let parent = package_parent(root);
+    for _ in 0..64 {
+        let counter = STAGING_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let name = format!(
+            ".{}.staging-{}-{counter}",
+            file_name.to_string_lossy(),
+            std::process::id()
+        );
+        let staging = parent.join(name);
+        match fs::create_dir(&staging) {
+            Ok(()) => return Ok(staging),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(io_failure(&staging, &error)),
+        }
+    }
+    Err(Diagnostic::new(
+        codes::PACKAGE_IO,
+        format!(
+            "could not allocate a fresh sibling staging directory for `{}`",
+            root.display()
+        ),
+    ))
+}
+
+fn cleanup_staging(staging: &Path) -> Result<(), Diagnostic> {
+    match fs::remove_dir_all(staging) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_failure(staging, &error)),
+    }
+}
+
+fn publication_failure(root: &Path, error: &io::Error) -> Diagnostic {
+    match fs::symlink_metadata(root) {
+        Ok(_) => Diagnostic::new(
+            codes::PACKAGE_OUTPUT_EXISTS,
+            format!(
+                "`{}` appeared before package publication and was left untouched",
+                root.display()
+            ),
+        )
+        .with_repair(RepairClass::WriteToNewOutputPath),
+        Err(_) => io_failure(root, error),
+    }
+}
+
+fn require_package_root(root: &Path) -> Result<(), Diagnostic> {
+    let metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return Err(manifest_invalid("package root is missing"));
+        }
+        Err(error) => return Err(io_failure(root, &error)),
+    };
+    if metadata.file_type().is_dir() {
+        Ok(())
+    } else {
+        Err(entry_type_invalid(
+            root,
+            "a world package root must be a directory and not a symlink",
+        ))
+    }
+}
+
+fn require_manifest_file(path: &Path) -> Result<(), Diagnostic> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(_) => Err(entry_type_invalid(
+            path,
+            "the package manifest must be a regular file",
+        )),
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            Err(manifest_invalid("package manifest is missing"))
+        }
+        Err(error) => Err(io_failure(path, &error)),
+    }
+}
+
+fn require_member_file(path: &Path, name: &MemberName) -> Result<(), Diagnostic> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(_) => Err(entry_type_invalid(
+            path,
+            "manifest-declared members must be regular files",
+        )),
+        Err(error) if error.kind() == ErrorKind::NotFound => Err(Diagnostic::new(
+            codes::PACKAGE_MEMBER_MISSING,
+            format!("member `{name}` is declared by the manifest but is missing"),
+        )
+        .with_repair(RepairClass::RebuildFromSource)),
+        Err(error) => Err(io_failure(path, &error)),
+    }
+}
+
+fn entry_type_invalid(path: &Path, reason: &str) -> Diagnostic {
+    Diagnostic::new(
+        codes::PACKAGE_ENTRY_TYPE_INVALID,
+        format!(
+            "`{}` has an invalid package entry type: {reason}",
+            path.display()
+        ),
+    )
+    .with_repair(RepairClass::RebuildFromSource)
+}
+
 fn io_failure(path: &Path, error: &std::io::Error) -> Diagnostic {
     Diagnostic::new(codes::PACKAGE_IO, format!("`{}`: {error}", path.display()))
 }
@@ -455,11 +654,13 @@ fn decode_manifest(bytes: &[u8]) -> Result<PackageManifest, Diagnostic> {
     let CanonicalValue::Object(fields) = &value else {
         return Err(manifest_invalid("manifest is not an object"));
     };
+    require_exact_fields(fields, &["members", "package_digest", "schema"], "manifest")?;
     let field = |name: &'static str| fields.get(&FieldName::declared(name));
 
     let Some(CanonicalValue::Object(schema_fields)) = field("schema") else {
         return Err(manifest_invalid("manifest has no `schema` object"));
     };
+    require_exact_fields(schema_fields, &["name", "version"], "manifest schema")?;
     let (Some(CanonicalValue::Text(schema_name)), Some(schema_version)) = (
         schema_fields.get(&FieldName::declared("name")),
         schema_fields
@@ -486,6 +687,7 @@ fn decode_manifest(bytes: &[u8]) -> Result<PackageManifest, Diagnostic> {
     };
     let mut members = Vec::with_capacity(rows.len());
     let mut names = BTreeSet::new();
+    let mut previous: Option<MemberName> = None;
     for row in rows {
         let member = decode_member(row)?;
         if !names.insert(member.name.clone()) {
@@ -494,6 +696,18 @@ fn decode_manifest(bytes: &[u8]) -> Result<PackageManifest, Diagnostic> {
                 member.name
             )));
         }
+        if let Some(prior) = &previous {
+            match member.name.cmp(prior) {
+                std::cmp::Ordering::Less => {
+                    return Err(manifest_invalid(format!(
+                        "manifest member `{}` is out of canonical member-name order",
+                        member.name
+                    )));
+                }
+                std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => {}
+            }
+        }
+        previous = Some(member.name.clone());
         members.push(member);
     }
 
@@ -521,6 +735,7 @@ fn decode_member(row: &CanonicalValue) -> Result<MemberRecord, Diagnostic> {
     let CanonicalValue::Object(fields) = row else {
         return Err(manifest_invalid("a manifest member row is not an object"));
     };
+    require_exact_fields(fields, &["name", "sha256", "size"], "manifest member row")?;
     let (Some(CanonicalValue::Text(name)), Some(CanonicalValue::Text(digest)), Some(size)) = (
         fields.get(&FieldName::declared("name")),
         fields.get(&FieldName::declared("sha256")),
@@ -537,4 +752,68 @@ fn decode_member(row: &CanonicalValue) -> Result<MemberRecord, Diagnostic> {
         size,
         digest,
     })
+}
+
+fn require_exact_fields(
+    fields: &BTreeMap<FieldName, CanonicalValue>,
+    expected: &[&str],
+    context: &str,
+) -> Result<(), Diagnostic> {
+    let exact = fields.len() == expected.len()
+        && expected
+            .iter()
+            .all(|name| fields.keys().any(|field| field.as_str() == *name));
+    if exact {
+        return Ok(());
+    }
+    let actual = fields
+        .keys()
+        .map(FieldName::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(manifest_invalid(format!(
+        "{context} fields must be exactly [{}]; found [{actual}]",
+        expected.join(", ")
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MemberName, WorldPackage};
+    use crate::CanonicalValue;
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn an_injected_mid_write_failure_cleans_staging_and_never_publishes() {
+        let parent = PathBuf::from(option_env!("CARGO_TARGET_TMPDIR").unwrap_or("target/tmp"))
+            .join("package-faults")
+            .join(std::process::id().to_string());
+        fs::create_dir_all(&parent).unwrap();
+        let root = parent.join("injected.world");
+        let members = ["alpha.json", "beta.json"].map(|name| {
+            (
+                MemberName::new(name).unwrap(),
+                CanonicalValue::object_declared([("value", CanonicalValue::Uint(1))])
+                    .to_canonical_bytes(),
+            )
+        });
+
+        let rejected = WorldPackage::write_internal(&root, members, Some(1)).unwrap_err();
+        assert_eq!(rejected.code().as_str(), "EK0407");
+        assert!(
+            !root.exists(),
+            "a partial destination must never be visible"
+        );
+        assert!(
+            fs::read_dir(&parent).unwrap().all(|entry| {
+                !entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .contains(".staging-")
+            }),
+            "a failed publication must remove its sibling staging directory"
+        );
+    }
 }

--- a/crates/estate-core/src/package.rs
+++ b/crates/estate-core/src/package.rs
@@ -46,7 +46,8 @@
 //! - **Verified reads.** [`WorldPackage::open`] recomputes the manifest digest
 //!   and every member's size and hash, revalidates canonical bytes, and refuses
 //!   unknown fields, non-regular entries, or anything the manifest does not
-//!   declare.
+//!   declare. The caller owns a quiescent package tree while verification runs;
+//!   this path-based reader is not a hostile-filesystem sandbox.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -259,6 +260,8 @@ impl WorldPackage {
         members: impl IntoIterator<Item = (MemberName, Vec<u8>)>,
         fail_after_member_writes: Option<usize>,
     ) -> Result<Self, Diagnostic> {
+        let normalized_root = lexical_path(root);
+        let root = normalized_root.as_path();
         require_absent_destination(root)?;
         let mut unique_members = BTreeMap::new();
         for (name, bytes) in members {
@@ -353,7 +356,13 @@ impl WorldPackage {
     /// - `EK0409` when the root, manifest, or a member is not the required
     ///   directory/regular-file entry type.
     /// - `EK0410` when a hash-valid member is not canonical semantic bytes.
+    ///
+    /// The caller must prevent concurrent external mutation of the package tree
+    /// during verification. Existing symlinks are rejected, but this API is not
+    /// a race-safe hostile-filesystem sandbox.
     pub fn open(root: &Path) -> Result<Self, Diagnostic> {
+        let root = lexical_path(root);
+        let root = root.as_path();
         require_package_root(root)?;
         let manifest_path = root.join(MANIFEST_FILE);
         require_manifest_file(&manifest_path)?;
@@ -505,6 +514,10 @@ fn require_absent_destination(root: &Path) -> Result<(), Diagnostic> {
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
         Err(error) => Err(io_failure(root, &error)),
     }
+}
+
+fn lexical_path(path: &Path) -> PathBuf {
+    path.components().collect()
 }
 
 fn package_parent(root: &Path) -> &Path {

--- a/crates/estate-core/tests/package.rs
+++ b/crates/estate-core/tests/package.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use estate_core::canonical::read::parse_canonical;
-use estate_core::package::{MANIFEST_FILE, MemberName, RECEIPTS_DIR, WorldPackage};
+use estate_core::package::{COMPILER_RECEIPTS_FILE, MANIFEST_FILE, MemberName, WorldPackage};
 use estate_core::{CanonicalValue, FieldName, Sha256Digest};
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -30,6 +30,11 @@ fn member(name: &str) -> MemberName {
 fn simple_members() -> Vec<(MemberName, Vec<u8>)> {
     vec![
         (
+            member(COMPILER_RECEIPTS_FILE),
+            CanonicalValue::object_declared([("receipts", CanonicalValue::Array(vec![]))])
+                .to_canonical_bytes(),
+        ),
+        (
             member("world-ir.json"),
             CanonicalValue::object_declared([("tick", CanonicalValue::Uint(0))])
                 .to_canonical_bytes(),
@@ -48,8 +53,14 @@ fn a_written_package_is_inspectable_with_ordinary_file_tools() {
     let package = WorldPackage::write(&path, simple_members()).unwrap();
 
     assert!(path.join(MANIFEST_FILE).is_file());
-    assert!(path.join(RECEIPTS_DIR).is_dir());
+    assert!(path.join(COMPILER_RECEIPTS_FILE).is_file());
     assert!(path.join("world-ir.json").is_file());
+    assert!(
+        fs::read_dir(&path)
+            .unwrap()
+            .all(|entry| entry.unwrap().file_type().unwrap().is_file()),
+        "a verified package has no unmanifested subtree"
+    );
 
     // Members are ordered by member name in the manifest, not by write order.
     let names: Vec<String> = package
@@ -58,7 +69,10 @@ fn a_written_package_is_inspectable_with_ordinary_file_tools() {
         .iter()
         .map(|record| record.name().to_string())
         .collect();
-    assert_eq!(names, vec!["simulation.json", "world-ir.json"]);
+    assert_eq!(
+        names,
+        vec!["compiler-receipts.json", "simulation.json", "world-ir.json"]
+    );
 
     // The manifest itself is canonical, so `sha256sum` on a member file
     // reproduces the recorded digest byte for byte.
@@ -76,6 +90,23 @@ fn a_written_package_is_inspectable_with_ordinary_file_tools() {
             .unwrap()
             .to_canonical_bytes(),
         CanonicalValue::object_declared([("tick", CanonicalValue::Uint(0))]).to_canonical_bytes()
+    );
+}
+
+#[test]
+fn package_bytes_and_digest_ignore_input_insertion_order() {
+    let forward_path = fresh_path("forward-order");
+    let reverse_path = fresh_path("reverse-order");
+    let forward_members = simple_members();
+    let mut reverse_members = forward_members.clone();
+    reverse_members.reverse();
+
+    let forward = WorldPackage::write(&forward_path, forward_members).unwrap();
+    let reverse = WorldPackage::write(&reverse_path, reverse_members).unwrap();
+    assert_eq!(forward.manifest(), reverse.manifest());
+    assert_eq!(
+        fs::read(forward_path.join(MANIFEST_FILE)).unwrap(),
+        fs::read(reverse_path.join(MANIFEST_FILE)).unwrap()
     );
 }
 
@@ -242,6 +273,161 @@ fn duplicate_manifest_rows_fail_even_with_a_recomputed_digest() {
 }
 
 #[test]
+fn manifest_rows_must_be_in_canonical_member_name_order() {
+    let path = fresh_path("unsorted-manifest");
+    WorldPackage::write(&path, simple_members()).unwrap();
+    rewrite_manifest(&path, |fields| {
+        let CanonicalValue::Array(rows) = fields
+            .get_mut(&FieldName::declared("members"))
+            .expect("writer emits member rows")
+        else {
+            panic!("manifest members are an array")
+        };
+        rows.swap(0, 1);
+    });
+
+    let rejected = WorldPackage::open(&path).unwrap_err();
+    assert_eq!(rejected.code().as_str(), "EK0405");
+    assert!(rejected.message().contains("canonical member-name order"));
+}
+
+#[test]
+fn manifest_schema_and_member_rows_reject_canonical_unknown_fields() {
+    for (label, mutate) in [
+        (
+            "manifest-unknown",
+            add_manifest_unknown as fn(&mut std::collections::BTreeMap<FieldName, CanonicalValue>),
+        ),
+        ("schema-unknown", add_schema_unknown),
+        ("row-unknown", add_row_unknown),
+    ] {
+        let path = fresh_path(label);
+        WorldPackage::write(&path, simple_members()).unwrap();
+        rewrite_manifest(&path, mutate);
+        let rejected = WorldPackage::open(&path).unwrap_err();
+        assert_eq!(rejected.code().as_str(), "EK0405");
+        assert!(rejected.message().contains("fields must be exactly"));
+    }
+}
+
+#[test]
+fn hash_valid_but_noncanonical_member_bytes_are_rejected() {
+    let path = fresh_path("noncanonical-open");
+    WorldPackage::write(&path, simple_members()).unwrap();
+    let bytes = br#"{ "tick": 0 }"#.to_vec();
+    fs::write(path.join("world-ir.json"), &bytes).unwrap();
+    rewrite_manifest(&path, |fields| {
+        let CanonicalValue::Array(rows) = fields
+            .get_mut(&FieldName::declared("members"))
+            .expect("writer emits member rows")
+        else {
+            panic!("manifest members are an array")
+        };
+        let CanonicalValue::Object(row) = rows
+            .iter_mut()
+            .find(|row| {
+                matches!(
+                    row,
+                    CanonicalValue::Object(fields)
+                        if fields.get(&FieldName::declared("name"))
+                            == Some(&CanonicalValue::text("world-ir.json"))
+                )
+            })
+            .expect("world IR row exists")
+        else {
+            panic!("member row is an object")
+        };
+        row.insert(
+            FieldName::declared("sha256"),
+            CanonicalValue::text(Sha256Digest::of_bytes(&bytes).to_hex()),
+        );
+        row.insert(
+            FieldName::declared("size"),
+            CanonicalValue::Uint(bytes.len() as u64),
+        );
+    });
+
+    let rejected = WorldPackage::open(&path).unwrap_err();
+    assert_eq!(rejected.code().as_str(), "EK0410");
+    assert!(rejected.message().contains("world-ir.json"));
+}
+
+#[test]
+fn directories_are_never_package_members_or_unmanifested_subtrees() {
+    let declared = fresh_path("declared-directory");
+    WorldPackage::write(&declared, simple_members()).unwrap();
+    fs::remove_file(declared.join("world-ir.json")).unwrap();
+    fs::create_dir(declared.join("world-ir.json")).unwrap();
+    assert_eq!(
+        WorldPackage::open(&declared).unwrap_err().code().as_str(),
+        "EK0409"
+    );
+
+    let undeclared = fresh_path("undeclared-directory");
+    WorldPackage::write(&undeclared, simple_members()).unwrap();
+    fs::create_dir(undeclared.join("receipts")).unwrap();
+    assert_eq!(
+        WorldPackage::open(&undeclared).unwrap_err().code().as_str(),
+        "EK0409"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_roots_manifests_and_members_are_rejected_without_following() {
+    use std::os::unix::fs::symlink;
+
+    let real = fresh_path("real-package");
+    WorldPackage::write(&real, simple_members()).unwrap();
+    let linked_root = fresh_path("linked-root");
+    symlink(&real, &linked_root).unwrap();
+    assert_eq!(
+        WorldPackage::open(&linked_root)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0409"
+    );
+
+    let linked_manifest = fresh_path("linked-manifest");
+    WorldPackage::write(&linked_manifest, simple_members()).unwrap();
+    let outside_manifest = fresh_path("outside-manifest");
+    fs::rename(linked_manifest.join(MANIFEST_FILE), &outside_manifest).unwrap();
+    symlink(&outside_manifest, linked_manifest.join(MANIFEST_FILE)).unwrap();
+    assert_eq!(
+        WorldPackage::open(&linked_manifest)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0409"
+    );
+
+    let linked_member = fresh_path("linked-member");
+    WorldPackage::write(&linked_member, simple_members()).unwrap();
+    let outside_member = fresh_path("outside-member");
+    fs::rename(linked_member.join("world-ir.json"), &outside_member).unwrap();
+    symlink(&outside_member, linked_member.join("world-ir.json")).unwrap();
+    assert_eq!(
+        WorldPackage::open(&linked_member)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0409"
+    );
+
+    let broken_output = fresh_path("broken-output-link");
+    symlink("missing-target", &broken_output).unwrap();
+    let rejected = WorldPackage::write(&broken_output, simple_members()).unwrap_err();
+    assert_eq!(rejected.code().as_str(), "EK0401");
+    assert!(
+        fs::symlink_metadata(&broken_output)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[test]
 fn member_names_are_constrained() {
     assert!(MemberName::new("world-ir.json").is_ok());
     assert!(MemberName::new("schemas.json").is_ok());
@@ -260,4 +446,69 @@ fn member_names_are_constrained() {
             "`{illegal}` must be refused"
         );
     }
+}
+
+fn rewrite_manifest(
+    package: &std::path::Path,
+    mutate: impl FnOnce(&mut std::collections::BTreeMap<FieldName, CanonicalValue>),
+) {
+    let manifest_path = package.join(MANIFEST_FILE);
+    let CanonicalValue::Object(mut fields) =
+        parse_canonical(&fs::read(&manifest_path).unwrap()).unwrap()
+    else {
+        panic!("writer emits an object manifest")
+    };
+    mutate(&mut fields);
+    let body = CanonicalValue::object_declared([
+        (
+            "members",
+            fields
+                .get(&FieldName::declared("members"))
+                .expect("manifest has members")
+                .clone(),
+        ),
+        (
+            "schema",
+            fields
+                .get(&FieldName::declared("schema"))
+                .expect("manifest has schema")
+                .clone(),
+        ),
+    ]);
+    fields.insert(
+        FieldName::declared("package_digest"),
+        CanonicalValue::text(Sha256Digest::of_canonical(&body).to_hex()),
+    );
+    fs::write(
+        manifest_path,
+        CanonicalValue::Object(fields).to_canonical_bytes(),
+    )
+    .unwrap();
+}
+
+fn add_manifest_unknown(fields: &mut std::collections::BTreeMap<FieldName, CanonicalValue>) {
+    fields.insert(FieldName::declared("extra"), CanonicalValue::Bool(true));
+}
+
+fn add_schema_unknown(fields: &mut std::collections::BTreeMap<FieldName, CanonicalValue>) {
+    let CanonicalValue::Object(schema) = fields
+        .get_mut(&FieldName::declared("schema"))
+        .expect("manifest has schema")
+    else {
+        panic!("manifest schema is an object")
+    };
+    schema.insert(FieldName::declared("extra"), CanonicalValue::Bool(true));
+}
+
+fn add_row_unknown(fields: &mut std::collections::BTreeMap<FieldName, CanonicalValue>) {
+    let CanonicalValue::Array(rows) = fields
+        .get_mut(&FieldName::declared("members"))
+        .expect("manifest has member rows")
+    else {
+        panic!("manifest members are an array")
+    };
+    let CanonicalValue::Object(row) = &mut rows[0] else {
+        panic!("member row is an object")
+    };
+    row.insert(FieldName::declared("extra"), CanonicalValue::Bool(true));
 }

--- a/crates/estate-core/tests/package.rs
+++ b/crates/estate-core/tests/package.rs
@@ -388,6 +388,14 @@ fn symlinked_roots_manifests_and_members_are_rejected_without_following() {
             .as_str(),
         "EK0409"
     );
+    let linked_root_with_separator = PathBuf::from(format!("{}/", linked_root.display()));
+    assert_eq!(
+        WorldPackage::open(&linked_root_with_separator)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0409"
+    );
 
     let linked_manifest = fresh_path("linked-manifest");
     WorldPackage::write(&linked_manifest, simple_members()).unwrap();

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -70,7 +70,7 @@ never accumulates history (git has that).
   object fields, stable keyed arrays, package members/manifest rows,
   machine/claim identities, transitions, and interactions fail closed instead
   of retaining a final duplicate.
-- **SW-E is implemented on `feature/sw-e-28`:** construction IR advances to
+- **SW-E is merged (#28/#29):** construction IR advances to
   `estate.world_ir.construction@3` with explicit movement composition,
   coherence, connectivity, and resolver subjects. Simulation advances to `@2`,
   navigation begins at `@1`, and both receive one byte-identical typed resolver
@@ -87,15 +87,19 @@ never accumulates history (git has that).
   `compiler-receipts.json`; runtime causal receipts remain only in run outputs.
   It also defines same-filesystem staged publication and exact filesystem and
   manifest verification. The implementation and four-command author proof are
-  green on `feature/package-boundary-22`; exact-head Luna/CI evidence is pending.
-  Revision 4 remains effective until this branch merges.
+  green on `feature/package-boundary-22`. The first GPT-5.6 Luna max pass on
+  `c70b5bf` found a trailing-separator root-symlink bypass and an unstated
+  path-based reader race boundary. Both are repaired: roots are lexically
+  normalized before entry checks, the regression test covers both spellings,
+  and revision 5 now explicitly requires a caller-owned quiescent package tree.
+  A replacement exact-head Luna rerun is pending. Revision 4 remains effective
+  until this branch merges.
 
 ## What is next
 
-Implement **issue #22 — seal the WorldPackage evidence boundary** under decision
-0006. Harden atomic publication, exact manifest decoding, canonical member
-validation, ordering, and filesystem entry-type checks before SW-F relies on
-packages.
+Finish **issue #22 — seal the WorldPackage evidence boundary** under decision
+0006 by obtaining the replacement exact-head non-author rerun, merging PR #30,
+and confirming post-merge CI before SW-F relies on packages.
 
 Do not pull #24 typed forensic provenance into this package-boundary repair.
 Resolve #24 before stable World IR promotion or `explain-*`. Issue #17 remains

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,6 +1,6 @@
 # Handoff — state of the repository
 
-Updated 2026-08-21 on the SW-E issue #28 implementation branch.
+Updated 2026-08-21 after SW-E merged and package-boundary issue #22 began.
 This file orients a fresh session; it is rewritten at each slice boundary and
 never accumulates history (git has that).
 
@@ -78,14 +78,22 @@ never accumulates history (git has that).
   claim activation after complete local/causal settlement and exposes immutable
   before/after facts. The exact fixture proves two initial gate blockers, ward
   survival after opening or destruction, base cost `1` after unsealing, and
-  water cost `3`. The four-command author proof passes; exact-head non-author
-  and CI evidence are pending.
+  water cost `3`. GPT-5.6 Luna max found and verified fixes for stale projection
+  documentation and invalid-connectivity validation, then reran exact head
+  `6dda1d0` green. PR #29 and post-merge CI run `32521857686` passed; merge
+  commit `dacfaef` is clean on main. Issue #28 is closed.
+- **Contract revision 5 is in progress for #22:** decision 0006 replaces the
+  unmanifested package `receipts/` subtree with canonical hashed
+  `compiler-receipts.json`; runtime causal receipts remain only in run outputs.
+  It also defines same-filesystem staged publication and exact filesystem and
+  manifest verification. Revision 4 remains effective until this branch merges.
 
 ## What is next
 
-Finish **SW-E issue #28**: run the complete author proof, obtain the exact-head
-GPT-5.6 Luna max non-author rerun, merge after CI, and record the resulting
-evidence.
+Implement **issue #22 — seal the WorldPackage evidence boundary** under decision
+0006. Harden atomic publication, exact manifest decoding, canonical member
+validation, ordering, and filesystem entry-type checks before SW-F relies on
+packages.
 
 Do not pull #22 package hardening or #24 typed forensic provenance sideways into
 SW-E. Resolve #22 before package/CLI/migration evidence and #24 before stable

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -86,7 +86,9 @@ never accumulates history (git has that).
   unmanifested package `receipts/` subtree with canonical hashed
   `compiler-receipts.json`; runtime causal receipts remain only in run outputs.
   It also defines same-filesystem staged publication and exact filesystem and
-  manifest verification. Revision 4 remains effective until this branch merges.
+  manifest verification. The implementation and four-command author proof are
+  green on `feature/package-boundary-22`; exact-head Luna/CI evidence is pending.
+  Revision 4 remains effective until this branch merges.
 
 ## What is next
 
@@ -95,14 +97,13 @@ Implement **issue #22 — seal the WorldPackage evidence boundary** under decisi
 validation, ordering, and filesystem entry-type checks before SW-F relies on
 packages.
 
-Do not pull #22 package hardening or #24 typed forensic provenance sideways into
-SW-E. Resolve #22 before package/CLI/migration evidence and #24 before stable
-World IR promotion or `explain-*`. Issue #17 remains a formal cold-author
-tooling blocker, not a blocker for semantic implementation.
+Do not pull #24 typed forensic provenance into this package-boundary repair.
+Resolve #24 before stable World IR promotion or `explain-*`. Issue #17 remains
+a formal cold-author tooling blocker, not a blocker for implementation.
 
-After SW-E: SW-F (runtime state, replay, migration v1→v2, `explain-*`), complete
-command surface/package orchestration, determinism matrix, and formal cold-agent
-gates.
+After #22: resolve #24 at its stated boundary, then continue SW-F runtime state,
+replay, migration v1→v2, package/command orchestration, explanations, the
+determinism matrix, and formal cold-agent gates.
 
 ## How to prove the current branch
 

--- a/docs/decisions/0006-package-evidence-boundary.md
+++ b/docs/decisions/0006-package-evidence-boundary.md
@@ -1,0 +1,157 @@
+---
+title: Contract revision 5 — package evidence boundary
+status: Owner-authorized; effective when merged
+number: 0006
+date: 2026-08-21
+issue: 22
+supersedes_contract_revision: 4
+establishes_contract_revision: 5
+owner: Peter Permenter
+implementing_reviewer: GPT-5.6
+---
+
+# Contract revision 5 — package evidence boundary
+
+## Decision authority
+
+The owner accepted issue #22 at its recorded slice boundary, then authorized
+proceeding with that slice on 2026-08-21. This record supplies the explicit
+contract repair that #22 requires before package implementation can continue.
+Contract revision 5 becomes effective when this record and its implementation
+merge; revision 4 remains effective until then.
+
+## Problem
+
+KERNEL section 5 names `receipts/` inside the immutable world-package layout,
+while the same section places runtime causal receipts in separate run outputs.
+The SW-B writer created the package directory but excluded it from the manifest,
+and the verifier deliberately ignored it. Anything placed there could change
+without changing the package digest.
+
+That contradicts the claim that a verified package has one exact immutable
+structure. It also leaves two plausible authorities for runtime receipts.
+
+## Amendment A1 — one authority for compiler and runtime receipts
+
+### Prior wording
+
+KERNEL section 5 specified:
+
+```text
+build/gaol.world/
+  manifest.json
+  world-ir.json
+  simulation.json
+  navigation.json
+  persistence.json
+  diagnostics.json
+  schemas.json
+  receipts/
+```
+
+It separately specified `runs/<run>/causal-receipts.json` for runtime output.
+The contract did not say whether the package directory held compiler receipts,
+runtime receipts, or both, and did not say whether its contents were hashed.
+
+### Replacement wording
+
+Gate K world packages contain only regular files at their root. The example
+layout replaces `receipts/` with:
+
+```text
+  compiler-receipts.json
+```
+
+`manifest.json` declares and hashes every other package entry, including
+`compiler-receipts.json`. Compiler, linker, validation, and invariant receipts
+that belong to a compiled build live in that canonical member. Runtime causal
+receipts live only in the separately versioned run output
+`causal-receipts.json`; commands, runs, and replays never write receipts into an
+input world package. No unmanifested directory or file is permitted inside a
+verified package.
+
+### Reason
+
+Build receipts describe how the immutable package was produced and therefore
+belong inside its hash boundary. Runtime receipts describe execution against
+that input and therefore belong beside mutable run state. A single canonical
+member is inspectable with ordinary tools and avoids inventing recursive
+directory-manifest semantics for Gate K.
+
+### Effect on existing evidence
+
+No accepted Gate K package exists. SW-B package tests prove canonical member
+hashing, basic tamper detection, and refusal to overwrite an existing output;
+those proofs remain useful but did not establish a complete package boundary.
+
+The empty unmanifested `receipts/` directory emitted by SW-B is invalidated as
+package-layout evidence and is removed. Historical Git and rerun receipts
+remain evidence of what SW-B actually tested. Canonical member bytes, SHA-256,
+source/IR/projection schemas, runtime semantics, and the frozen core hash fixture
+are unchanged. The manifest body shape remains `estate.package.manifest@1`;
+this repair tightens structural validation without changing its encoded fields.
+
+### Owner disposition
+
+Approved as the issue #22 repair: compiler/build receipts are canonical hashed
+package members, runtime causal receipts remain separate run artifacts, and the
+unverified subtree is removed.
+
+### New contract revision
+
+5.
+
+## Amendment A2 — exact publication and verification boundary
+
+### Prior wording
+
+KERNEL section 5 said that a compiled package is immutable evidence and that
+commands and migrations never modify it in place. It did not define how a new
+directory becomes visible or which filesystem entry types are legal.
+
+### Replacement wording
+
+A package writer validates all inputs, writes a complete package to a fresh
+sibling staging directory on the same filesystem, verifies that staged package,
+and publishes it with one rename. A failed write removes its staging directory
+and leaves the requested destination absent. An existing destination is never
+replaced or merged into. Atomicity is claimed only for the documented supported
+local-filesystem, single-publisher boundary.
+
+On open, the manifest, nested schema object, and member rows have exact field
+sets. Member rows are unique and strictly ordered by member name. Every declared
+member is a regular file whose bytes are canonical and match the recorded size
+and digest. The package root contains only the regular `manifest.json` plus its
+declared regular member files; symlinks, special files, and undeclared files or
+directories are refused.
+
+### Reason
+
+Sequential writes into the destination can strand a partial path that the
+immutability rule then refuses to replace. Hash checking alone also does not
+prove that decoded structure was exact or that filesystem traversal did not
+cross an undeclared entry type. Publication and verification must cover the
+same structure the package claims as evidence.
+
+### Effect on existing evidence
+
+Existing successful package bytes and manifest digests remain unchanged. Tests
+that relied on the ignored `receipts/` directory change under amendment A1.
+New failure-injection and tamper tests extend the evidence; they do not upgrade
+the current construction snapshots into valid stable World IR packages.
+
+### Owner disposition
+
+Approved as the fail-closed publication and read boundary required by issue #22.
+
+### New contract revision
+
+5.
+
+## Evidence limits preserved
+
+This repair does not implement package orchestration, stable World IR,
+compiler-receipt schema content, signing/authenticity, runtime commit, replay,
+migration, CLI commands, aarch64 evidence, the ten-run matrix, or formal cold
+agents. It makes the generic directory boundary safe enough for those later
+slices to rely on; it does not claim any of them complete.

--- a/docs/decisions/0006-package-evidence-boundary.md
+++ b/docs/decisions/0006-package-evidence-boundary.md
@@ -125,6 +125,14 @@ and digest. The package root contains only the regular `manifest.json` plus its
 declared regular member files; symlinks, special files, and undeclared files or
 directories are refused.
 
+Verification is defined for a caller-owned, quiescent package tree on the
+supported local filesystem. The caller must prevent another process from
+renaming or replacing entries while `open` runs. Path-based verification is not
+a race-safe hostile-filesystem sandbox, authenticity boundary, or substitute
+for the later signing threat-model decision. Inputs already containing symlinks
+are refused without following their final component, including root paths
+spelled with trailing separators.
+
 ### Reason
 
 Sequential writes into the destination can strand a partial path that the

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,74 @@
+---
+title: Gate K package evidence boundary
+status: Implementation reference for issue 22 and contract revision 5
+date: 2026-08-21
+applies_to: KERNEL.md sections 5-7; acceptance 12
+---
+
+# Gate K package evidence boundary
+
+Contract revision 5 makes one directory mean one verified package. Its root
+contains only regular files:
+
+```text
+manifest.json
+world-ir.json
+simulation.json
+navigation.json
+persistence.json
+diagnostics.json
+schemas.json
+compiler-receipts.json
+```
+
+The generic `estate-core::package` layer validates names, canonical bytes,
+hashes, publication, and filesystem structure. It deliberately does not decide
+which semantic members a complete Gate K package requires; later compiler/CLI
+orchestration owns that exact artifact set. When that orchestration lands,
+`compiler-receipts.json` is a required canonical manifest member. Runtime
+causal receipts never enter an input package and live only in run outputs.
+
+## Publication
+
+`WorldPackage::write` performs these steps:
+
+1. refuse an existing destination without following symlinks;
+2. reject duplicate names and noncanonical member bytes before disk mutation;
+3. create a uniquely named sibling staging directory;
+4. write every member and the canonical manifest into staging;
+5. reopen and fully verify the staged package;
+6. recheck that the destination is absent;
+7. publish with one same-filesystem rename.
+
+Any reported failure removes the staging directory and leaves the requested
+destination absent. Existing destinations are never merged into or replaced.
+The atomicity claim covers the supported local-filesystem, single-publisher
+boundary. It is not a claim of crash durability, distributed-filesystem rename
+semantics, or coordination with an external process racing to create the same
+destination.
+
+## Verification
+
+`WorldPackage::open` refuses unless:
+
+- the root is a real directory rather than a symlink;
+- `manifest.json` and every declared member are regular files;
+- the manifest, nested schema object, and every member row have exactly their
+  declared fields;
+- member rows are unique and strictly ordered by canonical member name;
+- the package digest matches the canonical manifest body;
+- the root contains no undeclared file or directory;
+- every member matches its recorded size and SHA-256 digest; and
+- every hash-valid member independently parses as canonical bytes.
+
+The reader inspects entry types without following symlinks before reading.
+Tests cover root, manifest, and member symlinks, declared and undeclared
+directories, canonical unknown fields with recomputed digests, duplicate and
+unsorted rows, and noncanonical members whose hashes were maliciously updated.
+
+## Evidence limits
+
+SHA-256 proves byte identity, not authenticity or provenance. This slice does
+not define the compiler-receipt schema, assemble a complete world package,
+implement signing, guarantee power-loss durability, or satisfy package CLI,
+migration, replay, or whole-Gate-K acceptance.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -61,10 +61,18 @@ destination.
 - every member matches its recorded size and SHA-256 digest; and
 - every hash-valid member independently parses as canonical bytes.
 
-The reader inspects entry types without following symlinks before reading.
-Tests cover root, manifest, and member symlinks, declared and undeclared
-directories, canonical unknown fields with recomputed digests, duplicate and
-unsorted rows, and noncanonical members whose hashes were maliciously updated.
+The reader lexically normalizes trailing separators and inspects entry types
+without following existing final-component symlinks before reading. Tests cover
+root spellings with and without a trailing separator, manifest and member
+symlinks, declared and undeclared directories, canonical unknown fields with
+recomputed digests, duplicate and unsorted rows, and noncanonical members whose
+hashes were maliciously updated.
+
+The caller must own a quiescent package tree for the duration of `open`; an
+external process concurrently replacing entries is outside this path-based
+integrity boundary. This verifier does not claim to be a hostile-filesystem
+sandbox or authenticity mechanism. That limitation is explicit because SHA-256
+binds bytes but supplies neither access control nor provenance.
 
 ## Evidence limits
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -125,6 +125,14 @@ The module knows nothing about member *meaning*. It enforces names, bytes,
 hashes, and immutability. What `simulation.json` must contain stays in
 `estate-projection`.
 
+Contract revision 5 closes the directory boundary around that generic layer.
+Writes use a verified sibling staging directory and one same-filesystem rename;
+reads require exact manifest shapes, ordered unique rows, canonical members,
+and regular-file-only roots without symlinks or undeclared subtrees. Compiler
+receipts become the hashed `compiler-receipts.json` member, while runtime causal
+receipts remain separate run artifacts. [`packages.md`](packages.md) records the
+supported local-filesystem/single-publisher limit and the evidence still absent.
+
 ### SHA-256 in-crate under the Gate K dependency policy
 
 The state hash is the constitutional identity of authoritative state, and


### PR DESCRIPTION
## Outcome

Resolves issue #22 before package orchestration, migration, or SW-F relies on `WorldPackage` as immutable evidence.

- records owner-authorized contract revision 5 in decision 0006
- replaces the unmanifested `receipts/` subtree with manifest-hashed `compiler-receipts.json`
- keeps runtime causal receipts exclusively in separate run outputs
- validates all member inputs before disk mutation
- writes and verifies a fresh sibling staging package before same-filesystem rename publication
- cleans staging after failure and never exposes a partial requested destination
- decodes exact manifest/schema/member-row shapes
- requires unique, strictly ordered manifest member rows
- revalidates every hash-valid member as canonical bytes
- rejects symlinked roots/manifests/members, directories, special/non-regular entries, and undeclared files
- normalizes trailing root separators before final-component symlink checks

## Author evidence

Exact head: `5f659783568641c458dcac401ce28ef59d5c70f6`

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo xtask boundary`

All pass with a clean worktree before and after. Focused package evidence includes injected mid-write cleanup, canonical unknown fields with recomputed digest, duplicate/unsorted rows, hash-valid noncanonical bytes, root symlinks with and without trailing separators, manifest/member symlinks, directories, no-clobber behavior, and insertion-order determinism.

## Review disposition

The first GPT-5.6 Luna max pass on `c70b5bf` found two real gaps: a trailing-separator root-symlink bypass and an unstated TOCTOU boundary in path-based verification. This head repairs the bypass and explicitly limits verification to a caller-owned, quiescent package tree across KERNEL revision 5, decision 0006, the API, and package documentation. The replacement GPT-5.6 Luna max exact-head rerun is GREEN.

## Atomicity and reader limits

Publication is one verified sibling-directory rename on the supported local filesystem with a single publisher. It does not claim crash durability, distributed-filesystem rename semantics, or protection from an external process racing to create the same destination.

Reading requires a caller-owned, quiescent package tree. The path-based verifier rejects existing final-component symlinks but is not a race-safe hostile-filesystem sandbox or an authenticity mechanism.

## Evidence limits

This does not define compiler-receipt schema content, assemble a complete Gate K package, implement signing, committed runtime state, replay, migration, package CLI commands, aarch64 evidence, the ten-run matrix, or formal cold-agent acceptance.

Closes #22.