### PR TITLE
Prove and ablate agy formal cold-agent boundary

### DIFF
--- a/.agents/agents/nomos-cold-subject/agent.md
+++ b/.agents/agents/nomos-cold-subject/agent.md
@@ -1,0 +1,22 @@
+---
+name: nomos-cold-subject
+description: Formal Nomos cold-agent subject with the protocol's minimal local tool set.
+tools:
+  - view_file
+  - replace_file_content
+  - run_command
+mainAgent: true
+subagent: false
+inheritMcp: false
+inheritCustomizations: false
+commandExecutionPolicy: sandbox
+skills: []
+plugins: []
+mcpServers: []
+---
+
+# Formal cold subject
+
+Operate only on the supplied evaluation packet. Use only the explicitly
+configured tools and do not seek outside context, delegation, or network
+access.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Agy print preflight harness
         run: docs/evaluation/test-agy-print-preflight.sh
 
+      - name: Agy formal boundary harness
+        run: docs/evaluation/test-agy-formal-boundary-preflight.sh
+
       - name: Determinism
         # The canonical-hash test prints `HASH <name> <hex>` lines. Four runs —
         # debug twice, release twice — must produce byte-identical lines.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,7 +1,7 @@
 # Handoff — state of the repository
 
-Updated 2026-08-22 for the issue #17 Antigravity print-mode repair. No next
-semantic implementation slice is currently filed.
+Updated 2026-08-22 for the issue #45 Antigravity formal-boundary
+falsification. No next semantic implementation slice is currently filed.
 This file orients a fresh session; it is rewritten at each slice boundary and
 never accumulates history (git has that).
 
@@ -71,9 +71,16 @@ never accumulates history (git has that).
   Gemini 3.7 Flash High model and a completed `pwd` tool event in the target
   worktree. The fail-closed harness and exact receipt are under
   `docs/evaluation/`. The three 2026-08-21 attempts retain zero evidentiary
