### PR TITLE
SW-H: expose validate, compile, and inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ any renderer is built.
 ## Status
 
 - **Architecture status:** exploratory and non-authoritative
-- **Implementation status:** implemented through SW-G: foundations, source and
+- **Implementation status:** implemented through SW-H: foundations, source and
   preserved construction IR, stable `nomos.world_ir@1`, compiled transitions,
   shared movement and light resolution, all four projections, immutable runtime
-  commits, and complete hash-verified world packages; no filesystem command
-  surface, replay, or migration
+  commits, complete hash-verified world packages, and the filesystem `validate`,
+  `compile`, and `inspect` commands; no filesystem runtime execution, replay, or
+  migration
 - **Contract revision:** 6, owner-authorized in decision 0007
 - **Cold-agent protocol revision:** 2, owner-authorized in decision 0008
 - **Scope:** greenfield / vacuum architecture exercise

--- a/crates/nomos-cli/src/command.rs
+++ b/crates/nomos-cli/src/command.rs
@@ -1,0 +1,272 @@
+//! Exact argument grammar and filesystem command orchestration.
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nomos_compiler::{compile_world_package, inspect_compiled_package};
+use nomos_core::package::MANIFEST_FILE;
+use nomos_core::{CanonicalValue, Diagnostic, RepairClass, SourcePath};
+
+use crate::{ExitCode, compile_and_write_world, render_rejection};
+
+const ROOT_HELP: &str = "Nomos Gate K filesystem authoring\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos --help\n";
+const VALIDATE_HELP: &str = "Validate one Nomos source file without writing artifacts.\n\nUsage:\n  nomos validate <source.nomos>\n";
+const COMPILE_HELP: &str = "Compile one Nomos source file into a new immutable world package.\n\nUsage:\n  nomos compile <source.nomos> --out <new.world/>\n";
+const INSPECT_HELP: &str =
+    "Inspect one verified immutable world package.\n\nUsage:\n  nomos inspect <world/>\n";
+
+/// One completed command-line execution, including its exact stdout bytes.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Execution {
+    exit: ExitCode,
+    stdout: Vec<u8>,
+}
+
+impl Execution {
+    /// Process exit classification.
+    #[must_use]
+    pub const fn exit(&self) -> ExitCode {
+        self.exit
+    }
+
+    /// Exact bytes to write to stdout.
+    #[must_use]
+    pub fn stdout(&self) -> &[u8] {
+        &self.stdout
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum Command {
+    Help(&'static str),
+    Validate { source: String },
+    Compile { source: String, output: String },
+    Inspect { package: String },
+}
+
+/// Parses and executes exactly one supported command.
+///
+/// Every handled result is returned as stdout bytes; callers do not need to
+/// interpret diagnostics or semantic report fields.
+#[must_use]
+pub fn execute(args: impl IntoIterator<Item = OsString>) -> Execution {
+    match parse(args) {
+        Ok(Command::Help(help)) => Execution {
+            exit: ExitCode::Completed,
+            stdout: help.as_bytes().to_vec(),
+        },
+        Ok(command) => execute_command(command),
+        Err(diagnostic) => rejected(ExitCode::InvalidUsage, &diagnostic),
+    }
+}
+
+fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Command, Diagnostic> {
+    let args = args
+        .into_iter()
+        .enumerate()
+        .map(|(index, argument)| {
+            argument.into_string().map_err(|_| {
+                usage(format!(
+                    "argument {} is not UTF-8 and cannot name a Nomos operation",
+                    index + 1
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let command = match args.as_slice() {
+        [only] if only == "--help" => Command::Help(ROOT_HELP),
+        [name, help] if name == "validate" && help == "--help" => Command::Help(VALIDATE_HELP),
+        [name, source] if name == "validate" && !is_option(source) => Command::Validate {
+            source: source.clone(),
+        },
+        [name, help] if name == "compile" && help == "--help" => Command::Help(COMPILE_HELP),
+        [name, source, option, output]
+            if name == "compile"
+                && !is_option(source)
+                && option == "--out"
+                && !is_option(output) =>
+        {
+            Command::Compile {
+                source: source.clone(),
+                output: output.clone(),
+            }
+        }
+        [name, help] if name == "inspect" && help == "--help" => Command::Help(INSPECT_HELP),
+        [name, package] if name == "inspect" && !is_option(package) => Command::Inspect {
+            package: package.clone(),
+        },
+        _ => {
+            return Err(usage(
+                "arguments do not match a supported Nomos command; use `nomos --help`",
+            ));
+        }
+    };
+    Ok(command)
+}
+
+fn is_option(argument: &str) -> bool {
+    argument.starts_with('-')
+}
+
+fn execute_command(command: Command) -> Execution {
+    let result = match command {
+        Command::Help(_) => unreachable!("help is returned before command execution"),
+        Command::Validate { source } => validate(&source),
+        Command::Compile { source, output } => compile(&source, &output),
+        Command::Inspect { package } => inspect(&package),
+    };
+    match result {
+        Ok(value) => completed(value),
+        Err(diagnostic) => rejected(ExitCode::for_diagnostic(&diagnostic), &diagnostic),
+    }
+}
+
+fn validate(source: &str) -> Result<CanonicalValue, Diagnostic> {
+    let source_path = SourcePath::new(source)?;
+    let text = read_source(source)?;
+    let compiled = compile_world_package(&text, source_path)?;
+    compiled.validate_artifacts()?;
+    let artifacts = compiled
+        .members()?
+        .into_iter()
+        .map(|(name, _)| CanonicalValue::text(name.as_str()))
+        .collect();
+    Ok(CanonicalValue::object_declared([
+        ("artifacts", CanonicalValue::Array(artifacts)),
+        ("command", CanonicalValue::text("validate")),
+        ("source", CanonicalValue::text(source)),
+        ("status", CanonicalValue::text("completed")),
+        (
+            "world_ir_schema",
+            compiled.stable_ir().schema().to_canonical(),
+        ),
+    ]))
+}
+
+fn compile(source: &str, output: &str) -> Result<CanonicalValue, Diagnostic> {
+    let source_path = SourcePath::new(source)?;
+    let output_path = relative_filesystem_path(output)?;
+    let text = read_source(source)?;
+    let package = compile_and_write_world(&text, source_path, &output_path)?;
+    let artifacts = std::iter::once(MANIFEST_FILE)
+        .chain(
+            package
+                .manifest()
+                .members()
+                .iter()
+                .map(|record| record.name().as_str()),
+        )
+        .map(|name| CanonicalValue::text(artifact_path(output, name)))
+        .collect();
+    Ok(CanonicalValue::object_declared([
+        ("artifacts", CanonicalValue::Array(artifacts)),
+        ("command", CanonicalValue::text("compile")),
+        (
+            "manifest_digest",
+            CanonicalValue::text(package.manifest().digest().to_hex()),
+        ),
+        ("output", CanonicalValue::text(output)),
+        ("source", CanonicalValue::text(source)),
+        ("status", CanonicalValue::text("completed")),
+    ]))
+}
+
+fn inspect(package: &str) -> Result<CanonicalValue, Diagnostic> {
+    let package = relative_filesystem_path(package)?;
+    inspect_compiled_package(&package)
+}
+
+fn read_source(source: &str) -> Result<String, Diagnostic> {
+    let path = Path::new(source);
+    let metadata = fs::metadata(path).map_err(|error| io_failure(path, &error))?;
+    if !metadata.is_file() {
+        return Err(Diagnostic::new(
+            nomos_core::diagnostic::codes::CLI_IO,
+            format!("`{source}` is not a regular source file"),
+        ));
+    }
+    let bytes = fs::read(path).map_err(|error| io_failure(path, &error))?;
+    String::from_utf8(bytes).map_err(|_| {
+        Diagnostic::new(
+            nomos_core::diagnostic::codes::CLI_SOURCE_ENCODING,
+            format!("source `{source}` is not UTF-8 text"),
+        )
+        .with_repair(RepairClass::FixSourceSyntax)
+    })
+}
+
+fn relative_filesystem_path(spelling: &str) -> Result<PathBuf, Diagnostic> {
+    let rejected = spelling.is_empty()
+        || spelling.starts_with('/')
+        || spelling.starts_with('\\')
+        || spelling.split(['/', '\\']).any(|segment| segment == "..")
+        || spelling.as_bytes().get(1) == Some(&b':');
+    if rejected {
+        return Err(Diagnostic::new(
+            nomos_core::diagnostic::codes::CLI_PATH_NOT_RELATIVE,
+            format!("filesystem path `{spelling}` is not a safe relative spelling"),
+        )
+        .with_repair(RepairClass::UseSupportedIdentifierShape));
+    }
+    Ok(PathBuf::from(spelling))
+}
+
+fn artifact_path(root: &str, member: &str) -> String {
+    format!("{}/{member}", root.trim_end_matches(['/', '\\']))
+}
+
+fn usage(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(nomos_core::diagnostic::codes::CLI_USAGE, message)
+}
+
+fn io_failure(path: &Path, error: &std::io::Error) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::CLI_IO,
+        format!("`{}`: {error}", path.display()),
+    )
+}
+
+fn completed(value: CanonicalValue) -> Execution {
+    let mut stdout = value.to_canonical_bytes();
+    stdout.push(b'\n');
+    Execution {
+        exit: ExitCode::Completed,
+        stdout,
+    }
+}
+
+fn rejected(exit: ExitCode, diagnostic: &Diagnostic) -> Execution {
+    let mut stdout = render_rejection(diagnostic).into_bytes();
+    stdout.push(b'\n');
+    Execution { exit, stdout }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grammar_is_exact_and_future_commands_are_unknown() {
+        for args in [
+            vec![],
+            vec!["run"],
+            vec!["--version"],
+            vec!["validate", "--help", "extra"],
+            vec!["compile", "source.nomos", "--out=build/world"],
+            vec!["compile", "--out", "build/world", "source.nomos"],
+            vec!["inspect", "--", "build/world"],
+        ] {
+            let execution = execute(args.into_iter().map(OsString::from));
+            assert_eq!(execution.exit(), ExitCode::InvalidUsage);
+            assert!(execution.stdout().starts_with(b"{\"diagnostics\":"));
+        }
+    }
+
+    #[test]
+    fn help_is_the_only_plain_text_output() {
+        let help = execute([OsString::from("--help")]);
+        assert_eq!(help.exit(), ExitCode::Completed);
+        assert_eq!(help.stdout(), ROOT_HELP.as_bytes());
+    }
+}

--- a/crates/nomos-cli/src/lib.rs
+++ b/crates/nomos-cli/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! `KERNEL.md` section 10 assigns this crate *command-line surface and artifact
 //! orchestration*, and section 8 fixes the exit codes every command must use.
-//! SW-B lands the exit-code contract and the boundary; the commands themselves
-//! (`validate`, `compile`, `inspect`, `run`, `command`, `explain-entity`,
-//! `explain-transition`, `replay`, `migrate`) belong to later slices.
+//! SW-H implements the filesystem-authoring commands (`validate`, `compile`,
+//! and `inspect`) over that boundary. Runtime execution, explanation, replay,
+//! and migration commands belong to later accepted slices.
 //!
 //! # Boundary
 //!
@@ -31,8 +31,10 @@
 
 use nomos_core::Diagnostic;
 
+mod command;
 mod package;
 
+pub use command::{Execution, execute};
 pub use package::{
     compile_and_write_world, initial_state_from_package, open_compiled_world, write_compiled_world,
 };
@@ -64,12 +66,15 @@ impl ExitCode {
 
     /// Classifies a diagnostic.
     ///
-    /// A diagnostic in the package I/O range means the environment refused the
-    /// work rather than the world being wrong, which section 8 separates: a
-    /// full disk is not a rejected world.
+    /// A package or CLI I/O diagnostic means the environment refused the work
+    /// rather than the world being wrong, which section 8 separates: a missing
+    /// source or full disk is not a rejected world.
     #[must_use]
     pub fn for_diagnostic(diagnostic: &Diagnostic) -> Self {
-        if diagnostic.code() == nomos_core::diagnostic::codes::PACKAGE_IO {
+        if matches!(
+            diagnostic.code(),
+            nomos_core::diagnostic::codes::PACKAGE_IO | nomos_core::diagnostic::codes::CLI_IO
+        ) {
             Self::Environment
         } else {
             Self::Rejected
@@ -111,8 +116,10 @@ mod tests {
     #[test]
     fn an_io_failure_is_an_environment_failure_not_a_rejected_world() {
         let io = Diagnostic::new(codes::PACKAGE_IO, "disk full");
+        let source_io = Diagnostic::new(codes::CLI_IO, "source missing");
         let world = Diagnostic::new(codes::PACKAGE_MEMBER_HASH_MISMATCH, "tampered");
         assert_eq!(ExitCode::for_diagnostic(&io), ExitCode::Environment);
+        assert_eq!(ExitCode::for_diagnostic(&source_io), ExitCode::Environment);
         assert_eq!(ExitCode::for_diagnostic(&world), ExitCode::Rejected);
     }
 

--- a/crates/nomos-cli/src/main.rs
+++ b/crates/nomos-cli/src/main.rs
@@ -1,33 +1,15 @@
 //! The `nomos` binary.
 //!
-//! `KERNEL.md` section 8 defines nine commands. None of them exist yet: SW-B
-//! builds the workspace, identity, encoding, and package mechanics they will
-//! stand on. Rather than pretend, the binary reports its own state and exits
-//! `2` (invalid usage) for anything asked of it.
+//! SW-H exposes the Gate K filesystem-authoring commands while leaving runtime,
+//! replay, migration, and explanation commands for their accepted slices.
 
+use std::io::{self, Write};
 use std::process::ExitCode as ProcessExitCode;
 
-use nomos_cli::ExitCode;
-use nomos_core::CanonicalValue;
-
 fn main() -> ProcessExitCode {
-    let requested: Vec<String> = std::env::args().skip(1).collect();
-    let report = CanonicalValue::object_declared([
-        ("implemented_commands", CanonicalValue::Array(Vec::new())),
-        (
-            "message",
-            CanonicalValue::text(
-                "the nomos command surface is defined in KERNEL.md section 8 and \
-                 implemented by a later slice; SW-B provides the workspace, stable \
-                 IDs, canonical encoding, hashing, and package mechanics",
-            ),
-        ),
-        (
-            "requested",
-            CanonicalValue::Array(requested.iter().map(CanonicalValue::text).collect()),
-        ),
-        ("status", CanonicalValue::text("not_implemented")),
-    ]);
-    println!("{}", String::from_utf8_lossy(&report.to_canonical_bytes()));
-    ProcessExitCode::from(u8::try_from(ExitCode::InvalidUsage.code()).unwrap_or(2))
+    let execution = nomos_cli::execute(std::env::args_os().skip(1));
+    if io::stdout().write_all(execution.stdout()).is_err() {
+        return ProcessExitCode::from(3);
+    }
+    ProcessExitCode::from(u8::try_from(execution.exit().code()).unwrap_or(3))
 }

--- a/crates/nomos-cli/src/package.rs
+++ b/crates/nomos-cli/src/package.rs
@@ -28,8 +28,7 @@ pub fn compile_and_write_world(
 }
 
 /// Publishes a complete compiled world through the generic immutable package
-/// boundary. This is a library operation; the filesystem CLI remains a later
-/// slice.
+/// boundary used by the filesystem `compile` command.
 ///
 /// # Errors
 ///

--- a/crates/nomos-cli/tests/sw_h_cli.rs
+++ b/crates/nomos-cli/tests/sw_h_cli.rs
@@ -1,0 +1,315 @@
+//! SW-H end-to-end proof for the filesystem authoring CLI.
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use nomos_core::CanonicalValue;
+use nomos_core::canonical::read::parse_canonical;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+const SOURCE: &[u8] = include_bytes!("../../../fixtures/gaol.nomos");
+
+fn fresh_workspace(label: &str) -> PathBuf {
+    let index = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+        .join("sw-h-cli")
+        .join(format!("{}-{nonce}-{label}-{index}", std::process::id()));
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("gaol.nomos"), SOURCE).unwrap();
+    root
+}
+
+fn run<I, S>(cwd: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new(env!("CARGO_BIN_EXE_nomos"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap()
+}
+
+fn assert_exit(output: &Output, expected: i32) {
+    assert_eq!(output.status.code(), Some(expected));
+    assert!(output.stderr.is_empty());
+}
+
+fn canonical_stdout(output: &Output) -> CanonicalValue {
+    assert_eq!(output.stdout.last(), Some(&b'\n'));
+    assert_ne!(
+        output.stdout.get(output.stdout.len().saturating_sub(2)),
+        Some(&b'\n')
+    );
+    parse_canonical(&output.stdout[..output.stdout.len() - 1]).unwrap()
+}
+
+fn object(
+    value: &CanonicalValue,
+) -> &std::collections::BTreeMap<nomos_core::FieldName, CanonicalValue> {
+    let CanonicalValue::Object(fields) = value else {
+        panic!("expected canonical object")
+    };
+    fields
+}
+
+fn field<'a>(value: &'a CanonicalValue, name: &'static str) -> &'a CanonicalValue {
+    object(value)
+        .get(&nomos_core::FieldName::declared(name))
+        .unwrap()
+}
+
+fn package_bytes(root: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut rows = fs::read_dir(root)
+        .unwrap()
+        .map(|entry| {
+            let entry = entry.unwrap();
+            (
+                entry.file_name().into_string().unwrap(),
+                fs::read(entry.path()).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.0.cmp(&right.0));
+    rows
+}
+
+#[test]
+fn exact_help_and_usage_are_stable() {
+    let cwd = fresh_workspace("grammar");
+    for args in [
+        vec!["--help"],
+        vec!["validate", "--help"],
+        vec!["compile", "--help"],
+        vec!["inspect", "--help"],
+    ] {
+        let first = run(&cwd, &args);
+        let second = run(&cwd, &args);
+        assert_exit(&first, 0);
+        assert_eq!(first.stdout, second.stdout);
+        assert!(!first.stdout.starts_with(b"{"));
+    }
+
+    for args in [
+        vec![],
+        vec!["run"],
+        vec!["--version"],
+        vec!["validate"],
+        vec!["validate", "--help", "gaol.nomos"],
+        vec!["compile", "gaol.nomos", "--out=one.world"],
+        vec!["compile", "--out", "one.world", "gaol.nomos"],
+        vec!["inspect", "--", "one.world"],
+    ] {
+        let output = run(&cwd, &args);
+        assert_exit(&output, 2);
+        let value = canonical_stdout(&output);
+        assert_eq!(field(&value, "status"), &CanonicalValue::text("rejected"));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn non_utf8_argv_is_invalid_usage_without_lossy_echo() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let cwd = fresh_workspace("non-utf8-argv");
+    let output = run(
+        &cwd,
+        [OsString::from("validate"), OsString::from_vec(vec![0xff])],
+    );
+    assert_exit(&output, 2);
+    let value = canonical_stdout(&output);
+    assert_eq!(
+        field(&value, "diagnostics"),
+        &CanonicalValue::Array(vec![CanonicalValue::object_declared([
+            ("code", CanonicalValue::text("EK0001")),
+            (
+                "message",
+                CanonicalValue::text("argument 2 is not UTF-8 and cannot name a Nomos operation",),
+            ),
+            ("repairs", CanonicalValue::Array(Vec::new())),
+        ])])
+    );
+}
+
+#[test]
+fn validate_compile_and_inspect_are_immutable_and_deterministic() {
+    let cwd = fresh_workspace("roundtrip");
+    let source_before = fs::read(cwd.join("gaol.nomos")).unwrap();
+    let entries_before = fs::read_dir(&cwd).unwrap().count();
+
+    let first_validate = run(&cwd, ["validate", "gaol.nomos"]);
+    let second_validate = run(&cwd, ["validate", "gaol.nomos"]);
+    assert_exit(&first_validate, 0);
+    assert_eq!(first_validate.stdout, second_validate.stdout);
+    let validated = canonical_stdout(&first_validate);
+    assert_eq!(
+        field(&validated, "command"),
+        &CanonicalValue::text("validate")
+    );
+    assert_eq!(fs::read_dir(&cwd).unwrap().count(), entries_before);
+
+    let first_compile = run(
+        &cwd,
+        ["compile", "gaol.nomos", "--out", "build/first.world"],
+    );
+    let second_compile = run(
+        &cwd,
+        ["compile", "gaol.nomos", "--out", "build/second.world"],
+    );
+    assert_exit(&first_compile, 0);
+    assert_exit(&second_compile, 0);
+    let first_result = canonical_stdout(&first_compile);
+    let second_result = canonical_stdout(&second_compile);
+    assert_eq!(
+        field(&first_result, "manifest_digest"),
+        field(&second_result, "manifest_digest")
+    );
+    assert_eq!(
+        package_bytes(&cwd.join("build/first.world")),
+        package_bytes(&cwd.join("build/second.world"))
+    );
+
+    let first_inspect = run(&cwd, ["inspect", "build/first.world"]);
+    let second_inspect = run(&cwd, ["inspect", "build/first.world"]);
+    assert_exit(&first_inspect, 0);
+    assert_eq!(first_inspect.stdout, second_inspect.stdout);
+    let inspection = canonical_stdout(&first_inspect);
+    let CanonicalValue::Array(entities) = field(&inspection, "entities") else {
+        panic!("inspection entities must be an array")
+    };
+    assert_eq!(entities.len(), 3);
+    assert_eq!(
+        field(&entities[0], "id"),
+        &CanonicalValue::text("brazier_02")
+    );
+    assert_eq!(
+        field(&entities[1], "id"),
+        &CanonicalValue::text("flooded_section")
+    );
+    assert_eq!(
+        field(&entities[2], "id"),
+        &CanonicalValue::text("north_gate")
+    );
+    for entity in entities {
+        for name in ["primitive", "source", "capabilities", "machines", "claims"] {
+            let _ = field(entity, name);
+        }
+    }
+
+    assert_eq!(fs::read(cwd.join("gaol.nomos")).unwrap(), source_before);
+    assert!(fs::read_dir(cwd.join("build")).unwrap().all(|entry| {
+        !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains(".staging-")
+    }));
+}
+
+#[test]
+fn semantic_usage_and_environment_failures_use_distinct_exits() {
+    let cwd = fresh_workspace("failures");
+
+    let missing_source = run(&cwd, ["validate", "missing.nomos"]);
+    assert_exit(&missing_source, 3);
+    assert_eq!(
+        field(&canonical_stdout(&missing_source), "status"),
+        &CanonicalValue::text("rejected")
+    );
+
+    fs::create_dir(cwd.join("source-directory")).unwrap();
+    let source_directory = run(&cwd, ["validate", "source-directory"]);
+    assert_exit(&source_directory, 3);
+
+    fs::write(cwd.join("non-utf8.nomos"), [0xff]).unwrap();
+    let non_utf8_source = run(&cwd, ["validate", "non-utf8.nomos"]);
+    assert_exit(&non_utf8_source, 1);
+
+    let escaped_source = run(&cwd, ["validate", "../gaol.nomos"]);
+    assert_exit(&escaped_source, 1);
+    let escaped_output = run(&cwd, ["compile", "gaol.nomos", "--out", "../escaped.world"]);
+    assert_exit(&escaped_output, 1);
+
+    fs::write(cwd.join("invalid.nomos"), b"not nomos source\n").unwrap();
+    let invalid_compile = run(
+        &cwd,
+        ["compile", "invalid.nomos", "--out", "build/rejected.world"],
+    );
+    assert_exit(&invalid_compile, 1);
+    assert!(!cwd.join("build/rejected.world").exists());
+    assert!(
+        !cwd.join("build").exists()
+            || fs::read_dir(cwd.join("build")).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains(".staging-"))
+    );
+
+    let missing_package = run(&cwd, ["inspect", "missing.world"]);
+    assert_exit(&missing_package, 1);
+}
+
+#[test]
+fn tampering_extra_entries_and_existing_outputs_fail_closed() {
+    let cwd = fresh_workspace("immutability");
+    let compile = run(
+        &cwd,
+        ["compile", "gaol.nomos", "--out", "build/evidence.world"],
+    );
+    assert_exit(&compile, 0);
+
+    let existing = cwd.join("build/existing.world");
+    fs::create_dir(&existing).unwrap();
+    fs::write(existing.join("sentinel"), b"do not replace").unwrap();
+    let before = package_bytes(&existing);
+    let rejected = run(
+        &cwd,
+        ["compile", "gaol.nomos", "--out", "build/existing.world"],
+    );
+    assert_exit(&rejected, 1);
+    assert_eq!(package_bytes(&existing), before);
+
+    let world = cwd.join("build/evidence.world");
+    fs::write(world.join("extra.json"), b"{}").unwrap();
+    let extra = run(&cwd, ["inspect", "build/evidence.world"]);
+    assert_exit(&extra, 1);
+    fs::remove_file(world.join("extra.json")).unwrap();
+
+    let mut bytes = fs::read(world.join("world-ir.json")).unwrap();
+    bytes.push(b'\n');
+    fs::write(world.join("world-ir.json"), bytes).unwrap();
+    let tampered = run(&cwd, ["inspect", "build/evidence.world"]);
+    assert_exit(&tampered, 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn source_symlinks_are_followed_but_package_root_symlinks_are_refused() {
+    use std::os::unix::fs::symlink;
+
+    let cwd = fresh_workspace("symlinks");
+    symlink("gaol.nomos", cwd.join("source-link.nomos")).unwrap();
+    let validate = run(&cwd, ["validate", "source-link.nomos"]);
+    assert_exit(&validate, 0);
+    assert_eq!(
+        field(&canonical_stdout(&validate), "source"),
+        &CanonicalValue::text("source-link.nomos")
+    );
+
+    let compile = run(&cwd, ["compile", "gaol.nomos", "--out", "evidence.world"]);
+    assert_exit(&compile, 0);
+    symlink("evidence.world", cwd.join("alias.world")).unwrap();
+    let inspect = run(&cwd, ["inspect", "alias.world"]);
+    assert_exit(&inspect, 1);
+}

--- a/crates/nomos-compiler/src/inspect.rs
+++ b/crates/nomos-compiler/src/inspect.rs
@@ -1,0 +1,298 @@
+//! Compiler-owned inspection of verified compiled-world packages.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use nomos_core::{
+    CanonicalValue, ClaimRef, Diagnostic, EntityId, FieldName, Ident, NamespaceId, PrimitiveKindId,
+    RepairClass, SourcePath,
+};
+
+use crate::{OpenedCompiledWorld, open_compiled_package};
+
+/// Opens and fully validates a compiled-world package, then returns the flat
+/// deterministic report used by `nomos inspect`.
+///
+/// The returned value is deliberately self-contained. Callers serialize it as
+/// an opaque canonical value and never need to name or decode World IR fields.
+///
+/// # Errors
+///
+/// Returns the first package integrity, semantic-package, or inspection-shape
+/// diagnostic. No report is returned for partial or disagreeing evidence.
+pub fn inspect_compiled_package(root: &Path) -> Result<CanonicalValue, Diagnostic> {
+    let opened = open_compiled_package(root)?;
+    inspection_report(&opened)
+}
+
+fn inspection_report(opened: &OpenedCompiledWorld) -> Result<CanonicalValue, Diagnostic> {
+    // The report is derived only after complete typed rehydration and exact
+    // reprojection. Rendering the authoritative type back to its canonical
+    // value preserves the complete nested machine and claim shapes without
+    // creating another persisted-package decoder.
+    let stable_ir = opened.stable_ir().to_canonical();
+    let world = object(&stable_ir, "World IR")?;
+    let entities = array(field(world, "entities")?, "World IR entities")?;
+    let mut previous_id: Option<String> = None;
+    let inspected = entities
+        .iter()
+        .map(|entity| inspect_entity(entity, &mut previous_id))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(CanonicalValue::object_declared([
+        ("command", CanonicalValue::text("inspect")),
+        (
+            "compiler_version",
+            field(world, "compiler_version")?.clone(),
+        ),
+        (
+            "construction_schema",
+            field(world, "construction_schema")?.clone(),
+        ),
+        ("entities", CanonicalValue::Array(inspected)),
+        (
+            "manifest_digest",
+            CanonicalValue::text(opened.package_digest().to_hex()),
+        ),
+        ("package_schema", opened.manifest().schema().to_canonical()),
+        (
+            "primitive_catalog_version",
+            field(world, "primitive_catalog_version")?.clone(),
+        ),
+        ("status", CanonicalValue::text("completed")),
+        ("world_ir_schema", field(world, "schema")?.clone()),
+    ]))
+}
+
+fn inspect_entity(
+    value: &CanonicalValue,
+    previous_id: &mut Option<String>,
+) -> Result<CanonicalValue, Diagnostic> {
+    let fields = object(value, "World IR entity")?;
+    require_exact_fields(
+        fields,
+        &[
+            "binding",
+            "credential",
+            "expansion",
+            "id",
+            "primitive",
+            "source",
+        ],
+        "World IR entity",
+    )?;
+    let id = text(field(fields, "id")?, "entity id")?;
+    let entity_id = EntityId::parse(id).map_err(|error| invalid(error.message()))?;
+    if previous_id
+        .as_ref()
+        .is_some_and(|previous| previous.as_str() >= id)
+    {
+        return Err(invalid(
+            "World IR entities are not in strict stable-ID order",
+        ));
+    }
+    *previous_id = Some(id.to_owned());
+
+    let primitive = text(field(fields, "primitive")?, "entity primitive")?;
+    let primitive_id =
+        PrimitiveKindId::parse(primitive).map_err(|error| invalid(error.message()))?;
+    if crate::catalog::lookup(&primitive_id).is_none() {
+        return Err(invalid(format!(
+            "entity `{id}` names unsupported primitive `{primitive}`"
+        )));
+    }
+    let source = object(field(fields, "source")?, "entity source mapping")?;
+    require_exact_fields(
+        source,
+        &["byte_end", "byte_start", "column", "line", "path"],
+        "entity source mapping",
+    )?;
+    validate_source_mapping(source)?;
+    let expansion = object(field(fields, "expansion")?, "primitive expansion")?;
+    require_exact_fields(
+        expansion,
+        &["capabilities", "claims", "interactions", "machines"],
+        "primitive expansion",
+    )?;
+
+    let capabilities = text_array(field(expansion, "capabilities")?, "capabilities")?;
+    let machines = ordered_object_array(
+        field(expansion, "machines")?,
+        "machines",
+        "namespace",
+        &["initial", "namespace", "states", "transitions"],
+    )?;
+    for machine in &machines {
+        let machine = object(machine, "machine")?;
+        let namespace = NamespaceId::parse(text(field(machine, "namespace")?, "namespace")?)
+            .map_err(|error| invalid(error.message()))?;
+        if namespace.entity() != &entity_id {
+            return Err(invalid(format!(
+                "machine `{namespace}` does not belong to entity `{id}`"
+            )));
+        }
+        let states = text_array(field(machine, "states")?, "machine states")?;
+        let mut state_names = std::collections::BTreeSet::new();
+        for state in &states {
+            let name = Ident::new(text(state, "machine state")?)
+                .map_err(|error| invalid(error.message()))?;
+            if !state_names.insert(name) {
+                return Err(invalid(format!("machine `{namespace}` repeats a state")));
+            }
+        }
+        array(field(machine, "transitions")?, "machine transitions")?;
+        let initial = Ident::new(text(field(machine, "initial")?, "machine initial state")?)
+            .map_err(|error| invalid(error.message()))?;
+        if !state_names.contains(&initial) {
+            return Err(invalid(format!(
+                "machine `{namespace}` initial state is absent from its states"
+            )));
+        }
+    }
+    let claims = ordered_object_array(
+        field(expansion, "claims")?,
+        "claims",
+        "id",
+        &["activation", "capability", "id", "value"],
+    )?;
+    for claim in &claims {
+        let claim = object(claim, "claim")?;
+        let claim_id = ClaimRef::parse(text(field(claim, "id")?, "claim id")?)
+            .map_err(|error| invalid(error.message()))?;
+        if claim_id.namespace().entity() != &entity_id {
+            return Err(invalid(format!(
+                "claim `{claim_id}` does not belong to entity `{id}`"
+            )));
+        }
+        let capability = text(field(claim, "capability")?, "claim capability")?;
+        if claim_id.capability().as_str() != capability {
+            return Err(invalid(format!(
+                "claim `{claim_id}` capability disagrees with `{capability}`"
+            )));
+        }
+    }
+
+    Ok(CanonicalValue::object_declared([
+        ("capabilities", CanonicalValue::Array(capabilities)),
+        ("claims", CanonicalValue::Array(claims)),
+        ("id", CanonicalValue::text(id)),
+        ("machines", CanonicalValue::Array(machines)),
+        ("primitive", CanonicalValue::text(primitive)),
+        ("source", CanonicalValue::Object(source.clone())),
+    ]))
+}
+
+fn ordered_object_array(
+    value: &CanonicalValue,
+    label: &str,
+    identity: &'static str,
+    expected_fields: &[&str],
+) -> Result<Vec<CanonicalValue>, Diagnostic> {
+    let rows = array(value, label)?;
+    let mut previous: Option<String> = None;
+    let mut inspected = Vec::with_capacity(rows.len());
+    for row in rows {
+        let fields = object(row, label)?;
+        require_exact_fields(fields, expected_fields, label)?;
+        let current = text(field(fields, identity)?, label)?;
+        if previous
+            .as_ref()
+            .is_some_and(|previous| previous.as_str() >= current)
+        {
+            return Err(invalid(format!(
+                "{label} are not in strict `{identity}` order"
+            )));
+        }
+        previous = Some(current.to_owned());
+        inspected.push(CanonicalValue::Object(fields.clone()));
+    }
+    Ok(inspected)
+}
+
+fn text_array(value: &CanonicalValue, label: &str) -> Result<Vec<CanonicalValue>, Diagnostic> {
+    let rows = array(value, label)?;
+    for row in rows {
+        text(row, label)?;
+    }
+    Ok(rows.to_vec())
+}
+
+fn validate_source_mapping(fields: &BTreeMap<FieldName, CanonicalValue>) -> Result<(), Diagnostic> {
+    SourcePath::new(text(field(fields, "path")?, "source path")?)
+        .map_err(|error| invalid(error.message()))?;
+    let start = unsigned(field(fields, "byte_start")?, "source byte start")?;
+    let end = unsigned(field(fields, "byte_end")?, "source byte end")?;
+    let line = unsigned(field(fields, "line")?, "source line")?;
+    let column = unsigned(field(fields, "column")?, "source column")?;
+    if start > end || line == 0 || column == 0 {
+        return Err(invalid("entity source mapping is not a valid source span"));
+    }
+    Ok(())
+}
+
+fn unsigned(value: &CanonicalValue, label: &str) -> Result<u64, Diagnostic> {
+    match value {
+        CanonicalValue::Uint(value) => Ok(*value),
+        CanonicalValue::Int(value) => {
+            u64::try_from(*value).map_err(|_| invalid(format!("{label} is negative")))
+        }
+        _ => Err(invalid(format!("{label} is not an integer"))),
+    }
+}
+
+fn field<'a>(
+    fields: &'a BTreeMap<FieldName, CanonicalValue>,
+    name: &'static str,
+) -> Result<&'a CanonicalValue, Diagnostic> {
+    fields
+        .get(&FieldName::declared(name))
+        .ok_or_else(|| invalid(format!("inspection input has no `{name}` field")))
+}
+
+fn object<'a>(
+    value: &'a CanonicalValue,
+    label: &str,
+) -> Result<&'a BTreeMap<FieldName, CanonicalValue>, Diagnostic> {
+    let CanonicalValue::Object(fields) = value else {
+        return Err(invalid(format!("{label} is not an object")));
+    };
+    Ok(fields)
+}
+
+fn array<'a>(value: &'a CanonicalValue, label: &str) -> Result<&'a [CanonicalValue], Diagnostic> {
+    let CanonicalValue::Array(rows) = value else {
+        return Err(invalid(format!("{label} is not an array")));
+    };
+    Ok(rows)
+}
+
+fn text<'a>(value: &'a CanonicalValue, label: &str) -> Result<&'a str, Diagnostic> {
+    let CanonicalValue::Text(value) = value else {
+        return Err(invalid(format!("{label} is not text")));
+    };
+    Ok(value)
+}
+
+fn require_exact_fields(
+    fields: &BTreeMap<FieldName, CanonicalValue>,
+    expected: &[&str],
+    label: &str,
+) -> Result<(), Diagnostic> {
+    let actual = fields.keys().map(FieldName::as_str).collect::<Vec<_>>();
+    let mut expected = expected.to_vec();
+    expected.sort_unstable();
+    if actual != expected {
+        return Err(invalid(format!(
+            "{label} fields are {actual:?}; expected {expected:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn invalid(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::PACKAGE_MEMBER_SCHEMA_INVALID,
+        message,
+    )
+    .with_repair(RepairClass::RebuildFromSource)
+}

--- a/crates/nomos-compiler/src/lib.rs
+++ b/crates/nomos-compiler/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod catalog;
 pub mod diagnostics;
+mod inspect;
 mod linker;
 mod opened;
 mod package;
@@ -24,6 +25,7 @@ use nomos_core::{Diagnostic, SchemaId, SourcePath};
 pub use nomos_projection::{DiagnosticsPlan, NavigationPlan, PersistencePlan, SimulationPlan};
 use nomos_schema::{SourceDocument, StableWorldIr, WorldIr};
 
+pub use inspect::inspect_compiled_package;
 pub use opened::{OpenedCompiledWorld, open_compiled_package, validate_compiled_package};
 pub use package::{CompiledWorld, compile_world_package, compiler_receipts_schema};
 

--- a/crates/nomos-core/src/diagnostic.rs
+++ b/crates/nomos-core/src/diagnostic.rs
@@ -18,6 +18,7 @@ use crate::canonical::{CanonicalValue, FieldName};
 ///
 /// | Range | Area |
 /// | --- | --- |
+/// | `EK00xx` | command-line usage and host input |
 /// | `EK01xx` | identifiers and stable IDs |
 /// | `EK02xx` | checked arithmetic |
 /// | `EK03xx` | canonical encoding |
@@ -377,6 +378,15 @@ impl std::error::Error for Diagnostic {}
 pub mod codes {
     use super::DiagnosticCode;
 
+    /// The command-line argument vector does not name one supported operation.
+    pub const CLI_USAGE: DiagnosticCode = DiagnosticCode::new("EK0001");
+    /// A command-line filesystem path is not a safe relative spelling.
+    pub const CLI_PATH_NOT_RELATIVE: DiagnosticCode = DiagnosticCode::new("EK0002");
+    /// Source bytes are not UTF-8 text.
+    pub const CLI_SOURCE_ENCODING: DiagnosticCode = DiagnosticCode::new("EK0003");
+    /// A host filesystem operation failed before semantic work could complete.
+    pub const CLI_IO: DiagnosticCode = DiagnosticCode::new("EK0004");
+
     /// An identifier segment is empty or uses unsupported characters.
     pub const IDENT_UNSUPPORTED: DiagnosticCode = DiagnosticCode::new("EK0101");
     /// A source path is absolute, empty, or escapes the repository root.
@@ -509,6 +519,10 @@ pub mod codes {
 
     /// Every code this crate owns, for well-formedness and uniqueness tests.
     pub const ALL: &[DiagnosticCode] = &[
+        CLI_USAGE,
+        CLI_PATH_NOT_RELATIVE,
+        CLI_SOURCE_ENCODING,
+        CLI_IO,
         IDENT_UNSUPPORTED,
         SOURCE_PATH_NOT_RELATIVE,
         SOURCE_SPAN_INVALID,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,7 +1,8 @@
 # Handoff — state of the repository
 
-Updated 2026-08-22 for the issue #54 SW-G semantic-open repair.
-Issue #52 / draft PR #53 remains the next feature slice after this repair.
+Updated 2026-08-22 for the issue #52 filesystem-authoring CLI integration.
+The SW-G semantic-open repair is merged; SW-H is rebased onto that boundary and
+its refreshed proof and exact-head disposition remain pending.
 This file orients a fresh session; it is rewritten at each slice boundary and
 never accumulates history (git has that).
 
@@ -107,8 +108,9 @@ never accumulates history (git has that).
   changes the active default tool wording from the published `estate` CLI to
   the published `nomos` CLI. Tool scope, packet boundaries, budgets, rubric,
   roster, attempt accounting, existing verdicts, and immutable prototype-era
-  receipts do not change. The revision becomes effective when this change
-  merges; no formal cold-agent attempt is launched by it.
+  receipts do not change. PR #51 merged as `795791e`, issue #47 closed, its
+  exact-head Luna rerun and CI passed, and no formal cold-agent attempt was
+  launched by it.
 - **CI uses `actions/checkout@v7` (#11):** PR and post-merge verification passed
   without the Node 20 compatibility annotation.
 - **The GPT Pro architecture checkpoint is owner-disposed (#25):** review of
@@ -191,40 +193,41 @@ never accumulates history (git has that).
   reran the exact head with no findings and a clean tree before and after. PR
   CI run `32537565881` passed; PR #42 merged as `0863750`, issue #40 closed,
   and post-merge CI run `32537995524` passed.
-- **SW-G semantic open is under repair (#54/#55):** GPT Pro identified that the
-  package writer was strongly typed while the reader decoded only selected IR
-  and initialization fields. Draft PR #55 at implementation commit `200a617`
-  adds complete strict `StableWorldIr` reconstruction, re-derives
-  compiler-owned primitive/resolver/movement/relation/provenance invariants,
-  regenerates all four typed projections, and returns one
-  `OpenedCompiledWorld`. The partial initialization decoder and alternate
-  runtime path are deleted. Mutations covering commands, handlers, primitive
-  expansions, capabilities, claims, transitions, interactions, bindings,
-  relations, resolvers, stable movement, provenance, and semantic order all
-  refresh both compiler-receipt and manifest integrity evidence and still fail
-  semantic open. The full author proof is green. Because committing a rerun
-  result changes the head it names, final PR CI and non-author exact-head
-  disposition are recorded externally in PR #55.
-- **SW-H is implemented but blocked (#52/#53):** draft PR #53 implements the
-  exact `validate`, `compile`, and `inspect` filesystem CLI slice at
-  `48c2b72b`, with author proof, CI, and a Luna non-author rerun already green.
-  It must be rebased onto the merged #54 repair and change inspection to consume
-  `OpenedCompiledWorld` before it can leave draft.
+- **SW-G semantic open is repaired (#54/#55):** package opening now performs
+  complete strict `StableWorldIr` reconstruction, re-derives compiler-owned
+  primitive/resolver/movement/relation/provenance invariants, regenerates all
+  four typed projections, and returns one `OpenedCompiledWorld`. The partial
+  initialization decoder and alternate runtime path are deleted. Refreshed
+  receipt-and-manifest mutation tests fail closed across nested commands,
+  handlers, claims, capabilities, provenance, ordering, and IR/projection
+  disagreement. Exact repair head `d43150a736cd91c7307da22c16992c720e8827e6`
+  passed PR CI and a clean non-author rerun; PR #55 merged as `15661d2`, and
+  post-merge CI run `32550461102` passed.
+- **SW-H is implemented on issue #52's feature branch:** the `nomos` binary now
+  exposes exact dependency-free `validate`, `compile`, and `inspect` command
+  grammars. Non-help results are one canonical JSON value; source, argv,
+  package, and host failures use the fixed four exit classes. Compilation uses
+  the existing staged immutable package boundary. Inspection opens and
+  semantically validates the package as an `OpenedCompiledWorld`; its
+  compiler-owned report prints the three primitives' capabilities, independent
+  machines, claims, and source mappings without reading source or exposing
+  `nomos-schema` to the CLI.
+  The end-to-end subprocess suite proves all four exits, determinism,
+  no-artifact validation, tamper/extra-entry refusal, symlink policy, staging
+  cleanup, and existing-output preservation. Draft PR #53 must receive a fresh
+  author proof, PR CI, and non-author exact-head rerun after this rebase before
+  the slice is green.
 
 ## What is next
 
-Finish issue #54 / PR #55 first: obtain PR CI and a non-author exact-head rerun,
-then leave merge/disposition to the owner. After merge, rebase draft PR #53,
-make its compiler-owned inspection report consume `OpenedCompiledWorld`, rerun
-the complete SW-H proof and non-author review, and dispose issue #52. Do not
-begin persisted runtime/run/replay work while either read-side repair or SW-H
-is open.
-
-After SW-H, the remaining work includes persisted runtime types and command
-language, run-directory artifacts, replay, explanations, the required stable
-v1-to-v2 movement migration, direct v2 runtime loading/refusal evidence, the
-Linux aarch64 and ten-run matrix, measured Gate K budgets, final
-schema-ownership review, and the formal cold-agent gates.
+Finish issue #52 through refreshed author proof, PR CI, non-author exact-head
+rerun, and owner merge. Do not begin another semantic implementation without a
+new issue. After SW-H, the next slice defines persisted runtime types and the
+command language before runtime `run`/`command`; later work includes verified
+run bundles, replay, explanations, the required stable v1-to-v2 movement
+migration, direct v2 runtime loading/refusal evidence, the Linux aarch64 and
+ten-run matrix, measured Gate K budgets, final schema-ownership review, and the
+formal cold-agent gates.
 
 The old `agy` Gemini route remains falsified evidence. Issue #49 qualifies Pi as
 the replacement transport without spending a formal attempt or changing the
@@ -238,6 +241,10 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
 cargo xtask boundary
+cargo run --locked --bin nomos -- --help
+cargo run --locked --bin nomos -- validate fixtures/gaol.nomos
+cargo run --locked --bin nomos -- compile fixtures/gaol.nomos --out target/tmp/sw-h-proof/gaol.world
+cargo run --locked --bin nomos -- inspect target/tmp/sw-h-proof/gaol.world
 docs/evaluation/test-agy-print-preflight.sh
 docs/evaluation/test-agy-formal-boundary-preflight.sh
 docs/evaluation/test-pi-cold-agent-preflight.sh
@@ -255,8 +262,8 @@ CI passed all four commands;
 the focused release SW-G test also passed. SW-F, SW-D, and
 issue #24 have the same author/non-author/CI chain as recorded above. Earlier
 SW-C, revision-4, and Rust-1.98 maintenance reruns also passed.
-Still unproven: Linux aarch64 release, ten runs per target, the complete
-`nomos` command surface, migration/replay, measured Gate K budgets, and formal
+Still unproven: Linux aarch64 release, ten runs per target, runtime and
+explanation commands, migration/replay, measured Gate K budgets, and formal
 cold-agent gates. The contract also requires a final explicit schema-ownership
 source-review receipt after the Gate K schema set stabilizes; that final
 receipt does not exist yet.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -255,11 +255,13 @@ The authenticated formal-boundary command is an expected negative proof on
 print `AGY_FORMAL_BOUNDARY BLOCKED`. A zero exit would require inspection and
 owner disposition before any formal launch.
 
-The issue #54 repair author proof passed all four commands at `200a617`; final
-PR CI and non-author exact-head disposition are recorded externally in PR #55.
-SW-G's original author proof, Luna max exact-head rerun, PR CI, and post-merge
-CI passed all four commands;
-the focused release SW-G test also passed. SW-F, SW-D, and
+The issue #54 repair author proof, PR CI, non-author exact-head rerun, and
+post-merge CI passed as recorded above and externally in PR #55. SW-H's
+refreshed author proof passes all four workspace commands plus the exact CLI
+smoke commands after rebasing onto that repair; final PR CI and non-author
+exact-head disposition are recorded externally in PR #53. SW-G's original
+author proof, Luna max exact-head rerun, PR CI, and post-merge CI also passed all
+four commands; the focused release SW-G test passed. SW-F, SW-D, and
 issue #24 have the same author/non-author/CI chain as recorded above. Earlier
 SW-C, revision-4, and Rust-1.98 maintenance reruns also passed.
 Still unproven: Linux aarch64 release, ten runs per target, runtime and

--- a/docs/movement.md
+++ b/docs/movement.md
@@ -71,6 +71,7 @@ claim. These results are computed from the projected activation expressions;
 
 SW-E's resolver remains ground-movement-only. SW-F now carries its before/after
 facts into committed typed receipts alongside light facts; the movement plan
-and navigation schema do not change. Replay, migration, package artifacts,
-filesystem CLI commands, explanations, and the multi-target/formal cold-agent
-evidence remain open.
+and navigation schema do not change. SW-G packages those artifacts and SW-H
+exposes their filesystem validation, compilation, and inspection. Replay,
+migration, runtime CLI execution, explanations, and the multi-target/formal
+cold-agent evidence remain open.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -143,6 +143,7 @@ binds bytes but supplies neither access control nor provenance.
 
 SHA-256 proves byte identity, not authenticity. Compiler receipts bind exact
 source and artifact bytes inside the package, but they are not signatures.
-This slice does not implement signing, guarantee power-loss durability, expose
-filesystem CLI commands, write run directories, replay, migrate, or satisfy
-whole-Gate-K acceptance.
+SW-H exposes this boundary through filesystem `validate`, `compile`, and
+`inspect` commands. It does not implement signing, guarantee power-loss
+durability, write run directories, execute runtime commands, replay, migrate,
+or satisfy whole-Gate-K acceptance.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -78,7 +78,8 @@ remains downstream and is not part of the canonical semantic receipt.
 ## Evidence boundary
 
 SW-F proves in-memory snapshot immutability and commit evidence; SW-G proves the
-package contains deterministic material for the same initial snapshot. Neither
-slice writes run directories, implements filesystem CLI commands or command
-logs, replays, performs the required World IR migration, runs the multi-target
-ten-run matrix, or performs formal cold-agent gates.
+package contains deterministic material for the same initial snapshot; SW-H
+exposes filesystem validation, compilation, and inspection. No slice yet writes
+run directories or command logs, executes runtime commands through the CLI,
+replays, performs the required World IR migration, runs the multi-target ten-run
+matrix, or performs formal cold-agent gates.

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -102,6 +102,7 @@ does not alter `ward`.
 SW-E's ground `MovementDisposition` facts remain as described in
 [`movement.md`](movement.md). SW-F proves light removal,
 persistence/diagnostics deltas, committed in-memory state, hashes, and typed
-causal receipts as described in [`runtime.md`](runtime.md). Replay, migration,
-package/filesystem CLI orchestration, the ten-run target matrix, and
+causal receipts as described in [`runtime.md`](runtime.md). SW-G packages those
+artifacts and SW-H exposes filesystem validation, compilation, and inspection.
+Runtime CLI execution, replay, migration, the ten-run target matrix, and
 whole-Gate-K cold-agent acceptance remain open.


### PR DESCRIPTION
## Summary

- expose the exact dependency-free nomos validate, nomos compile, and nomos inspect filesystem-authoring grammar
- emit canonical JSON for every non-help result with stable CLI diagnostics and the four fixed exit classes
- make inspection open the package through the repaired complete OpenedCompiledWorld boundary, then emit one compiler-owned report
- prove immutable compilation, deterministic inspection, tamper refusal, symlink policy, and all exit classes through real-binary integration tests
- update current documentation to distinguish the implemented authoring surface from still-open runtime, replay, migration, and explanation work

Closes #52.

## Author evidence

Exact head: 8288e71c5af4301b117af565733dd8ed9cd8eb32

The tree was clean before and after. These commands passed on the exact head:

    cargo fmt --all -- --check
    cargo clippy --workspace --all-targets --locked -- -D warnings
    cargo test --workspace --locked
    cargo xtask boundary

The exact CLI help, validate, compile, and inspect smoke commands also passed after the rebase. The inspect result contains the complete ordered machine transitions and claim activation/value records for all three fixture entities.

The SW-H subprocess suite has six tests covering exact help/usage, non-UTF-8 argv, all four exits, no-artifact validation, byte-identical dual compilation, deterministic compiler-owned inspection, source/package symlink policy, source/package tampering, staging cleanup, and existing-output preservation. The merged SW-G repair suite additionally proves that complete semantic opening rejects deep IR and projection tampering even after compiler-receipt and package-manifest hashes are refreshed.

## Independent evidence

Fresh exact-head PR CI and non-author rerun are pending. The earlier CI and Luna rerun applied to the pre-repair head and are intentionally not claimed for this rebased head.

## Review provenance

Before filing #52, supplemental Claude Opus 5 at high effort attacked the draft for ambiguous grammar, exit classification, filesystem safety, ownership, and scope expansion. The owner disposition is recorded in the issue body. GPT Pro later identified the incomplete semantic-open boundary; issue #54 and PR #55 repaired it before this branch was rebased. Inspection now consumes that repaired boundary.

Gemini and DeepSeek were not used to implement or review this slice. Fresh sessions would be context-cold, but the formal protocol also preserves subject-role independence until the declared Gate K attempts.

## Unresolved limits

- no runtime run/command, run-directory, explanation, replay, or migration implementation
- no hostile-filesystem or concurrent-publisher claim beyond KERNEL's caller-owned local-filesystem/single-publisher boundary
- no Gate K budget, multi-target/ten-run, final schema-ownership, or formal cold-agent disposition