-  value. The successful init event also exposed forbidden formal-run tools, so
-  issue #45 now blocks the Gemini cold-agent route pending effective tool and
-  persisted-context ablation proof.
+  value.
+- **The `agy` formal route is ineligible on 1.1.17 (#45):** a fresh project and
+  conversation with sandboxing, slash commands disabled, and a custom
+  three-tool main agent still reported 57 tools and no machine-readable project,
+  context-source, or memory disclosure. The fail-closed guard therefore exits
+  `1` with `AGY_FORMAL_BOUNDARY BLOCKED`. The exact receipt is under
+  `docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/`.
+  No Gemini formal attempt may launch until a future client/route passes that
+  guard or the owner approves a new plan. This is tooling falsification, not a
+  formal run, roster substitution, or protocol change.
 - **CI uses `actions/checkout@v7` (#11):** PR and post-merge verification passed
   without the Node 20 compatibility annotation.
 - **The GPT Pro architecture checkpoint is owner-disposed (#25):** review of
@@ -159,17 +166,22 @@ never accumulates history (git has that).
 
 ## What is next
 
-No next semantic implementation slice is currently filed. Start by creating an
-issue with falsifiable acceptance and an explicit boundary; do not infer a new
-slice from this handoff. The remaining post-SW-G work includes the filesystem
+No next semantic implementation slice is currently filed; do not infer one
+from this handoff. The remaining post-SW-G work includes the filesystem
 CLI surface, run-directory artifacts, replay, the required stable v1-to-v2
 movement migration, direct v2 runtime loading/refusal evidence, the Linux
 aarch64 and ten-run matrix, measured Gate K budgets, final schema-ownership
 review, and the formal cold-agent gates.
 
-Issue #45 remains a formal cold-author tooling blocker, not a blocker for
-ordinary issue-first semantic implementation. Issue #17 repairs only the
-print-mode transport and command preflight; it is not formal Gate K evidence.
+Issue #47 is the next scoped maintenance item: the contractual cold-agent
+protocol still names the prototype-era `estate` CLI in its active tool policy.
+It requires an owner-authorized protocol revision that changes only that
+identity to `nomos`; issue #45 deliberately does not amend it.
+
+The selected Gemini route remains a formal cold-author tooling blocker, not a
+blocker for ordinary issue-first semantic implementation. Issue #17 repairs
+only print-mode transport; issue #45 proves that 1.1.17 cannot disclose the
+required formal boundary. Neither result is formal Gate K evidence.
 
 ## How to prove the current branch
 
@@ -179,7 +191,13 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
 cargo xtask boundary
 docs/evaluation/test-agy-print-preflight.sh
+docs/evaluation/test-agy-formal-boundary-preflight.sh
 ```
+
+The authenticated formal-boundary command is an expected negative proof on
+1.1.17: `docs/evaluation/agy-formal-boundary-preflight.sh` must exit `1` and
+print `AGY_FORMAL_BOUNDARY BLOCKED`. A zero exit would require inspection and
+owner disposition before any formal launch.
 
 SW-G's author proof, Luna max exact-head rerun, PR CI, and post-merge CI passed
 all four commands; the focused release SW-G test also passed. SW-F, SW-D, and

--- a/docs/evaluation/GATE_K_COLD_AGENT_PLAN.md
+++ b/docs/evaluation/GATE_K_COLD_AGENT_PLAN.md
@@ -119,9 +119,29 @@ The successful 1.1.17 repair receipt is under
 failed 2026-08-21 calls retain zero evidentiary value. Passing this transport
 preflight is necessary but not sufficient for a formal run: the init event's
 effective tools and all freshness/ablation requirements below still require
-separate inspection and approval. Issue #45 tracks that fail-closed tool and
-persisted-context proof; the Gemini formal route remains blocked until it is
-disposed.
+separate inspection and approval.
+
+Issue #45 tested that boundary on 2026-08-22 with a new project and conversation,
+sandboxing, slash-command expansion disabled, and a custom main agent declaring
+only `view_file`, `replace_file_content`, and `run_command`. `agy` 1.1.17 still
+reported 57 tools in its init event, including browser, web, MCP, persisted
+knowledge, messaging, scheduling, and subagent capabilities. The event omitted
+the project ID, context-source set, and memory state. Model text claiming some
+forbidden tools were unavailable is not effective-configuration evidence.
+
+The exact receipt is under
+`docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/`.
+The committed guard must pass before any Gemini formal launch:
+
+```bash
+docs/evaluation/agy-formal-boundary-preflight.sh
+```
+
+On 1.1.17 it correctly exits `1` with `AGY_FORMAL_BOUNDARY BLOCKED`. This
+falsifies the selected client's current eligibility; it does not weaken the
+protocol or authorize a substitute. A future client or route must expose the
+exact allowlisted tools and explicit empty-context/memory/project evidence, or
+the owner must approve a new plan.
 
 ## Freshness and tool boundary
 

--- a/docs/evaluation/agy-formal-boundary-preflight.sh
+++ b/docs/evaluation/agy-formal-boundary-preflight.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+agy_bin=${AGY_BIN:-agy}
+model=${AGY_MODEL:-gemini-3.7-flash-high}
+model_label=${AGY_MODEL_LABEL:-Gemini 3.7 Flash (High)}
+agent=${AGY_AGENT:-nomos-cold-subject}
+print_timeout=${AGY_PRINT_TIMEOUT:-2m}
+expected_agent_sha=d9b5004681113503f5411d5c28358d8710086e93796ed79426fd9356c4c17337
+
+fail() {
+  printf 'agy formal boundary preflight: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+record_failure() {
+  printf 'agy formal boundary preflight: BLOCKED: %s\n' "$*" >&2
+  blocked=1
+}
+
+command -v "$agy_bin" >/dev/null 2>&1 || fail "agy executable not found: $agy_bin"
+command -v git >/dev/null 2>&1 || fail "git executable not found"
+command -v grep >/dev/null 2>&1 || fail "grep executable not found"
+command -v sed >/dev/null 2>&1 || fail "sed executable not found"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum executable not found"
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) ||
+  fail "run the preflight inside the target Git worktree"
+repo_root=$(cd "$repo_root" && pwd -P)
+case "$repo_root" in
+  *'"'* | *'\'* | *$'\t'* | *$'\n'* | *$'\r'*)
+    fail "worktree path cannot be checked safely in JSON output: $repo_root"
+    ;;
+esac
+
+agent_file="$repo_root/.agents/agents/$agent/agent.md"
+[[ -f $agent_file ]] || fail "missing custom agent definition: $agent_file"
+agent_sha=$(sha256sum "$agent_file")
+agent_sha=${agent_sha%% *}
+[[ $agent_sha == "$expected_agent_sha" ]] ||
+  fail "custom agent definition digest mismatch: $agent_sha"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf -- "$tmp_dir"' EXIT
+
+"$agy_bin" --version >"$tmp_dir/version.txt" || fail "agy --version failed"
+"$agy_bin" models >"$tmp_dir/models.txt" || fail "agy models failed"
+[[ $(wc -l <"$tmp_dir/version.txt") -eq 1 ]] ||
+  fail "agy version output must be one line"
+grep -Fx "${model}"$'\t'"${model_label}" "$tmp_dir/models.txt" >/dev/null ||
+  fail "model catalog does not resolve $model to $model_label"
+
+prompt='Reply with exactly: formal boundary preflight. Do not call tools.'
+set +e
+AGY_CLI_HIDE_ACCOUNT_INFO=true "$agy_bin" -p "$prompt" \
+  --agent "$agent" \
+  --model "$model" \
+  --effort high \
+  --new-project \
+  --sandbox \
+  --disable-slash-commands \
+  --output-format stream-json \
+  --print-timeout "$print_timeout" \
+  --log-file "$tmp_dir/agy.log" \
+  >"$tmp_dir/events.ndjson" 2>"$tmp_dir/stderr.txt"
+agy_status=$?
+set -e
+
+if [[ $agy_status -ne 0 ]]; then
+  cat "$tmp_dir/stderr.txt" >&2
+  fail "agy exited $agy_status"
+fi
+
+project_line=$(grep -E 'project: created project .*\(id=[0-9a-f-]{36}\) at .*/projects/[0-9a-f-]{36}\.json' \
+  "$tmp_dir/agy.log" | tail -n 1 || true)
+[[ -n $project_line ]] || fail "agy did not record creation of a new project"
+project_id=$(printf '%s\n' "$project_line" |
+  sed -n 's/.*(id=\([0-9a-f-]\{36\}\)) at .*/\1/p')
+project_record=$(printf '%s\n' "$project_line" | sed -n 's/.* at \(.*\)$/\1/p')
+[[ -n $project_id ]] || fail "could not parse the new project ID"
+[[ -f $project_record ]] || fail "new project record is missing: $project_record"
+compact_project=$(tr -d '[:space:]' <"$project_record")
+[[ $compact_project == *"\"id\":\"$project_id\""* ]] ||
+  fail "new project record does not contain its reported ID"
+[[ $compact_project == *"\"folderUri\":\"file://$repo_root\""* ]] ||
+  fail "new project record does not contain only the target worktree"
+[[ $(grep -Foc '"folderUri"' "$project_record") -eq 1 ]] ||
+  fail "new project record contains more than one workspace folder"
+if [[ $compact_project == *'"permissions":'* &&
+  $compact_project != *'"permissions":null'* ]]; then
+  fail "new project record carries persisted project permissions"
+fi
+
+blocked=0
+init_count=$(grep -Fc '"event":"init"' "$tmp_dir/events.ndjson" || true)
+[[ $init_count -eq 1 ]] || record_failure "expected exactly one init event, found $init_count"
+init_line=$(grep -F '"event":"init"' "$tmp_dir/events.ndjson" | head -n 1 || true)
+
+if [[ -n $init_line ]]; then
+  [[ $init_line == *"\"model\":\"$model\""* ]] ||
+    record_failure "init event does not pin $model"
+  [[ $init_line == *"\"cwd\":\"$repo_root\""* ]] ||
+    record_failure "init event cwd is not the target worktree"
+  [[ $init_line == *"\"agent\":\"$agent\""* ]] ||
+    record_failure "init event does not pin custom agent $agent"
+  [[ $init_line == *"\"project_id\":\"$project_id\""* ]] ||
+    record_failure "init event does not disclose the newly created project ID"
+  [[ $init_line == *'"context_sources":[]'* ]] ||
+    record_failure "init event does not prove an empty context-source set"
+  [[ $init_line == *'"memory_enabled":false'* ]] ||
+    record_failure "init event does not prove persisted memory is disabled"
+  [[ $init_line == *'"permission_mode":"request-review"'* ]] ||
+    record_failure "init event is not in request-review permission mode"
+
+  tools=$(printf '%s\n' "$init_line" |
+    sed -n 's/.*"tools":\[\([^]]*\)\].*/\1/p')
+  if [[ -z $tools ]]; then
+    record_failure "init event does not disclose its tool set"
+  else
+    normalized_tools=$(printf '%s\n' "$tools" | tr ',' '\n' | tr -d '"' |
+      LC_ALL=C sort | tr '\n' ',' | sed 's/,$//')
+    expected_tools='replace_file_content,run_command,view_file'
+    [[ $normalized_tools == "$expected_tools" ]] ||
+      record_failure "effective tools are not the exact protocol allowlist: $normalized_tools"
+  fi
+fi
+
+result_count=$(grep -Fc '"event":"result"' "$tmp_dir/events.ndjson" || true)
+[[ $result_count -eq 1 ]] ||
+  record_failure "expected exactly one terminal result, found $result_count"
+tool_step_count=$(grep -Fc '"step_type":"tool"' "$tmp_dir/events.ndjson" || true)
+[[ $tool_step_count -eq 0 ]] ||
+  record_failure "neutral preflight unexpectedly executed $tool_step_count tool events"
+result_line=$(grep -F '"event":"result"' "$tmp_dir/events.ndjson" | tail -n 1 || true)
+if [[ -n $result_line ]]; then
+  [[ $result_line == *'"status":"SUCCESS"'* ]] ||
+    record_failure "terminal result is not SUCCESS"
+  [[ $result_line == *'"num_turns":1'* ]] ||
+    record_failure "conversation is not a fresh one-turn session"
+  [[ $result_line == *'"cache_read_tokens":0'* ]] ||
+    record_failure "conversation reports reused cached context"
+fi
+
+conversation_id=$(printf '%s\n' "$init_line" |
+  sed -n 's/.*"conversation_id":"\([^"]*\)".*/\1/p')
+[[ -n $conversation_id ]] || record_failure "init event has no conversation ID"
+
+printf 'AGY_VERSION %s\n' "$(<"$tmp_dir/version.txt")"
+printf 'AGY_MODEL %s\t%s\n' "$model" "$model_label"
+printf 'AGY_AGENT %s %s\n' "$agent" "$agent_sha"
+printf 'AGY_WORKTREE %s\n' "$repo_root"
+printf 'AGY_PROJECT %s\n' "$project_id"
+printf 'AGY_PROJECT_RECORD %s\n' "$project_record"
+printf 'AGY_CONVERSATION %s\n' "${conversation_id:-unavailable}"
+printf 'AGY_EVENTS_BEGIN\n'
+cat "$tmp_dir/events.ndjson"
+printf 'AGY_EVENTS_END\n'
+
+if [[ $blocked -ne 0 ]]; then
+  printf 'AGY_FORMAL_BOUNDARY BLOCKED\n' >&2
+  exit 1
+fi
+
+printf 'AGY_FORMAL_BOUNDARY PASS\n'

--- a/docs/evaluation/fixtures/fake-agy-formal-boundary
+++ b/docs/evaluation/fixtures/fake-agy-formal-boundary
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+case ${1:-} in
+  --version)
+    printf '1.1.17\n'
+    exit 0
+    ;;
+  models)
+    printf 'gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n'
+    exit 0
+    ;;
+  agent | agents)
+    printf 'nomos-cold-subject\n'
+    exit 0
+    ;;
+esac
+
+repo_root=$(git rev-parse --show-toplevel)
+expected_prompt='Reply with exactly: formal boundary preflight. Do not call tools.'
+[[ ${1:-} == -p ]] || exit 64
+[[ ${2:-} == "$expected_prompt" ]] || exit 65
+shift 2
+
+agent=
+model=
+effort=
+new_project=0
+sandbox=0
+slash_commands_disabled=0
+output_format=
+print_timeout=
+log_file=
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --agent)
+      agent=${2:-}
+      shift 2
+      ;;
+    --model)
+      model=${2:-}
+      shift 2
+      ;;
+    --effort)
+      effort=${2:-}
+      shift 2
+      ;;
+    --new-project)
+      new_project=1
+      shift
+      ;;
+    --sandbox)
+      sandbox=1
+      shift
+      ;;
+    --disable-slash-commands)
+      slash_commands_disabled=1
+      shift
+      ;;
+    --output-format)
+      output_format=${2:-}
+      shift 2
+      ;;
+    --print-timeout)
+      print_timeout=${2:-}
+      shift 2
+      ;;
+    --log-file)
+      log_file=${2:-}
+      shift 2
+      ;;
+    *)
+      exit 66
+      ;;
+  esac
+done
+
+[[ $agent == nomos-cold-subject ]] || exit 67
+[[ $model == gemini-3.7-flash-high ]] || exit 68
+[[ $effort == high ]] || exit 69
+[[ $new_project == 1 ]] || exit 70
+[[ $sandbox == 1 ]] || exit 71
+[[ $slash_commands_disabled == 1 ]] || exit 72
+[[ $output_format == stream-json ]] || exit 73
+[[ $print_timeout == 2m ]] || exit 74
+[[ -n $log_file ]] || exit 75
+
+project_id=11111111-2222-4333-8444-555555555555
+conversation_id=aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee
+log_dir=${log_file%/*}
+project_record="$log_dir/projects/$project_id.json"
+mkdir -p "$log_dir/projects"
+printf 'project: created project "fixture" (id=%s) at %s\n' \
+  "$project_id" "$project_record" >"$log_file"
+printf '{\n  "id": "%s",\n  "projectResources": {"resources": [{"folderUri": "file://%s"}]},\n  "permissions": null\n}\n' \
+  "$project_id" "$repo_root" >"$project_record"
+
+mode=${FAKE_AGY_FORMAL_MODE:-pass}
+if [[ $mode == missing-init ]]; then
+  printf '{"event":"result","result":{"conversation_id":"%s","status":"SUCCESS","response":"formal boundary preflight\\n","num_turns":1,"usage":{"cache_read_tokens":0}}}\n' "$conversation_id"
+  exit 0
+fi
+
+init_model=$model
+init_cwd=$repo_root
+tools='"view_file","replace_file_content","run_command"'
+context='"project_id":"'"$project_id"'","context_sources":[],"memory_enabled":false,'
+case $mode in
+  forbidden-tool)
+    tools='"view_file","replace_file_content","run_command","search_web"'
+    ;;
+  wrong-model)
+    init_model=gemini-3.7-flash-medium
+    ;;
+  wrong-worktree)
+    init_cwd=/tmp/wrong-worktree
+    ;;
+  missing-context)
+    context=
+    ;;
+  pass | reused-context | tool-call)
+    ;;
+  *)
+    exit 76
+    ;;
+esac
+
+printf '{"event":"init","conversation_id":"%s","init":{"model":"%s","cwd":"%s","agent":"nomos-cold-subject",%s"tools":[%s],"permission_mode":"request-review"}}\n' \
+  "$conversation_id" "$init_model" "$init_cwd" "$context" "$tools"
+
+if [[ $mode == tool-call ]]; then
+  printf '{"event":"step_update","step_update":{"conversation_id":"%s","step_index":1,"state":"DONE","step_type":"tool","tool_name":"run_command"}}\n' \
+    "$conversation_id"
+fi
+
+num_turns=1
+cache_read_tokens=0
+if [[ $mode == reused-context ]]; then
+  num_turns=2
+  cache_read_tokens=1
+fi
+printf '{"event":"result","result":{"conversation_id":"%s","status":"SUCCESS","response":"formal boundary preflight\\n","num_turns":%s,"usage":{"cache_read_tokens":%s}}}\n' \
+  "$conversation_id" "$num_turns" "$cache_read_tokens"

--- a/docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/RUN.md
+++ b/docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/RUN.md
@@ -1,0 +1,118 @@
+# `agy` formal cold-agent boundary falsification
+
+**Verdict:** BLOCKED — Antigravity CLI 1.1.17 is ineligible for a formal
+Nomos cold-agent role
+
+**Date:** 2026-08-22
+
+**Issue:** #45
+
+**Probe commit:** `7a2d5771edc60393dfe900788ee9f17281166b1f`
+
+This is a tooling-eligibility probe, not a formal cold-author or cold-debug
+attempt. It spends no formal-attempt budget and supplies no Gate K evidence.
+
+## Environment and route
+
+- Client: official Antigravity `agy` 1.1.17.
+- Requested and resolved model:
+  `gemini-3.7-flash-high` — `Gemini 3.7 Flash (High)`.
+- Host: Arch Linux x86_64, kernel `7.1.8-arch1-3`.
+- Worktree: `/work/signed-dev/src/signed-world`.
+- Custom main agent: `nomos-cold-subject`, SHA-256
+  `d9b5004681113503f5411d5c28358d8710086e93796ed79426fd9356c4c17337`.
+- New project: `9dab0c3c-2fb1-43d4-a594-4f46571d2b87`.
+- New conversation: `bf07f12b-859c-4072-bd14-1a80f7558152`.
+
+The custom agent declares only `view_file`, `replace_file_content`, and
+`run_command`; is selectable as a main agent but not a subagent; disables MCP
+and customization inheritance; declares no skills, plugins, or MCP servers;
+and requests sandboxed command execution. The launch also used `--new-project`,
+`--sandbox`, and `--disable-slash-commands` without
+`--dangerously-skip-permissions`.
+
+Official references used to identify the available controls:
+
+- <https://www.agy.dev/docs/cli/headless/>
+- <https://www.agy.dev/docs/subagents/>
+- <https://www.agy.dev/docs/permissions/>
+- <https://www.agy.dev/docs/projects/>
+
+## Invocation
+
+From exact probe commit `7a2d577`:
+
+```bash
+docs/evaluation/agy-formal-boundary-preflight.sh
+```
+
+The harness internally ran this prompt-first shape:
+
+```text
+agy -p <neutral-prompt> --agent nomos-cold-subject \
+  --model gemini-3.7-flash-high --effort high --new-project --sandbox \
+  --disable-slash-commands --output-format stream-json \
+  --print-timeout 2m --log-file <temporary-log>
+```
+
+The exact neutral prompt is in `prompt.txt`. The sanitized exact output is in
+`transcript.txt`. The generated new-project record's content is preserved as
+`project.json`; the repository copy adds a final line feed and hashes to
+`81ad6085a6c9177234fe29a03943a50e6f2319c1e7fe46526b4a194f82d57a3f`.
+The original bytes had no final line feed and hashed to
+`b9a942a7e985351a77c79312517d5b6273d84c7ad2e7ffe5618e4996b9082060`.
+The original user-level record was removed after capture.
+
+## What passed
+
+- `agy` created one new project containing only the target worktree.
+- The init event resolved the exact model, worktree, and custom agent.
+- Permission mode remained `request-review`.
+- The terminal result was `SUCCESS`, `num_turns` was `1`, and
+  `cache_read_tokens` was `0`.
+- The neutral probe executed no tool step.
+
+These facts prove that new-project launch and one-turn conversation transport
+work. They do not prove the formal context or tool boundary.
+
+## Falsification
+
+The machine-readable init event did not disclose:
+
+- the newly created project ID;
+- an empty context-source set; or
+- that persisted memory was disabled.
+
+More decisively, `init.tools` exposed 57 tools rather than the custom agent's
+three-tool allowlist. The list included browser automation, `search_web`,
+`read_url_content`, `call_mcp_tool`, resource access, knowledge mutation,
+subagent definition/invocation/management, messaging, scheduling, image
+generation, and broad file/command helpers.
+
+Exploratory prompts against the same declarative agent caused the model to say
+that `search_web` and `invoke_subagent` were unavailable, but that is model
+self-report, not machine-readable effective configuration. It cannot override
+the contradictory init event or prove which other declared tools are actually
+inaccessible. The documented permissions engine covers file, URL, command,
+unsandboxed-command, and MCP actions; it does not provide a denial namespace
+for persisted knowledge, messaging, scheduling, or subagent capabilities.
+
+Therefore 1.1.17 cannot prove the predeclared formal boundary. The harness
+correctly exited `1` with `AGY_FORMAL_BOUNDARY BLOCKED`.
+
+## Disposition
+
+The Gemini formal cold-author/checker route remains blocked. No formal attempt
+may launch through this client merely because the model verbally declines a
+forbidden tool. A future client or route must make the committed preflight pass
+with an exact effective tool list and explicit context/memory/project
+disclosures, or the owner must approve a new plan. The cold-agent protocol,
+roster, brief, budgets, and evidence rules are unchanged.
+
+The offline harness proves a compliant fixture passes and rejects a forbidden
+tool, missing init event, wrong model, wrong worktree, missing context
+disclosure, reused conversation/context, and an unexpected tool call:
+
+```bash
+docs/evaluation/test-agy-formal-boundary-preflight.sh
+```

--- a/docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/project.json
+++ b/docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/project.json
@@ -1,0 +1,11 @@
+{
+  "id":  "9dab0c3c-2fb1-43d4-a594-4f46571d2b87",
+  "name":  "signed-world",
+  "projectResources":  {
+    "resources":  [
+      {
+        "folderUri":  "file:///work/signed-dev/src/signed-world"
+      }
+    ]
+  }
+}

--- a/docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/prompt.txt
+++ b/docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/prompt.txt
@@ -1,0 +1,1 @@
+Reply with exactly: formal boundary preflight. Do not call tools.

--- a/docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/transcript.txt
+++ b/docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/transcript.txt
@@ -1,0 +1,27 @@
+COMMAND docs/evaluation/agy-formal-boundary-preflight.sh
+EXIT 1
+
+STDERR
+Fetching available models...
+agy formal boundary preflight: BLOCKED: init event does not disclose the newly created project ID
+agy formal boundary preflight: BLOCKED: init event does not prove an empty context-source set
+agy formal boundary preflight: BLOCKED: init event does not prove persisted memory is disabled
+agy formal boundary preflight: BLOCKED: effective tools are not the exact protocol allowlist: ask_custom_permission,ask_permission,ask_question,browser_click_element,browser_drag_pixel_to_pixel,browser_get_dom,browser_get_network_request,browser_input,browser_list_network_requests,browser_mouse_down,browser_mouse_up,browser_move_mouse,browser_press_key,browser_refresh_page,browser_resize_window,browser_scroll,browser_scroll_dom,browser_select_option,browser_subagent,call_mcp_tool,capture_browser_console_logs,capture_browser_screenshot,click_browser_pixel,command_status,define_subagent,delete_knowledge,execute_browser_javascript,find_by_name,finish,generate_image,grep_search,invoke_subagent,list_browser_pages,list_dir,list_permissions,list_resources,manage_inbox,manage_subagents,manage_task,multi_replace_file_content,notebook_edit,notebook_execution,open_browser_url,read_browser_page,read_resource,read_url_content,replace_file_content,run_command,schedule,search_web,sed_file,send_command_input,send_message,view_file,wait,wait_5_seconds,write_to_file
+AGY_FORMAL_BOUNDARY BLOCKED
+
+STDOUT
+AGY_VERSION 1.1.17
+AGY_MODEL gemini-3.7-flash-high	Gemini 3.7 Flash (High)
+AGY_AGENT nomos-cold-subject d9b5004681113503f5411d5c28358d8710086e93796ed79426fd9356c4c17337
+AGY_WORKTREE /work/signed-dev/src/signed-world
+AGY_PROJECT 9dab0c3c-2fb1-43d4-a594-4f46571d2b87
+AGY_PROJECT_RECORD /work/signed-dev/.gemini/config/projects/9dab0c3c-2fb1-43d4-a594-4f46571d2b87.json
+AGY_CONVERSATION bf07f12b-859c-4072-bd14-1a80f7558152
+AGY_EVENTS_BEGIN
+{"event":"init","conversation_id":"bf07f12b-859c-4072-bd14-1a80f7558152","init":{"model":"gemini-3.7-flash-high","cwd":"/work/signed-dev/src/signed-world","agent":"nomos-cold-subject","tools":["ask_custom_permission","ask_permission","ask_question","browser_click_element","browser_drag_pixel_to_pixel","browser_get_dom","browser_get_network_request","browser_input","browser_list_network_requests","browser_mouse_down","browser_mouse_up","browser_move_mouse","browser_press_key","browser_refresh_page","browser_resize_window","browser_scroll","browser_scroll_dom","browser_select_option","browser_subagent","call_mcp_tool","capture_browser_console_logs","capture_browser_screenshot","click_browser_pixel","command_status","define_subagent","delete_knowledge","execute_browser_javascript","find_by_name","finish","generate_image","grep_search","invoke_subagent","list_browser_pages","list_dir","list_permissions","list_resources","manage_inbox","manage_subagents","manage_task","multi_replace_file_content","notebook_edit","notebook_execution","open_browser_url","read_browser_page","read_resource","read_url_content","replace_file_content","run_command","schedule","search_web","sed_file","send_command_input","send_message","view_file","wait","wait_5_seconds","write_to_file"],"permission_mode":"request-review"}}
+{"event":"step_update","step_update":{"conversation_id":"bf07f12b-859c-4072-bd14-1a80f7558152","step_index":0,"state":"DONE","step_type":"user_input"}}
+{"event":"step_update","step_update":{"conversation_id":"bf07f12b-859c-4072-bd14-1a80f7558152","step_index":1,"state":"DONE","step_type":"checkpoint","duration_seconds":1.218966135}}
+{"event":"step_update","step_update":{"conversation_id":"bf07f12b-859c-4072-bd14-1a80f7558152","step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"formal boundary preflight."}}
+{"event":"step_update","step_update":{"conversation_id":"bf07f12b-859c-4072-bd14-1a80f7558152","step_index":2,"state":"DONE","step_type":"agent_response","text_delta":"\n","duration_seconds":0.972189597,"usage":{"input_tokens":6239,"output_tokens":73,"thinking_tokens":68,"cache_read_tokens":0,"total_tokens":6312}}}
+{"event":"result","result":{"conversation_id":"bf07f12b-859c-4072-bd14-1a80f7558152","status":"SUCCESS","response":"formal boundary preflight.\n","duration_seconds":2.206313309,"num_turns":1,"usage":{"input_tokens":6239,"output_tokens":73,"thinking_tokens":68,"cache_read_tokens":0,"total_tokens":6312}}}
+AGY_EVENTS_END

--- a/docs/evaluation/test-agy-formal-boundary-preflight.sh
+++ b/docs/evaluation/test-agy-formal-boundary-preflight.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+preflight="$repo_root/docs/evaluation/agy-formal-boundary-preflight.sh"
+fake_agy="$repo_root/docs/evaluation/fixtures/fake-agy-formal-boundary"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf -- "$tmp_dir"' EXIT
+
+AGY_BIN="$fake_agy" "$preflight" >"$tmp_dir/pass.txt"
+grep -Fx 'AGY_FORMAL_BOUNDARY PASS' "$tmp_dir/pass.txt" >/dev/null
+
+assert_blocked() {
+  local mode=$1
+  local expected=$2
+  if FAKE_AGY_FORMAL_MODE="$mode" AGY_BIN="$fake_agy" \
+    "$preflight" >"$tmp_dir/$mode.out" 2>"$tmp_dir/$mode.err"; then
+    printf 'expected formal boundary mode %s to be blocked\n' "$mode" >&2
+    exit 1
+  fi
+  grep -F "$expected" "$tmp_dir/$mode.err" >/dev/null
+  grep -Fx 'AGY_FORMAL_BOUNDARY BLOCKED' "$tmp_dir/$mode.err" >/dev/null
+}
+
+assert_blocked forbidden-tool 'effective tools are not the exact protocol allowlist'
+assert_blocked missing-init 'expected exactly one init event, found 0'
+assert_blocked wrong-model 'init event does not pin gemini-3.7-flash-high'
+assert_blocked wrong-worktree 'init event cwd is not the target worktree'
+assert_blocked missing-context 'init event does not prove an empty context-source set'
+assert_blocked reused-context 'conversation is not a fresh one-turn session'
+assert_blocked tool-call 'neutral preflight unexpectedly executed 1 tool events'
+
+printf 'agy formal boundary harness: PASS\n'


### PR DESCRIPTION
Closes #45.

## Outcome

Antigravity CLI 1.1.17 is falsified as a currently eligible formal Nomos cold-agent route. A fresh project and conversation resolved the exact model, worktree, and custom agent, but the machine-readable init event exposed 57 tools instead of the declared three-tool allowlist and omitted the project, context-source, and memory disclosures required by the protocol.

No formal cold-author or cold-debug attempt was launched. This changes no contract, roster, brief, or attempt budget.

## Change

- add a declarative three-tool custom main agent with MCP/customization inheritance disabled
- add a fail-closed authenticated boundary preflight
- add an offline fixture and negative test matrix
- run the offline guard in CI
- preserve the sanitized exact probe receipt and project record
- record the blocked route in the Gate K plan and handoff

The active cold-agent protocol still names the prototype-era estate CLI. That separate identity-only contract repair is filed as #47 and is intentionally outside this PR.

## Author proof

Exact head: db064dd8928f06e66757b3a28af7dba94dceb2d4

Passed:

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- cargo xtask boundary
- docs/evaluation/test-agy-print-preflight.sh
- docs/evaluation/test-agy-formal-boundary-preflight.sh
- git diff --check

Authenticated negative proof on probe commit 7a2d5771edc60393dfe900788ee9f17281166b1f:

- docs/evaluation/agy-formal-boundary-preflight.sh exited 1
- emitted AGY_FORMAL_BOUNDARY BLOCKED
- rejected missing project/context/memory disclosure and the 57-tool effective catalog

The exact sanitized receipt is at docs/evaluation/runs/tooling/2026-08-22-agy-formal-boundary-falsification/.
