### PR TITLE
SW-I: define persisted runtime evidence and command resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ any renderer is built.
 ## Status
 
 - **Architecture status:** exploratory and non-authoritative
-- **Implementation status:** implemented through SW-H: foundations, source and
+- **Implementation status:** implemented through SW-I: foundations, source and
   preserved construction IR, stable `nomos.world_ir@1`, compiled transitions,
   shared movement and light resolution, all four projections, immutable runtime
-  commits, complete hash-verified world packages, and the filesystem `validate`,
-  `compile`, and `inspect` commands; no filesystem runtime execution, replay, or
-  migration
+  commits, complete hash-verified world packages, the filesystem `validate`,
+  `compile`, and `inspect` commands, and strict persisted runtime evidence; no
+  filesystem runtime execution, replay, or migration
 - **Contract revision:** 6, owner-authorized in decision 0007
 - **Cold-agent protocol revision:** 2, owner-authorized in decision 0008
 - **Scope:** greenfield / vacuum architecture exercise

--- a/crates/nomos-cli/tests/sw_f.rs
+++ b/crates/nomos-cli/tests/sw_f.rs
@@ -162,6 +162,30 @@ fn exact_command_sequence_is_byte_deterministic_from_one_initial_snapshot() {
     let first = run_sequence(&plan, &initial);
     let second = run_sequence(&plan, &initial);
     assert_eq!(first, second);
+    assert_eq!(
+        first
+            .iter()
+            .map(|(_, receipt, _)| Sha256Digest::of_bytes(receipt).to_hex())
+            .collect::<Vec<_>>(),
+        [
+            "f03814a5501a5e63e1464aaf834622dfccff06146c5d70732478708f4b54b48e",
+            "c8f1bab24339dec8f4be88006a18d81b259cdba61f4fa25f9626ff914740dc55",
+            "6461972f898ee79984ecbca85f6e41728dcc1a5e993c257b3fde006738e35691",
+            "c7e9ca01679a6bf14c1c9c92dc78e87e27b89b5d8b32e8b294d595f974554517",
+        ]
+    );
+    assert_eq!(
+        first
+            .iter()
+            .map(|(_, _, state_hash)| state_hash.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "4076b938a5d03134810301257022d1124481343fb0d01bf06fa98772350022ae",
+            "9594a153dd1a65975d3737e5c7080868c14cd6d370482cee9809ac22fbb3aafb",
+            "1753f1f199c33add2827e105ce81af5bced8d25d7d53a918d9f797669f4aa49f",
+            "d9eed238e219747752154bfe8697d79773531df34ba66f96d5e11ee30b29affc",
+        ]
+    );
     assert_eq!(initial.tick(), 0);
 }
 

--- a/crates/nomos-cli/tests/sw_i.rs
+++ b/crates/nomos-cli/tests/sw_i.rs
@@ -2,10 +2,15 @@
 
 use nomos_compiler::compile_world;
 use nomos_core::canonical::read::parse_canonical;
-use nomos_core::{CanonicalValue, FieldName, SourcePath};
-use nomos_projection::CommandArgument;
+use nomos_core::{CanonicalValue, FieldName, Sha256Digest, SourcePath};
+use nomos_projection::{
+    CommandArgument, CommandRequirement, CommandTransition, LatticeCell, MachineDefinition,
+    ProjectedEntity, RuntimeBinding, SimulationPlan,
+};
 use nomos_sim::{
-    CommandRequest, CommandScript, PersistedRuntimeState, SimulationState, resolve_command,
+    CausalReceipt, CommandLog, CommandLogRow, CommandRequest, CommandScript, PersistedRuntimeState,
+    RunArtifactDigest, RunArtifactName, RunResult, SimulationState, StateHashSequence,
+    commit_transaction, resolve_command,
 };
 
 const SOURCE: &str = include_str!("../../../fixtures/gaol.nomos");
@@ -22,6 +27,63 @@ fn object(
         panic!("expected canonical object")
     };
     fields
+}
+
+fn executed_evidence() -> (
+    nomos_projection::SimulationPlan,
+    CommandLog,
+    Vec<CausalReceipt>,
+    StateHashSequence,
+) {
+    let plan = plan(SOURCE);
+    let script = CommandScript::from_bytes(
+        b"schema nomos.command_script@1\nunlock north_gate with credential/gaoler_key\nopen north_gate\nunseal north_gate\nignite north_gate\nextinguish brazier_02\n",
+    )
+    .unwrap();
+    let mut current = SimulationState::initialize(&plan).unwrap();
+    let initial_hash = current.state_hash();
+    let mut rows = Vec::new();
+    let mut receipts = Vec::new();
+    for (ordinal, request) in script.requests().iter().enumerate() {
+        let command = resolve_command(&plan, request).unwrap();
+        let input_hash = current.state_hash();
+        let committed = commit_transaction(&plan, &current, &command).unwrap();
+        rows.push(
+            CommandLogRow::new(
+                u64::try_from(ordinal).unwrap(),
+                request.clone(),
+                command,
+                input_hash,
+                committed.receipt(),
+            )
+            .unwrap(),
+        );
+        receipts.push(committed.receipt().clone());
+        current = committed.into_snapshot();
+    }
+    let log = CommandLog::new(rows).unwrap();
+    let hashes = StateHashSequence::from_command_log(initial_hash, &log).unwrap();
+    (plan, log, receipts, hashes)
+}
+
+fn artifact_digests(log: &CommandLog, hashes: &StateHashSequence) -> Vec<RunArtifactDigest> {
+    [
+        RunArtifactName::InitialState,
+        RunArtifactName::FinalState,
+        RunArtifactName::CommandLog,
+        RunArtifactName::CausalReceipts,
+        RunArtifactName::StateHashes,
+    ]
+    .into_iter()
+    .map(|name| {
+        let digest = match name {
+            RunArtifactName::CommandLog => Sha256Digest::of_bytes(&log.to_canonical_bytes()),
+            RunArtifactName::StateHashes => Sha256Digest::of_bytes(&hashes.to_canonical_bytes()),
+            _ => Sha256Digest::of_bytes(name.as_str().as_bytes()),
+        };
+        RunArtifactDigest::new(name, digest)
+    })
+    .collect()
 }
 
 #[test]
@@ -140,7 +202,11 @@ fn command_language_rejects_noncanonical_text_and_requirement_mismatches() {
         &b"schema nomos.command_script@1\n"[..],
         &b"schema nomos.command_script@1\r\nopen north_gate\r\n"[..],
         &b"schema nomos.command_script@1\nopen  north_gate\n"[..],
+        &b"schema nomos.command_script@1\nopen\tnorth_gate\n"[..],
         &b"schema nomos.command_script@1\nopen north_gate \n"[..],
+        &b"schema nomos.command_script@1\nopen north_gate extra\n"[..],
+        &b"schema nomos.command_script@1\nopen north_gate with\n"[..],
+        &b"schema nomos.command_script@1\nopen north_gate"[..],
         &b"schema nomos.command_script@1\n# comment\n"[..],
         &b"schema nomos.command_script@1\nopen north_gate\n\n"[..],
         &b"schema nomos.command_script@2\nopen north_gate\n"[..],
@@ -166,6 +232,30 @@ fn command_language_rejects_noncanonical_text_and_requirement_mismatches() {
         nomos_core::diagnostic::codes::RUNTIME_ARGUMENT_MISMATCH
     );
 
+    let wrong_credential = CommandRequest::new(
+        nomos_core::Ident::new("unlock").unwrap(),
+        nomos_core::EntityId::parse("north_gate").unwrap(),
+        Some(nomos_core::CatalogValueId::parse("credential/other_key").unwrap()),
+    );
+    assert_eq!(
+        resolve_command(&plan, &wrong_credential)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_ARGUMENT_MISMATCH
+    );
+
+    let unexpected_credential = CommandRequest::new(
+        nomos_core::Ident::new("open").unwrap(),
+        nomos_core::EntityId::parse("north_gate").unwrap(),
+        Some(nomos_core::CatalogValueId::parse("credential/gaoler_key").unwrap()),
+    );
+    assert_eq!(
+        resolve_command(&plan, &unexpected_credential)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_ARGUMENT_MISMATCH
+    );
+
     let unknown = CommandRequest::new(
         nomos_core::Ident::new("dance").unwrap(),
         nomos_core::EntityId::parse("north_gate").unwrap(),
@@ -175,4 +265,419 @@ fn command_language_rejects_noncanonical_text_and_requirement_mismatches() {
         resolve_command(&plan, &unknown).unwrap_err().code(),
         nomos_core::diagnostic::codes::RUNTIME_ACTION_UNDECLARED
     );
+
+    let entity = nomos_core::EntityId::parse("subject").unwrap();
+    let action = nomos_core::Ident::new("toggle").unwrap();
+    let off = nomos_core::Ident::new("off").unwrap();
+    let on = nomos_core::Ident::new("on").unwrap();
+    let namespaces = ["first", "second"].map(|name| {
+        nomos_core::NamespaceId::new(entity.clone(), nomos_core::Ident::new(name).unwrap())
+    });
+    let machines = namespaces
+        .iter()
+        .map(|namespace| {
+            MachineDefinition::new(
+                namespace.clone(),
+                vec![off.clone(), on.clone()],
+                off.clone(),
+                vec![CommandTransition::new(
+                    action.clone(),
+                    CommandRequirement::None,
+                    off.clone(),
+                    on.clone(),
+                )],
+                Vec::new(),
+            )
+            .unwrap()
+        })
+        .collect();
+    let projected = ProjectedEntity::new(
+        entity.clone(),
+        RuntimeBinding::Cell(LatticeCell::new(0, 0, 0)),
+        namespaces.to_vec(),
+    )
+    .unwrap();
+    let ambiguous_plan = SimulationPlan::new(machines, Vec::new())
+        .unwrap()
+        .with_entities(vec![projected])
+        .unwrap();
+    let ambiguous = CommandRequest::new(action, entity, None);
+    assert_eq!(
+        resolve_command(&ambiguous_plan, &ambiguous)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_COMMAND_AMBIGUOUS
+    );
+}
+
+#[test]
+fn causal_receipts_reconstruct_complete_typed_evidence() {
+    let (_, _, receipts, _) = executed_evidence();
+    assert_eq!(receipts.len(), 5);
+    for receipt in &receipts {
+        let bytes = receipt.to_canonical_bytes();
+        let decoded = CausalReceipt::from_canonical_bytes(&bytes).unwrap();
+        assert_eq!(&decoded, receipt);
+        assert_eq!(decoded.to_canonical_bytes(), bytes);
+        assert_eq!(decoded.digest(), Sha256Digest::of_bytes(&bytes));
+    }
+    assert_eq!(receipts[3].steps().len(), 2, "ignite carries one event");
+    assert_eq!(receipts[4].projection_deltas().len(), 3);
+
+    let mut nested_unknown =
+        parse_canonical(&receipts[3].to_canonical_bytes()).expect("receipt is canonical");
+    let CanonicalValue::Array(transitions) = object(&mut nested_unknown)
+        .get_mut(&FieldName::declared("transitions"))
+        .unwrap()
+    else {
+        panic!("receipt transitions must be an array")
+    };
+    object(&mut transitions[1]).insert(FieldName::declared("unknown"), CanonicalValue::Bool(true));
+    assert_eq!(
+        CausalReceipt::from_canonical_bytes(&nested_unknown.to_canonical_bytes())
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_PERSISTED_INVALID
+    );
+}
+
+#[test]
+fn logs_hash_sequences_and_results_round_trip_and_cross_validate() {
+    let (plan, log, receipts, hashes) = executed_evidence();
+    let log_bytes = log.to_canonical_bytes();
+    let decoded_log = CommandLog::from_canonical_bytes(&log_bytes).unwrap();
+    assert_eq!(decoded_log, log);
+    decoded_log.validate_receipts(&receipts).unwrap();
+
+    let hash_bytes = hashes.to_canonical_bytes();
+    let decoded_hashes = StateHashSequence::from_canonical_bytes(&hash_bytes).unwrap();
+    assert_eq!(decoded_hashes, hashes);
+    decoded_hashes.validate_command_log(&decoded_log).unwrap();
+    assert_eq!(decoded_hashes.rows().len(), decoded_log.rows().len() + 1);
+    assert_eq!(
+        StateHashSequence::from_command_log(receipts.last().unwrap().state_hash(), &decoded_log)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+
+    let initial = SimulationState::initialize(&plan).unwrap();
+    let persisted = PersistedRuntimeState::new(&plan, initial).unwrap();
+    let result = RunResult::completed(
+        Sha256Digest::of_bytes(b"manifest.json"),
+        persisted.runtime_semantics_digest(),
+        artifact_digests(&decoded_log, &decoded_hashes),
+        &decoded_log,
+        &decoded_hashes,
+    )
+    .unwrap();
+    let result_bytes = result.to_canonical_bytes();
+    let decoded_result = RunResult::from_canonical_bytes(&result_bytes).unwrap();
+    assert_eq!(decoded_result, result);
+    decoded_result
+        .validate_evidence(&decoded_log, &decoded_hashes)
+        .unwrap();
+    assert_eq!(decoded_result.committed_command_count(), 5);
+    assert_eq!(decoded_result.rejection_diagnostic(), None);
+
+    let rejected = RunResult::rejected(
+        Sha256Digest::of_bytes(b"manifest.json"),
+        persisted.runtime_semantics_digest(),
+        artifact_digests(&decoded_log, &decoded_hashes),
+        &decoded_log,
+        &decoded_hashes,
+        nomos_core::diagnostic::codes::RUNTIME_SOURCE_STATE_ILLEGAL,
+    )
+    .unwrap();
+    assert_eq!(
+        RunResult::from_canonical_bytes(&rejected.to_canonical_bytes())
+            .unwrap()
+            .rejection_diagnostic(),
+        Some(nomos_core::diagnostic::codes::RUNTIME_SOURCE_STATE_ILLEGAL)
+    );
+
+    let empty_log = CommandLog::new(Vec::new()).unwrap();
+    let empty_hashes = StateHashSequence::from_command_log(
+        SimulationState::initialize(&plan).unwrap().state_hash(),
+        &empty_log,
+    )
+    .unwrap();
+    assert_eq!(
+        RunResult::completed(
+            Sha256Digest::of_bytes(b"manifest.json"),
+            persisted.runtime_semantics_digest(),
+            artifact_digests(&empty_log, &empty_hashes),
+            &empty_log,
+            &empty_hashes,
+        )
+        .unwrap_err()
+        .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+    RunResult::rejected(
+        Sha256Digest::of_bytes(b"manifest.json"),
+        persisted.runtime_semantics_digest(),
+        artifact_digests(&empty_log, &empty_hashes),
+        &empty_log,
+        &empty_hashes,
+        nomos_core::diagnostic::codes::RUNTIME_SOURCE_STATE_ILLEGAL,
+    )
+    .unwrap();
+}
+
+#[test]
+fn refreshed_receipt_digest_cannot_hide_typed_command_disagreement() {
+    let (_, log, mut receipts, _) = executed_evidence();
+    let last = receipts.last_mut().unwrap();
+    let mut receipt_value = parse_canonical(&last.to_canonical_bytes()).unwrap();
+    object(
+        object(&mut receipt_value)
+            .get_mut(&FieldName::declared("command"))
+            .unwrap(),
+    )
+    .insert(
+        FieldName::declared("action"),
+        CanonicalValue::text("darken"),
+    );
+    let CanonicalValue::Array(transitions) = object(&mut receipt_value)
+        .get_mut(&FieldName::declared("transitions"))
+        .unwrap()
+    else {
+        panic!("receipt transitions must be an array")
+    };
+    object(
+        object(&mut transitions[0])
+            .get_mut(&FieldName::declared("cause"))
+            .unwrap(),
+    )
+    .insert(
+        FieldName::declared("action"),
+        CanonicalValue::text("darken"),
+    );
+    *last = CausalReceipt::from_canonical_bytes(&receipt_value.to_canonical_bytes()).unwrap();
+
+    let mut log_value = parse_canonical(&log.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(rows) = object(&mut log_value)
+        .get_mut(&FieldName::declared("rows"))
+        .unwrap()
+    else {
+        panic!("command-log rows must be an array")
+    };
+    object(rows.last_mut().unwrap()).insert(
+        FieldName::declared("causal_receipt_digest"),
+        CanonicalValue::text(last.digest().to_hex()),
+    );
+    let refreshed_log = CommandLog::from_canonical_bytes(&log_value.to_canonical_bytes()).unwrap();
+    assert_eq!(
+        refreshed_log
+            .validate_receipts(&receipts)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+}
+
+#[test]
+fn persisted_evidence_rejects_order_hash_status_and_cross_object_mutations() {
+    let (plan, log, receipts, hashes) = executed_evidence();
+
+    let mut reordered = parse_canonical(&log.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(rows) = object(&mut reordered)
+        .get_mut(&FieldName::declared("rows"))
+        .unwrap()
+    else {
+        panic!("command-log rows must be an array")
+    };
+    rows.swap(0, 1);
+    assert_eq!(
+        CommandLog::from_canonical_bytes(&reordered.to_canonical_bytes())
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+
+    let mut changed_hash = parse_canonical(&hashes.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(rows) = object(&mut changed_hash)
+        .get_mut(&FieldName::declared("rows"))
+        .unwrap()
+    else {
+        panic!("state-hash rows must be an array")
+    };
+    object(&mut rows[1]).insert(
+        FieldName::declared("state_hash"),
+        CanonicalValue::text("0".repeat(64)),
+    );
+    let changed_hashes =
+        StateHashSequence::from_canonical_bytes(&changed_hash.to_canonical_bytes()).unwrap();
+    assert_eq!(
+        changed_hashes
+            .validate_command_log(&log)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+
+    let persisted =
+        PersistedRuntimeState::new(&plan, SimulationState::initialize(&plan).unwrap()).unwrap();
+    let result = RunResult::completed(
+        Sha256Digest::of_bytes(b"manifest.json"),
+        persisted.runtime_semantics_digest(),
+        artifact_digests(&log, &hashes),
+        &log,
+        &hashes,
+    )
+    .unwrap();
+    let mut changed_count = parse_canonical(&result.to_canonical_bytes()).unwrap();
+    object(&mut changed_count).insert(
+        FieldName::declared("committed_command_count"),
+        CanonicalValue::Uint(4),
+    );
+    let changed_result =
+        RunResult::from_canonical_bytes(&changed_count.to_canonical_bytes()).unwrap();
+    assert_eq!(
+        changed_result
+            .validate_evidence(&log, &hashes)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+
+    let mut wrong_status = parse_canonical(&result.to_canonical_bytes()).unwrap();
+    object(&mut wrong_status).insert(
+        FieldName::declared("status"),
+        CanonicalValue::text("rejected"),
+    );
+    assert_eq!(
+        RunResult::from_canonical_bytes(&wrong_status.to_canonical_bytes())
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+
+    let mut stale_digest_log = parse_canonical(&log.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(rows) = object(&mut stale_digest_log)
+        .get_mut(&FieldName::declared("rows"))
+        .unwrap()
+    else {
+        panic!("command-log rows must be an array")
+    };
+    object(&mut rows[0]).insert(
+        FieldName::declared("causal_receipt_digest"),
+        CanonicalValue::text("0".repeat(64)),
+    );
+    let stale_digest_log =
+        CommandLog::from_canonical_bytes(&stale_digest_log.to_canonical_bytes()).unwrap();
+    assert_eq!(
+        stale_digest_log
+            .validate_receipts(&receipts)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+
+    let mut log_unknown = parse_canonical(&log.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(rows) = object(&mut log_unknown)
+        .get_mut(&FieldName::declared("rows"))
+        .unwrap()
+    else {
+        panic!("command-log rows must be an array")
+    };
+    let request = object(&mut rows[0])
+        .get_mut(&FieldName::declared("request"))
+        .unwrap();
+    object(request).insert(FieldName::declared("unknown"), CanonicalValue::Bool(true));
+    assert!(CommandLog::from_canonical_bytes(&log_unknown.to_canonical_bytes()).is_err());
+
+    let mut hash_unknown = parse_canonical(&hashes.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(rows) = object(&mut hash_unknown)
+        .get_mut(&FieldName::declared("rows"))
+        .unwrap()
+    else {
+        panic!("state-hash rows must be an array")
+    };
+    object(&mut rows[0]).insert(FieldName::declared("unknown"), CanonicalValue::Bool(true));
+    assert!(StateHashSequence::from_canonical_bytes(&hash_unknown.to_canonical_bytes()).is_err());
+
+    let mut result_unknown = parse_canonical(&result.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(artifacts) = object(&mut result_unknown)
+        .get_mut(&FieldName::declared("artifacts"))
+        .unwrap()
+    else {
+        panic!("run artifacts must be an array")
+    };
+    object(&mut artifacts[0]).insert(FieldName::declared("unknown"), CanonicalValue::Bool(true));
+    assert!(RunResult::from_canonical_bytes(&result_unknown.to_canonical_bytes()).is_err());
+
+    let mut artifact_order = parse_canonical(&result.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(artifacts) = object(&mut artifact_order)
+        .get_mut(&FieldName::declared("artifacts"))
+        .unwrap()
+    else {
+        panic!("run artifacts must be an array")
+    };
+    artifacts.reverse();
+    assert!(RunResult::from_canonical_bytes(&artifact_order.to_canonical_bytes()).is_err());
+
+    let mut wrong_artifact_digest = parse_canonical(&result.to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(artifacts) = object(&mut wrong_artifact_digest)
+        .get_mut(&FieldName::declared("artifacts"))
+        .unwrap()
+    else {
+        panic!("run artifacts must be an array")
+    };
+    let command_log_index = artifacts
+        .iter()
+        .position(|artifact| {
+            let CanonicalValue::Object(fields) = artifact else {
+                return false;
+            };
+            fields
+                .get(&FieldName::declared("name"))
+                .is_some_and(|name| name == &CanonicalValue::text("command-log.json"))
+        })
+        .unwrap();
+    let command_log_artifact = &mut artifacts[command_log_index];
+    object(command_log_artifact).insert(
+        FieldName::declared("digest"),
+        CanonicalValue::text("0".repeat(64)),
+    );
+    let wrong_artifact_result =
+        RunResult::from_canonical_bytes(&wrong_artifact_digest.to_canonical_bytes()).unwrap();
+    assert_eq!(
+        wrong_artifact_result
+            .validate_evidence(&log, &hashes)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+
+    let mut receipt_order = parse_canonical(&receipts[4].to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(deltas) = object(&mut receipt_order)
+        .get_mut(&FieldName::declared("projection_deltas"))
+        .unwrap()
+    else {
+        panic!("projection deltas must be an array")
+    };
+    deltas.reverse();
+    assert!(CausalReceipt::from_canonical_bytes(&receipt_order.to_canonical_bytes()).is_err());
+
+    let mut overflow = parse_canonical(&receipts[3].to_canonical_bytes()).unwrap();
+    let CanonicalValue::Array(transitions) = object(&mut overflow)
+        .get_mut(&FieldName::declared("transitions"))
+        .unwrap()
+    else {
+        panic!("receipt transitions must be an array")
+    };
+    let payload = object(
+        object(&mut transitions[1])
+            .get_mut(&FieldName::declared("cause"))
+            .unwrap(),
+    )
+    .get_mut(&FieldName::declared("payload"))
+    .unwrap();
+    object(payload).insert(
+        FieldName::declared("amount"),
+        CanonicalValue::Uint(u64::MAX),
+    );
+    assert!(CausalReceipt::from_canonical_bytes(&overflow.to_canonical_bytes()).is_err());
 }

--- a/crates/nomos-cli/tests/sw_i.rs
+++ b/crates/nomos-cli/tests/sw_i.rs
@@ -464,6 +464,46 @@ fn logs_hash_sequences_and_results_round_trip_and_cross_validate() {
 }
 
 #[test]
+fn run_evidence_accepts_a_nonzero_persisted_initial_tick() {
+    let (plan, _, initial, _, _, _) = executed_evidence();
+    assert_eq!(initial.state().tick(), 5);
+    let request = CommandScript::from_bytes(b"schema nomos.command_script@1\nclose north_gate\n")
+        .unwrap()
+        .requests()[0]
+        .clone();
+    let command = resolve_command(&plan, &request).unwrap();
+    let committed = commit_transaction(&plan, initial.state(), &command).unwrap();
+    let receipt = committed.receipt().clone();
+    let log = CommandLog::new(vec![
+        CommandLogRow::new(0, request, command, initial.state_hash(), &receipt).unwrap(),
+    ])
+    .unwrap();
+    let receipts =
+        CausalReceiptSequence::new(initial.state().tick(), &log, vec![receipt.clone()]).unwrap();
+    let hashes = StateHashSequence::from_command_log(initial.state_hash(), &log).unwrap();
+    let final_state = PersistedRuntimeState::new(&plan, committed.into_snapshot()).unwrap();
+    let result = RunResult::completed(
+        Sha256Digest::of_bytes(b"manifest.json"),
+        &initial,
+        &final_state,
+        &log,
+        &receipts,
+        &hashes,
+    )
+    .unwrap();
+    result
+        .validate_evidence(&initial, &final_state, &log, &receipts, &hashes)
+        .unwrap();
+    assert_eq!(receipt.tick(), 6);
+    assert_eq!(
+        CausalReceiptSequence::new(0, &log, vec![receipt])
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
+}
+
+#[test]
 fn refreshed_receipt_digest_cannot_hide_typed_command_disagreement() {
     let (_, _, _, log, receipt_sequence, _) = executed_evidence();
     let mut receipts = receipt_sequence.receipts().to_vec();

--- a/crates/nomos-cli/tests/sw_i.rs
+++ b/crates/nomos-cli/tests/sw_i.rs
@@ -8,9 +8,9 @@ use nomos_projection::{
     ProjectedEntity, RuntimeBinding, SimulationPlan,
 };
 use nomos_sim::{
-    CausalReceipt, CommandLog, CommandLogRow, CommandRequest, CommandScript, PersistedRuntimeState,
-    RunArtifactDigest, RunArtifactName, RunResult, SimulationState, StateHashSequence,
-    commit_transaction, resolve_command,
+    CausalReceipt, CausalReceiptSequence, CommandLog, CommandLogRow, CommandRequest, CommandScript,
+    PersistedRuntimeState, RunResult, SimulationState, StateHashSequence, commit_transaction,
+    resolve_command,
 };
 
 const SOURCE: &str = include_str!("../../../fixtures/gaol.nomos");
@@ -31,8 +31,10 @@ fn object(
 
 fn executed_evidence() -> (
     nomos_projection::SimulationPlan,
+    PersistedRuntimeState,
+    PersistedRuntimeState,
     CommandLog,
-    Vec<CausalReceipt>,
+    CausalReceiptSequence,
     StateHashSequence,
 ) {
     let plan = plan(SOURCE);
@@ -41,6 +43,7 @@ fn executed_evidence() -> (
     )
     .unwrap();
     let mut current = SimulationState::initialize(&plan).unwrap();
+    let initial = PersistedRuntimeState::new(&plan, current.clone()).unwrap();
     let initial_hash = current.state_hash();
     let mut rows = Vec::new();
     let mut receipts = Vec::new();
@@ -63,27 +66,9 @@ fn executed_evidence() -> (
     }
     let log = CommandLog::new(rows).unwrap();
     let hashes = StateHashSequence::from_command_log(initial_hash, &log).unwrap();
-    (plan, log, receipts, hashes)
-}
-
-fn artifact_digests(log: &CommandLog, hashes: &StateHashSequence) -> Vec<RunArtifactDigest> {
-    [
-        RunArtifactName::InitialState,
-        RunArtifactName::FinalState,
-        RunArtifactName::CommandLog,
-        RunArtifactName::CausalReceipts,
-        RunArtifactName::StateHashes,
-    ]
-    .into_iter()
-    .map(|name| {
-        let digest = match name {
-            RunArtifactName::CommandLog => Sha256Digest::of_bytes(&log.to_canonical_bytes()),
-            RunArtifactName::StateHashes => Sha256Digest::of_bytes(&hashes.to_canonical_bytes()),
-            _ => Sha256Digest::of_bytes(name.as_str().as_bytes()),
-        };
-        RunArtifactDigest::new(name, digest)
-    })
-    .collect()
+    let receipts = CausalReceiptSequence::new(initial.state().tick(), &log, receipts).unwrap();
+    let final_state = PersistedRuntimeState::new(&plan, current).unwrap();
+    (plan, initial, final_state, log, receipts, hashes)
 }
 
 #[test]
@@ -135,6 +120,32 @@ fn persisted_state_rejects_semantic_rebinding_and_nested_shape_mutation() {
     assert_eq!(
         error.code(),
         nomos_core::diagnostic::codes::RUNTIME_PERSISTED_INVALID
+    );
+
+    let malformed_entities = original_plan
+        .entities()
+        .iter()
+        .map(|entity| {
+            let machines = if entity.id().to_string() == "north_gate" {
+                Vec::new()
+            } else {
+                entity.machines().to_vec()
+            };
+            ProjectedEntity::new(entity.id().clone(), entity.binding().clone(), machines).unwrap()
+        })
+        .collect();
+    let malformed_plan = original_plan
+        .clone()
+        .with_entities(malformed_entities)
+        .unwrap();
+    assert_eq!(
+        SimulationState::from_canonical_bytes(
+            &persisted.state().to_canonical_bytes(),
+            &malformed_plan,
+        )
+        .unwrap_err()
+        .code(),
+        nomos_core::diagnostic::codes::RUNTIME_STATE_INVALID
     );
 }
 
@@ -312,9 +323,15 @@ fn command_language_rejects_noncanonical_text_and_requirement_mismatches() {
 
 #[test]
 fn causal_receipts_reconstruct_complete_typed_evidence() {
-    let (_, _, receipts, _) = executed_evidence();
+    let (_, _, _, _, receipt_sequence, _) = executed_evidence();
+    let sequence_bytes = receipt_sequence.to_canonical_bytes();
+    assert_eq!(
+        CausalReceiptSequence::from_canonical_bytes(&sequence_bytes).unwrap(),
+        receipt_sequence
+    );
+    let receipts = receipt_sequence.receipts();
     assert_eq!(receipts.len(), 5);
-    for receipt in &receipts {
+    for receipt in receipts {
         let bytes = receipt.to_canonical_bytes();
         let decoded = CausalReceipt::from_canonical_bytes(&bytes).unwrap();
         assert_eq!(&decoded, receipt);
@@ -343,11 +360,20 @@ fn causal_receipts_reconstruct_complete_typed_evidence() {
 
 #[test]
 fn logs_hash_sequences_and_results_round_trip_and_cross_validate() {
-    let (plan, log, receipts, hashes) = executed_evidence();
+    let (plan, initial, final_state, log, receipts, hashes) = executed_evidence();
     let log_bytes = log.to_canonical_bytes();
     let decoded_log = CommandLog::from_canonical_bytes(&log_bytes).unwrap();
     assert_eq!(decoded_log, log);
-    decoded_log.validate_receipts(&receipts).unwrap();
+    decoded_log
+        .validate_receipts(0, receipts.receipts())
+        .unwrap();
+    assert_eq!(
+        decoded_log
+            .validate_receipts(1, receipts.receipts())
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+    );
 
     let hash_bytes = hashes.to_canonical_bytes();
     let decoded_hashes = StateHashSequence::from_canonical_bytes(&hash_bytes).unwrap();
@@ -355,19 +381,21 @@ fn logs_hash_sequences_and_results_round_trip_and_cross_validate() {
     decoded_hashes.validate_command_log(&decoded_log).unwrap();
     assert_eq!(decoded_hashes.rows().len(), decoded_log.rows().len() + 1);
     assert_eq!(
-        StateHashSequence::from_command_log(receipts.last().unwrap().state_hash(), &decoded_log)
-            .unwrap_err()
-            .code(),
+        StateHashSequence::from_command_log(
+            receipts.receipts().last().unwrap().state_hash(),
+            &decoded_log,
+        )
+        .unwrap_err()
+        .code(),
         nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
     );
 
-    let initial = SimulationState::initialize(&plan).unwrap();
-    let persisted = PersistedRuntimeState::new(&plan, initial).unwrap();
     let result = RunResult::completed(
         Sha256Digest::of_bytes(b"manifest.json"),
-        persisted.runtime_semantics_digest(),
-        artifact_digests(&decoded_log, &decoded_hashes),
+        &initial,
+        &final_state,
         &decoded_log,
+        &receipts,
         &decoded_hashes,
     )
     .unwrap();
@@ -375,16 +403,23 @@ fn logs_hash_sequences_and_results_round_trip_and_cross_validate() {
     let decoded_result = RunResult::from_canonical_bytes(&result_bytes).unwrap();
     assert_eq!(decoded_result, result);
     decoded_result
-        .validate_evidence(&decoded_log, &decoded_hashes)
+        .validate_evidence(
+            &initial,
+            &final_state,
+            &decoded_log,
+            &receipts,
+            &decoded_hashes,
+        )
         .unwrap();
     assert_eq!(decoded_result.committed_command_count(), 5);
     assert_eq!(decoded_result.rejection_diagnostic(), None);
 
     let rejected = RunResult::rejected(
         Sha256Digest::of_bytes(b"manifest.json"),
-        persisted.runtime_semantics_digest(),
-        artifact_digests(&decoded_log, &decoded_hashes),
+        &initial,
+        &final_state,
         &decoded_log,
+        &receipts,
         &decoded_hashes,
         nomos_core::diagnostic::codes::RUNTIME_SOURCE_STATE_ILLEGAL,
     )
@@ -397,17 +432,19 @@ fn logs_hash_sequences_and_results_round_trip_and_cross_validate() {
     );
 
     let empty_log = CommandLog::new(Vec::new()).unwrap();
-    let empty_hashes = StateHashSequence::from_command_log(
-        SimulationState::initialize(&plan).unwrap().state_hash(),
-        &empty_log,
-    )
-    .unwrap();
+    let empty_state =
+        PersistedRuntimeState::new(&plan, SimulationState::initialize(&plan).unwrap()).unwrap();
+    let empty_hashes =
+        StateHashSequence::from_command_log(empty_state.state_hash(), &empty_log).unwrap();
+    let empty_receipts =
+        CausalReceiptSequence::new(empty_state.state().tick(), &empty_log, Vec::new()).unwrap();
     assert_eq!(
         RunResult::completed(
             Sha256Digest::of_bytes(b"manifest.json"),
-            persisted.runtime_semantics_digest(),
-            artifact_digests(&empty_log, &empty_hashes),
+            &empty_state,
+            &empty_state,
             &empty_log,
+            &empty_receipts,
             &empty_hashes,
         )
         .unwrap_err()
@@ -416,9 +453,10 @@ fn logs_hash_sequences_and_results_round_trip_and_cross_validate() {
     );
     RunResult::rejected(
         Sha256Digest::of_bytes(b"manifest.json"),
-        persisted.runtime_semantics_digest(),
-        artifact_digests(&empty_log, &empty_hashes),
+        &empty_state,
+        &empty_state,
         &empty_log,
+        &empty_receipts,
         &empty_hashes,
         nomos_core::diagnostic::codes::RUNTIME_SOURCE_STATE_ILLEGAL,
     )
@@ -427,7 +465,8 @@ fn logs_hash_sequences_and_results_round_trip_and_cross_validate() {
 
 #[test]
 fn refreshed_receipt_digest_cannot_hide_typed_command_disagreement() {
-    let (_, log, mut receipts, _) = executed_evidence();
+    let (_, _, _, log, receipt_sequence, _) = executed_evidence();
+    let mut receipts = receipt_sequence.receipts().to_vec();
     let last = receipts.last_mut().unwrap();
     let mut receipt_value = parse_canonical(&last.to_canonical_bytes()).unwrap();
     object(
@@ -470,7 +509,7 @@ fn refreshed_receipt_digest_cannot_hide_typed_command_disagreement() {
     let refreshed_log = CommandLog::from_canonical_bytes(&log_value.to_canonical_bytes()).unwrap();
     assert_eq!(
         refreshed_log
-            .validate_receipts(&receipts)
+            .validate_receipts(0, &receipts)
             .unwrap_err()
             .code(),
         nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
@@ -479,7 +518,7 @@ fn refreshed_receipt_digest_cannot_hide_typed_command_disagreement() {
 
 #[test]
 fn persisted_evidence_rejects_order_hash_status_and_cross_object_mutations() {
-    let (plan, log, receipts, hashes) = executed_evidence();
+    let (_, initial, final_state, log, receipts, hashes) = executed_evidence();
 
     let mut reordered = parse_canonical(&log.to_canonical_bytes()).unwrap();
     let CanonicalValue::Array(rows) = object(&mut reordered)
@@ -517,13 +556,12 @@ fn persisted_evidence_rejects_order_hash_status_and_cross_object_mutations() {
         nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
     );
 
-    let persisted =
-        PersistedRuntimeState::new(&plan, SimulationState::initialize(&plan).unwrap()).unwrap();
     let result = RunResult::completed(
         Sha256Digest::of_bytes(b"manifest.json"),
-        persisted.runtime_semantics_digest(),
-        artifact_digests(&log, &hashes),
+        &initial,
+        &final_state,
         &log,
+        &receipts,
         &hashes,
     )
     .unwrap();
@@ -536,7 +574,7 @@ fn persisted_evidence_rejects_order_hash_status_and_cross_object_mutations() {
         RunResult::from_canonical_bytes(&changed_count.to_canonical_bytes()).unwrap();
     assert_eq!(
         changed_result
-            .validate_evidence(&log, &hashes)
+            .validate_evidence(&initial, &final_state, &log, &receipts, &hashes)
             .unwrap_err()
             .code(),
         nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
@@ -569,7 +607,7 @@ fn persisted_evidence_rejects_order_hash_status_and_cross_object_mutations() {
         CommandLog::from_canonical_bytes(&stale_digest_log.to_canonical_bytes()).unwrap();
     assert_eq!(
         stale_digest_log
-            .validate_receipts(&receipts)
+            .validate_receipts(0, receipts.receipts())
             .unwrap_err()
             .code(),
         nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
@@ -618,40 +656,30 @@ fn persisted_evidence_rejects_order_hash_status_and_cross_object_mutations() {
     artifacts.reverse();
     assert!(RunResult::from_canonical_bytes(&artifact_order.to_canonical_bytes()).is_err());
 
-    let mut wrong_artifact_digest = parse_canonical(&result.to_canonical_bytes()).unwrap();
-    let CanonicalValue::Array(artifacts) = object(&mut wrong_artifact_digest)
-        .get_mut(&FieldName::declared("artifacts"))
-        .unwrap()
-    else {
-        panic!("run artifacts must be an array")
-    };
-    let command_log_index = artifacts
-        .iter()
-        .position(|artifact| {
-            let CanonicalValue::Object(fields) = artifact else {
-                return false;
-            };
-            fields
-                .get(&FieldName::declared("name"))
-                .is_some_and(|name| name == &CanonicalValue::text("command-log.json"))
-        })
-        .unwrap();
-    let command_log_artifact = &mut artifacts[command_log_index];
-    object(command_log_artifact).insert(
-        FieldName::declared("digest"),
-        CanonicalValue::text("0".repeat(64)),
-    );
-    let wrong_artifact_result =
-        RunResult::from_canonical_bytes(&wrong_artifact_digest.to_canonical_bytes()).unwrap();
-    assert_eq!(
-        wrong_artifact_result
-            .validate_evidence(&log, &hashes)
-            .unwrap_err()
-            .code(),
-        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
-    );
+    for artifact_index in 0..5 {
+        let mut wrong_artifact_digest = parse_canonical(&result.to_canonical_bytes()).unwrap();
+        let CanonicalValue::Array(artifacts) = object(&mut wrong_artifact_digest)
+            .get_mut(&FieldName::declared("artifacts"))
+            .unwrap()
+        else {
+            panic!("run artifacts must be an array")
+        };
+        object(&mut artifacts[artifact_index]).insert(
+            FieldName::declared("digest"),
+            CanonicalValue::text("0".repeat(64)),
+        );
+        let wrong_artifact_result =
+            RunResult::from_canonical_bytes(&wrong_artifact_digest.to_canonical_bytes()).unwrap();
+        assert_eq!(
+            wrong_artifact_result
+                .validate_evidence(&initial, &final_state, &log, &receipts, &hashes)
+                .unwrap_err()
+                .code(),
+            nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT
+        );
+    }
 
-    let mut receipt_order = parse_canonical(&receipts[4].to_canonical_bytes()).unwrap();
+    let mut receipt_order = parse_canonical(&receipts.receipts()[4].to_canonical_bytes()).unwrap();
     let CanonicalValue::Array(deltas) = object(&mut receipt_order)
         .get_mut(&FieldName::declared("projection_deltas"))
         .unwrap()
@@ -661,7 +689,7 @@ fn persisted_evidence_rejects_order_hash_status_and_cross_object_mutations() {
     deltas.reverse();
     assert!(CausalReceipt::from_canonical_bytes(&receipt_order.to_canonical_bytes()).is_err());
 
-    let mut overflow = parse_canonical(&receipts[3].to_canonical_bytes()).unwrap();
+    let mut overflow = parse_canonical(&receipts.receipts()[3].to_canonical_bytes()).unwrap();
     let CanonicalValue::Array(transitions) = object(&mut overflow)
         .get_mut(&FieldName::declared("transitions"))
         .unwrap()

--- a/crates/nomos-cli/tests/sw_i.rs
+++ b/crates/nomos-cli/tests/sw_i.rs
@@ -1,0 +1,178 @@
+//! SW-I persisted runtime boundary integration proof.
+
+use nomos_compiler::compile_world;
+use nomos_core::canonical::read::parse_canonical;
+use nomos_core::{CanonicalValue, FieldName, SourcePath};
+use nomos_projection::CommandArgument;
+use nomos_sim::{
+    CommandRequest, CommandScript, PersistedRuntimeState, SimulationState, resolve_command,
+};
+
+const SOURCE: &str = include_str!("../../../fixtures/gaol.nomos");
+
+fn plan(source: &str) -> nomos_projection::SimulationPlan {
+    let ir = compile_world(source, SourcePath::new("fixtures/gaol.nomos").unwrap()).unwrap();
+    nomos_compiler::compile_simulation_plan(&ir).unwrap()
+}
+
+fn object(
+    value: &mut CanonicalValue,
+) -> &mut std::collections::BTreeMap<FieldName, CanonicalValue> {
+    let CanonicalValue::Object(fields) = value else {
+        panic!("expected canonical object")
+    };
+    fields
+}
+
+#[test]
+fn state_and_persisted_envelope_round_trip_exactly() {
+    let plan = plan(SOURCE);
+    let state = SimulationState::initialize(&plan).unwrap();
+    let state_bytes = state.to_canonical_bytes();
+    let decoded = SimulationState::from_canonical_bytes(&state_bytes, &plan).unwrap();
+    assert_eq!(decoded, state);
+    assert_eq!(decoded.to_canonical_bytes(), state_bytes);
+
+    let persisted = PersistedRuntimeState::new(&plan, state).unwrap();
+    let persisted_bytes = persisted.to_canonical_bytes();
+    let reopened = PersistedRuntimeState::from_canonical_bytes(&persisted_bytes, &plan).unwrap();
+    assert_eq!(reopened, persisted);
+    assert_eq!(reopened.to_canonical_bytes(), persisted_bytes);
+    assert_eq!(reopened.state_hash(), reopened.state().state_hash());
+}
+
+#[test]
+fn persisted_state_rejects_semantic_rebinding_and_nested_shape_mutation() {
+    let original_plan = plan(SOURCE);
+    let state = SimulationState::initialize(&original_plan).unwrap();
+    let persisted = PersistedRuntimeState::new(&original_plan, state).unwrap();
+    let bytes = persisted.to_canonical_bytes();
+
+    let changed_source = SOURCE.replace("credential/gaoler_key", "credential/other_key");
+    let changed_plan = plan(&changed_source);
+    let error = PersistedRuntimeState::from_canonical_bytes(&bytes, &changed_plan).unwrap_err();
+    assert_eq!(
+        error.code(),
+        nomos_core::diagnostic::codes::RUNTIME_SEMANTICS_MISMATCH
+    );
+
+    let mut value = parse_canonical(&bytes).unwrap();
+    let state = object(&mut value)
+        .get_mut(&FieldName::declared("state"))
+        .unwrap();
+    let CanonicalValue::Array(entities) = object(state)
+        .get_mut(&FieldName::declared("entities"))
+        .unwrap()
+    else {
+        panic!("state entities must be an array")
+    };
+    object(&mut entities[0]).insert(FieldName::declared("unknown"), CanonicalValue::Bool(true));
+    let error =
+        PersistedRuntimeState::from_canonical_bytes(&value.to_canonical_bytes(), &original_plan)
+            .unwrap_err();
+    assert_eq!(
+        error.code(),
+        nomos_core::diagnostic::codes::RUNTIME_PERSISTED_INVALID
+    );
+}
+
+#[test]
+fn persisted_state_rejects_hash_and_semantic_array_order_tampering() {
+    let plan = plan(SOURCE);
+    let state = SimulationState::initialize(&plan).unwrap();
+    let persisted = PersistedRuntimeState::new(&plan, state).unwrap();
+    let bytes = persisted.to_canonical_bytes();
+
+    let mut hash_mutation = parse_canonical(&bytes).unwrap();
+    object(&mut hash_mutation).insert(
+        FieldName::declared("state_hash"),
+        CanonicalValue::text("0".repeat(64)),
+    );
+    let error =
+        PersistedRuntimeState::from_canonical_bytes(&hash_mutation.to_canonical_bytes(), &plan)
+            .unwrap_err();
+    assert_eq!(
+        error.code(),
+        nomos_core::diagnostic::codes::RUNTIME_STATE_HASH_MISMATCH
+    );
+
+    let mut order_mutation = parse_canonical(&bytes).unwrap();
+    let state = object(&mut order_mutation)
+        .get_mut(&FieldName::declared("state"))
+        .unwrap();
+    let CanonicalValue::Array(entities) = object(state)
+        .get_mut(&FieldName::declared("entities"))
+        .unwrap()
+    else {
+        panic!("state entities must be an array")
+    };
+    entities.reverse();
+    assert!(
+        PersistedRuntimeState::from_canonical_bytes(&order_mutation.to_canonical_bytes(), &plan)
+            .is_err()
+    );
+}
+
+#[test]
+fn command_script_round_trips_and_resolves_owned_namespaces() {
+    let bytes = b"schema nomos.command_script@1\nunlock north_gate with credential/gaoler_key\nopen north_gate\nextinguish brazier_02\n";
+    let script = CommandScript::from_bytes(bytes).unwrap();
+    assert_eq!(script.to_bytes(), bytes);
+    assert_eq!(script.requests().len(), 3);
+
+    let plan = plan(SOURCE);
+    let unlock = resolve_command(&plan, &script.requests()[0]).unwrap();
+    assert_eq!(unlock.namespace().to_string(), "north_gate.access");
+    assert_eq!(unlock.action().as_str(), "unlock");
+    assert!(matches!(unlock.argument(), CommandArgument::Credential(_)));
+
+    let open = resolve_command(&plan, &script.requests()[1]).unwrap();
+    assert_eq!(open.namespace().to_string(), "north_gate.access");
+    assert!(matches!(open.argument(), CommandArgument::None));
+
+    let extinguish = resolve_command(&plan, &script.requests()[2]).unwrap();
+    assert_eq!(extinguish.namespace().to_string(), "brazier_02.emission");
+}
+
+#[test]
+fn command_language_rejects_noncanonical_text_and_requirement_mismatches() {
+    for bytes in [
+        &b"schema nomos.command_script@1\n"[..],
+        &b"schema nomos.command_script@1\r\nopen north_gate\r\n"[..],
+        &b"schema nomos.command_script@1\nopen  north_gate\n"[..],
+        &b"schema nomos.command_script@1\nopen north_gate \n"[..],
+        &b"schema nomos.command_script@1\n# comment\n"[..],
+        &b"schema nomos.command_script@1\nopen north_gate\n\n"[..],
+        &b"schema nomos.command_script@2\nopen north_gate\n"[..],
+        &[0xff][..],
+    ] {
+        let error = CommandScript::from_bytes(bytes).unwrap_err();
+        assert_eq!(
+            error.code(),
+            nomos_core::diagnostic::codes::RUNTIME_COMMAND_SCRIPT_INVALID
+        );
+    }
+
+    let plan = plan(SOURCE);
+    let missing_credential = CommandRequest::new(
+        nomos_core::Ident::new("unlock").unwrap(),
+        nomos_core::EntityId::parse("north_gate").unwrap(),
+        None,
+    );
+    assert_eq!(
+        resolve_command(&plan, &missing_credential)
+            .unwrap_err()
+            .code(),
+        nomos_core::diagnostic::codes::RUNTIME_ARGUMENT_MISMATCH
+    );
+
+    let unknown = CommandRequest::new(
+        nomos_core::Ident::new("dance").unwrap(),
+        nomos_core::EntityId::parse("north_gate").unwrap(),
+        None,
+    );
+    assert_eq!(
+        resolve_command(&plan, &unknown).unwrap_err().code(),
+        nomos_core::diagnostic::codes::RUNTIME_ACTION_UNDECLARED
+    );
+}

--- a/crates/nomos-core/src/diagnostic.rs
+++ b/crates/nomos-core/src/diagnostic.rs
@@ -476,6 +476,16 @@ pub mod codes {
     pub const RUNTIME_STATE_HASH_MISMATCH: DiagnosticCode = DiagnosticCode::new("EK0810");
     /// Runtime commit evidence disagrees with compiler-projected consumers.
     pub const RUNTIME_PROJECTION_MISMATCH: DiagnosticCode = DiagnosticCode::new("EK0811");
+    /// Persisted runtime evidence has an invalid schema or semantic shape.
+    pub const RUNTIME_PERSISTED_INVALID: DiagnosticCode = DiagnosticCode::new("EK0812");
+    /// A persisted state belongs to different compiled runtime semantics.
+    pub const RUNTIME_SEMANTICS_MISMATCH: DiagnosticCode = DiagnosticCode::new("EK0813");
+    /// A command script or request violates the accepted language.
+    pub const RUNTIME_COMMAND_SCRIPT_INVALID: DiagnosticCode = DiagnosticCode::new("EK0814");
+    /// A user command resolves to more than one owned machine namespace.
+    pub const RUNTIME_COMMAND_AMBIGUOUS: DiagnosticCode = DiagnosticCode::new("EK0815");
+    /// Persisted logs, hashes, receipts, or result evidence disagree.
+    pub const RUNTIME_EVIDENCE_INCONSISTENT: DiagnosticCode = DiagnosticCode::new("EK0816");
 
     /// A resolver-plan collection repeats one stable semantic identity.
     pub const RESOLVER_DUPLICATE_IDENTITY: DiagnosticCode = DiagnosticCode::new("EK0901");

--- a/crates/nomos-core/src/diagnostic.rs
+++ b/crates/nomos-core/src/diagnostic.rs
@@ -55,6 +55,15 @@ impl DiagnosticCode {
             && bytes[1] == b'K'
             && bytes[2..].iter().all(u8::is_ascii_digit)
     }
+
+    /// Resolves one known stable diagnostic-code spelling.
+    #[must_use]
+    pub fn parse(code: &str) -> Option<Self> {
+        codes::ALL
+            .iter()
+            .copied()
+            .find(|candidate| candidate.as_str() == code)
+    }
 }
 
 impl fmt::Display for DiagnosticCode {
@@ -575,6 +584,11 @@ pub mod codes {
         RUNTIME_STATE_INVALID,
         RUNTIME_STATE_HASH_MISMATCH,
         RUNTIME_PROJECTION_MISMATCH,
+        RUNTIME_PERSISTED_INVALID,
+        RUNTIME_SEMANTICS_MISMATCH,
+        RUNTIME_COMMAND_SCRIPT_INVALID,
+        RUNTIME_COMMAND_AMBIGUOUS,
+        RUNTIME_EVIDENCE_INCONSISTENT,
         RESOLVER_DUPLICATE_IDENTITY,
         RESOLVER_CLAIM_ENTITY_MISMATCH,
         RESOLVER_ACTIVATION_NAMESPACE_MISSING,

--- a/crates/nomos-core/src/hash.rs
+++ b/crates/nomos-core/src/hash.rs
@@ -102,6 +102,12 @@ impl StateHash {
     pub fn to_hex(&self) -> String {
         self.0.to_hex()
     }
+
+    /// Parses the one lowercase hexadecimal state-hash spelling.
+    #[must_use]
+    pub fn from_hex(text: &str) -> Option<Self> {
+        Sha256Digest::from_hex(text).map(Self)
+    }
 }
 
 impl fmt::Display for StateHash {

--- a/crates/nomos-sim/src/command_language.rs
+++ b/crates/nomos-sim/src/command_language.rs
@@ -10,6 +10,8 @@ use nomos_projection::{
     Command, CommandArgument, CommandRequirement, MachineDefinition, SimulationPlan,
 };
 
+use crate::state_persistence::{field, object, require_fields, text};
+
 const HEADER: &str = "schema nomos.command_script@1";
 
 /// One user-facing request before compiler-projected namespace resolution.
@@ -66,6 +68,38 @@ impl CommandRequest {
             ("argument", argument),
             ("entity", self.entity.to_canonical()),
         ])
+    }
+
+    pub(crate) fn from_canonical(value: &CanonicalValue) -> Result<Self, Diagnostic> {
+        let fields = object(value, "command request")?;
+        require_fields(fields, &["action", "argument", "entity"], "command request")?;
+        let action = Ident::new(text(field(fields, "action")?, "command request action")?)
+            .map_err(|error| invalid(error.message()))?;
+        let entity = EntityId::parse(text(field(fields, "entity")?, "command request entity")?)
+            .map_err(|error| invalid(error.message()))?;
+        let argument = match field(fields, "argument")? {
+            CanonicalValue::Null => None,
+            value => {
+                let fields = object(value, "command request argument")?;
+                require_fields(fields, &["kind", "value"], "command request argument")?;
+                if text(field(fields, "kind")?, "command request argument kind")? != "catalog_value"
+                {
+                    return Err(invalid("command request argument kind is unsupported"));
+                }
+                Some(
+                    CatalogValueId::parse(text(
+                        field(fields, "value")?,
+                        "command request catalog value",
+                    )?)
+                    .map_err(|error| invalid(error.message()))?,
+                )
+            }
+        };
+        Ok(Self {
+            action,
+            entity,
+            argument,
+        })
     }
 
     fn to_line(&self) -> String {

--- a/crates/nomos-sim/src/command_language.rs
+++ b/crates/nomos-sim/src/command_language.rs
@@ -1,0 +1,268 @@
+//! Exact persisted command language and typed projection resolution.
+
+use std::collections::BTreeMap;
+
+use nomos_core::id::StableId;
+use nomos_core::{
+    CanonicalValue, CatalogValueId, Diagnostic, EntityId, Ident, NamespaceId, RepairClass,
+};
+use nomos_projection::{
+    Command, CommandArgument, CommandRequirement, MachineDefinition, SimulationPlan,
+};
+
+const HEADER: &str = "schema nomos.command_script@1";
+
+/// One user-facing request before compiler-projected namespace resolution.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CommandRequest {
+    action: Ident,
+    entity: EntityId,
+    argument: Option<CatalogValueId>,
+}
+
+impl CommandRequest {
+    /// Builds one typed unresolved request.
+    #[must_use]
+    pub const fn new(action: Ident, entity: EntityId, argument: Option<CatalogValueId>) -> Self {
+        Self {
+            action,
+            entity,
+            argument,
+        }
+    }
+
+    /// Requested namespace-local action.
+    #[must_use]
+    pub const fn action(&self) -> &Ident {
+        &self.action
+    }
+
+    /// Entity whose owned machines are searched.
+    #[must_use]
+    pub const fn entity(&self) -> &EntityId {
+        &self.entity
+    }
+
+    /// Optional typed catalog argument.
+    #[must_use]
+    pub const fn argument(&self) -> Option<&CatalogValueId> {
+        self.argument.as_ref()
+    }
+
+    /// Canonical semantic value used by later command-log evidence.
+    #[must_use]
+    pub fn to_canonical(&self) -> CanonicalValue {
+        let argument = self
+            .argument
+            .as_ref()
+            .map_or(CanonicalValue::Null, |value| {
+                CanonicalValue::object_declared([
+                    ("kind", CanonicalValue::text("catalog_value")),
+                    ("value", value.to_canonical()),
+                ])
+            });
+        CanonicalValue::object_declared([
+            ("action", CanonicalValue::text(self.action.as_str())),
+            ("argument", argument),
+            ("entity", self.entity.to_canonical()),
+        ])
+    }
+
+    fn to_line(&self) -> String {
+        self.argument.as_ref().map_or_else(
+            || format!("{} {}", self.action, self.entity),
+            |argument| format!("{} {} with {argument}", self.action, self.entity),
+        )
+    }
+}
+
+/// A strict nonempty command script with one schema header.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CommandScript {
+    requests: Vec<CommandRequest>,
+}
+
+impl CommandScript {
+    /// Parses exact UTF-8 command-script bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0814` for any encoding, header, whitespace, line-ending,
+    /// arity, or typed-identifier disagreement.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Diagnostic> {
+        let text =
+            std::str::from_utf8(bytes).map_err(|_| invalid("command script is not UTF-8 text"))?;
+        if !text.ends_with('\n') || text.ends_with("\n\n") || text.contains('\r') {
+            return Err(invalid(
+                "command script must use LF lines and end in exactly one LF",
+            ));
+        }
+        let mut lines = text[..text.len() - 1].split('\n');
+        if lines.next() != Some(HEADER) {
+            return Err(invalid(
+                "command script has the wrong or missing schema header",
+            ));
+        }
+        let requests = lines.map(parse_request).collect::<Result<Vec<_>, _>>()?;
+        if requests.is_empty() {
+            return Err(invalid("command script contains no commands"));
+        }
+        let script = Self { requests };
+        if script.to_bytes() != bytes {
+            return Err(invalid(
+                "command script does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(script)
+    }
+
+    /// Requests in authored execution order.
+    #[must_use]
+    pub fn requests(&self) -> &[CommandRequest] {
+        &self.requests
+    }
+
+    /// Emits the one accepted script spelling.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut text = String::from(HEADER);
+        text.push('\n');
+        for request in &self.requests {
+            text.push_str(&request.to_line());
+            text.push('\n');
+        }
+        text.into_bytes()
+    }
+}
+
+/// Resolves one request to exactly one compiler-projected external namespace.
+///
+/// # Errors
+///
+/// Returns a stable runtime diagnostic when the entity/action is absent, the
+/// action spans multiple owned namespaces, requirements disagree, or the
+/// supplied argument does not exactly satisfy the compiled requirement.
+pub fn resolve_command(
+    plan: &SimulationPlan,
+    request: &CommandRequest,
+) -> Result<Command, Diagnostic> {
+    let entity = plan
+        .entities()
+        .iter()
+        .find(|entity| entity.id() == request.entity())
+        .ok_or_else(|| {
+            Diagnostic::new(
+                nomos_core::diagnostic::codes::RUNTIME_TARGET_MISSING,
+                format!("command entity `{}` does not exist", request.entity()),
+            )
+        })?;
+    let machines = plan
+        .machines()
+        .iter()
+        .filter(|machine| entity.machines().contains(machine.namespace()))
+        .collect::<Vec<_>>();
+    let mut candidates = BTreeMap::<NamespaceId, CommandRequirement>::new();
+    for machine in machines {
+        if let Some(requirement) = action_requirement(machine, request.action())? {
+            candidates.insert(machine.namespace().clone(), requirement);
+        }
+    }
+    if candidates.len() != 1 {
+        return if candidates.len() > 1 {
+            Err(Diagnostic::new(
+                nomos_core::diagnostic::codes::RUNTIME_COMMAND_AMBIGUOUS,
+                format!(
+                    "command `{}` is exposed by multiple machines owned by `{}`",
+                    request.action(),
+                    request.entity()
+                ),
+            ))
+        } else {
+            Err(Diagnostic::new(
+                nomos_core::diagnostic::codes::RUNTIME_ACTION_UNDECLARED,
+                format!(
+                    "entity `{}` exposes no external command `{}`",
+                    request.entity(),
+                    request.action()
+                ),
+            ))
+        };
+    }
+    let (namespace, requirement) = candidates
+        .into_iter()
+        .next()
+        .expect("the candidate count was exactly one");
+    let argument = match (&requirement, request.argument()) {
+        (CommandRequirement::None, None) => CommandArgument::None,
+        (CommandRequirement::Credential(required), Some(supplied)) if required == supplied => {
+            CommandArgument::Credential(supplied.clone())
+        }
+        _ => {
+            return Err(Diagnostic::new(
+                nomos_core::diagnostic::codes::RUNTIME_ARGUMENT_MISMATCH,
+                "command argument does not match the compiled input requirement",
+            ));
+        }
+    };
+    Ok(Command::new(namespace, request.action().clone(), argument))
+}
+
+fn action_requirement(
+    machine: &MachineDefinition,
+    action: &Ident,
+) -> Result<Option<CommandRequirement>, Diagnostic> {
+    let mut requirements = machine
+        .commands()
+        .iter()
+        .filter(|transition| transition.action() == action)
+        .map(|transition| transition.requirement().clone());
+    let Some(first) = requirements.next() else {
+        return Ok(None);
+    };
+    if requirements.any(|requirement| requirement != first) {
+        return Err(Diagnostic::new(
+            nomos_core::diagnostic::codes::RUNTIME_STATE_INVALID,
+            format!(
+                "machine `{}` gives action `{action}` inconsistent input requirements",
+                machine.namespace()
+            ),
+        ));
+    }
+    Ok(Some(first))
+}
+
+fn parse_request(line: &str) -> Result<CommandRequest, Diagnostic> {
+    if line.is_empty()
+        || line.starts_with(' ')
+        || line.ends_with(' ')
+        || line.contains("  ")
+        || line.contains('\t')
+    {
+        return Err(invalid("command line uses unsupported whitespace"));
+    }
+    let tokens = line.split(' ').collect::<Vec<_>>();
+    let (action, entity, argument) = match tokens.as_slice() {
+        [action, entity] => (*action, *entity, None),
+        [action, entity, "with", argument] => (*action, *entity, Some(*argument)),
+        _ => {
+            return Err(invalid(
+                "command line has unsupported arity or argument syntax",
+            ));
+        }
+    };
+    let action = Ident::new(action).map_err(|error| invalid(error.message()))?;
+    let entity = EntityId::parse(entity).map_err(|error| invalid(error.message()))?;
+    let argument = argument
+        .map(CatalogValueId::parse)
+        .transpose()
+        .map_err(|error| invalid(error.message()))?;
+    Ok(CommandRequest::new(action, entity, argument))
+}
+
+fn invalid(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RUNTIME_COMMAND_SCRIPT_INVALID,
+        message,
+    )
+    .with_repair(RepairClass::FixSourceSyntax)
+}

--- a/crates/nomos-sim/src/lib.rs
+++ b/crates/nomos-sim/src/lib.rs
@@ -38,14 +38,18 @@
 
 use nomos_core::id::SchemaId;
 
+mod command_language;
 mod commit;
 mod receipt;
 mod resolver;
+mod state_persistence;
 mod transaction;
 
+pub use command_language::{CommandRequest, CommandScript, resolve_command};
 pub use commit::{CommittedTransaction, commit_transaction, commit_transaction_with_budget};
 pub use receipt::{CausalReceipt, EffectiveFactRef, EffectiveFactValue, ProjectionDelta};
 pub use resolver::{resolve_light, resolve_movement};
+pub use state_persistence::PersistedRuntimeState;
 pub use transaction::{
     DEFAULT_TRANSITION_BUDGET, PreparedTransaction, RuntimeEntityState, SimulationState,
     TransitionCause, TransitionStep, prepare_transaction, prepare_transaction_with_budget,
@@ -64,6 +68,20 @@ pub use transaction::{
 #[must_use]
 pub fn runtime_state_schema() -> SchemaId {
     SchemaId::new("nomos.runtime_state", 1).expect("the runtime state schema id is a valid literal")
+}
+
+/// Schema for a standalone state file bound to exact simulation semantics.
+#[must_use]
+pub fn persisted_runtime_state_schema() -> SchemaId {
+    SchemaId::new("nomos.persisted_runtime_state", 1)
+        .expect("the persisted runtime-state schema id is a valid literal")
+}
+
+/// Schema identity named by strict persisted command scripts.
+#[must_use]
+pub fn command_script_schema() -> SchemaId {
+    SchemaId::new("nomos.command_script", 1)
+        .expect("the command-script schema id is a valid literal")
 }
 
 /// The typed causal-receipt schema written beside runtime state.

--- a/crates/nomos-sim/src/lib.rs
+++ b/crates/nomos-sim/src/lib.rs
@@ -43,6 +43,7 @@ mod commit;
 mod receipt;
 mod resolver;
 mod run_evidence;
+mod run_result;
 mod state_persistence;
 mod transaction;
 
@@ -51,9 +52,9 @@ pub use commit::{CommittedTransaction, commit_transaction, commit_transaction_wi
 pub use receipt::{CausalReceipt, EffectiveFactRef, EffectiveFactValue, ProjectionDelta};
 pub use resolver::{resolve_light, resolve_movement};
 pub use run_evidence::{
-    CommandLog, CommandLogRow, RunArtifactDigest, RunArtifactName, RunResult, RunStatus,
-    StateHashRow, StateHashSequence,
+    CausalReceiptSequence, CommandLog, CommandLogRow, StateHashRow, StateHashSequence,
 };
+pub use run_result::{RunArtifactDigest, RunArtifactName, RunResult, RunStatus};
 pub use state_persistence::PersistedRuntimeState;
 pub use transaction::{
     DEFAULT_TRANSITION_BUDGET, PreparedTransaction, RuntimeEntityState, SimulationState,
@@ -102,6 +103,13 @@ pub fn state_hash_sequence_schema() -> SchemaId {
         .expect("the state-hash-sequence schema id is a valid literal")
 }
 
+/// Canonical schema for the ordered causal-receipt artifact.
+#[must_use]
+pub fn causal_receipt_sequence_schema() -> SchemaId {
+    SchemaId::new("nomos.causal_receipt_sequence", 1)
+        .expect("the causal-receipt-sequence schema id is a valid literal")
+}
+
 /// Canonical schema for the future run bundle's content-binding result.
 #[must_use]
 pub fn run_result_schema() -> SchemaId {
@@ -131,9 +139,9 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::{
-        causal_receipt_schema, command_log_schema, command_script_schema,
-        persisted_runtime_state_schema, replay_log_schema, run_result_schema, runtime_state_schema,
-        state_hash_sequence_schema,
+        causal_receipt_schema, causal_receipt_sequence_schema, command_log_schema,
+        command_script_schema, persisted_runtime_state_schema, replay_log_schema,
+        run_result_schema, runtime_state_schema, state_hash_sequence_schema,
     };
 
     #[test]
@@ -144,6 +152,7 @@ mod tests {
             command_script_schema(),
             command_log_schema(),
             state_hash_sequence_schema(),
+            causal_receipt_sequence_schema(),
             run_result_schema(),
             causal_receipt_schema(),
             replay_log_schema(),

--- a/crates/nomos-sim/src/lib.rs
+++ b/crates/nomos-sim/src/lib.rs
@@ -42,6 +42,7 @@ mod command_language;
 mod commit;
 mod receipt;
 mod resolver;
+mod run_evidence;
 mod state_persistence;
 mod transaction;
 
@@ -49,6 +50,10 @@ pub use command_language::{CommandRequest, CommandScript, resolve_command};
 pub use commit::{CommittedTransaction, commit_transaction, commit_transaction_with_budget};
 pub use receipt::{CausalReceipt, EffectiveFactRef, EffectiveFactValue, ProjectionDelta};
 pub use resolver::{resolve_light, resolve_movement};
+pub use run_evidence::{
+    CommandLog, CommandLogRow, RunArtifactDigest, RunArtifactName, RunResult, RunStatus,
+    StateHashRow, StateHashSequence,
+};
 pub use state_persistence::PersistedRuntimeState;
 pub use transaction::{
     DEFAULT_TRANSITION_BUDGET, PreparedTransaction, RuntimeEntityState, SimulationState,
@@ -84,6 +89,25 @@ pub fn command_script_schema() -> SchemaId {
         .expect("the command-script schema id is a valid literal")
 }
 
+/// Canonical schema for committed command-log evidence.
+#[must_use]
+pub fn command_log_schema() -> SchemaId {
+    SchemaId::new("nomos.command_log", 1).expect("the command-log schema id is a valid literal")
+}
+
+/// Canonical schema for the initial-and-committed state-hash chain.
+#[must_use]
+pub fn state_hash_sequence_schema() -> SchemaId {
+    SchemaId::new("nomos.state_hash_sequence", 1)
+        .expect("the state-hash-sequence schema id is a valid literal")
+}
+
+/// Canonical schema for the future run bundle's content-binding result.
+#[must_use]
+pub fn run_result_schema() -> SchemaId {
+    SchemaId::new("nomos.run_result", 1).expect("the run-result schema id is a valid literal")
+}
+
 /// The typed causal-receipt schema written beside runtime state.
 #[must_use]
 pub fn causal_receipt_schema() -> SchemaId {
@@ -104,19 +128,42 @@ pub fn replay_log_schema() -> SchemaId {
 
 #[cfg(test)]
 mod tests {
-    use super::{causal_receipt_schema, replay_log_schema, runtime_state_schema};
+    use std::collections::BTreeSet;
+
+    use super::{
+        causal_receipt_schema, command_log_schema, command_script_schema,
+        persisted_runtime_state_schema, replay_log_schema, run_result_schema, runtime_state_schema,
+        state_hash_sequence_schema,
+    };
 
     #[test]
     fn runtime_schemas_are_independent_of_the_projections_this_crate_consumes() {
-        let runtime = runtime_state_schema();
-        assert_ne!(runtime.name(), replay_log_schema().name());
-        assert_ne!(runtime.name(), causal_receipt_schema().name());
+        let runtime_schemas = [
+            runtime_state_schema(),
+            persisted_runtime_state_schema(),
+            command_script_schema(),
+            command_log_schema(),
+            state_hash_sequence_schema(),
+            run_result_schema(),
+            causal_receipt_schema(),
+            replay_log_schema(),
+        ];
+        assert_eq!(
+            runtime_schemas
+                .iter()
+                .map(|schema| schema.name())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            runtime_schemas.len()
+        );
         for projection in nomos_projection::all_schemas() {
-            assert_ne!(
-                runtime.name(),
-                projection.name(),
-                "runtime state versions independently of any projection"
-            );
+            for runtime in &runtime_schemas {
+                assert_ne!(
+                    runtime.name(),
+                    projection.name(),
+                    "runtime evidence versions independently of every projection"
+                );
+            }
         }
     }
 }

--- a/crates/nomos-sim/src/receipt.rs
+++ b/crates/nomos-sim/src/receipt.rs
@@ -1,12 +1,22 @@
 //! Typed causal receipts for committed runtime transactions.
 
+use std::collections::{BTreeMap, BTreeSet};
+
+use nomos_core::canonical::read::parse_canonical;
 use nomos_core::id::StableId;
-use nomos_core::{CanonicalValue, ClaimRef, Diagnostic, EntityId, SchemaId, StateHash};
+use nomos_core::{
+    CanonicalValue, ClaimRef, Diagnostic, EntityId, Ident, NamespaceId, SchemaId, Sha256Digest,
+    StateHash,
+};
 use nomos_projection::{
     Command, CommandArgument, EventPayload, MovementDisposition, ResolvedLight, ResolvedLightFacts,
-    ResolvedMovementFacts, SimulationPlan, navigation_schema, simulation_schema,
+    ResolvedMovement, ResolvedMovementFacts, SimulationPlan, diagnostics_schema, navigation_schema,
+    persistence_schema, simulation_schema,
 };
 
+use crate::state_persistence::{
+    array, field, invalid, object, require_fields, schema, state_hash, text, uint,
+};
 use crate::{PreparedTransaction, TransitionCause, TransitionStep};
 
 /// Typed identity of one effective runtime fact.
@@ -154,8 +164,23 @@ impl CausalReceipt {
         tick: u64,
         state_hash: StateHash,
     ) -> Result<Self, Diagnostic> {
+        let actual_light_consumers = plan
+            .light_resolver()
+            .consumers()
+            .iter()
+            .map(|consumer| consumer.schema())
+            .collect::<BTreeSet<_>>();
+        let expected_light_consumers = [
+            diagnostics_schema(),
+            persistence_schema(),
+            simulation_schema(),
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+        if actual_light_consumers != expected_light_consumers {
+            return Err(projection_mismatch());
+        }
         let projection_deltas = projection_deltas(
-            plan,
             prepared.movement_before(),
             prepared.movement_after(),
             prepared.light_before(),
@@ -235,6 +260,68 @@ impl CausalReceipt {
         self.state_hash
     }
 
+    /// SHA-256 identity of the exact canonical receipt bytes.
+    #[must_use]
+    pub fn digest(&self) -> Sha256Digest {
+        Sha256Digest::of_bytes(&self.to_canonical_bytes())
+    }
+
+    /// Strictly reconstructs one complete typed causal receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first canonical, schema, typed-value, ordering, or
+    /// cross-field disagreement diagnostic.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, Diagnostic> {
+        let value = parse_canonical(bytes)?;
+        let fields = object(&value, "causal receipt")?;
+        require_fields(
+            fields,
+            &[
+                "command",
+                "effective_facts_after",
+                "effective_facts_before",
+                "projection_deltas",
+                "schema",
+                "state_hash",
+                "tick",
+                "transitions",
+            ],
+            "causal receipt",
+        )?;
+        let schema = schema(field(fields, "schema")?, "causal receipt schema")?;
+        if schema != crate::causal_receipt_schema() {
+            return Err(invalid("causal receipt names an unsupported schema"));
+        }
+        let command = decode_command(field(fields, "command")?)?;
+        let (movement_before, light_before) =
+            decode_facts(field(fields, "effective_facts_before")?)?;
+        let (movement_after, light_after) = decode_facts(field(fields, "effective_facts_after")?)?;
+        let projection_deltas = decode_projection_deltas(field(fields, "projection_deltas")?)?;
+        let tick = uint(field(fields, "tick")?, "causal receipt tick")?;
+        let state_hash = state_hash(field(fields, "state_hash")?)?;
+        let steps = decode_transitions(field(fields, "transitions")?)?;
+        let receipt = Self {
+            schema,
+            command,
+            steps,
+            movement_before,
+            movement_after,
+            light_before,
+            light_after,
+            projection_deltas,
+            tick,
+            state_hash,
+        };
+        receipt.validate_semantics()?;
+        if receipt.to_canonical_bytes() != bytes {
+            return Err(invalid(
+                "causal receipt does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(receipt)
+    }
+
     /// Canonical receipt bytes suitable for the separate run output.
     #[must_use]
     pub fn to_canonical_bytes(&self) -> Vec<u8> {
@@ -267,10 +354,79 @@ impl CausalReceipt {
         ])
         .to_canonical_bytes()
     }
+
+    fn validate_semantics(&self) -> Result<(), Diagnostic> {
+        if self.tick == 0 {
+            return Err(invalid(
+                "a committed causal receipt must advance beyond tick zero",
+            ));
+        }
+        if matches!(self.command.argument(), CommandArgument::Event(_)) {
+            return Err(invalid(
+                "a causal receipt initiating command cannot carry an internal event payload",
+            ));
+        }
+        let Some(first) = self.steps.first() else {
+            return Err(invalid("a causal receipt must contain a local transition"));
+        };
+        if first.phase() != nomos_projection::Phase::Local
+            || first.namespace() != self.command.namespace()
+            || !matches!(
+                first.cause(),
+                TransitionCause::Command(action) if action == self.command.action()
+            )
+        {
+            return Err(invalid(
+                "the first receipt transition does not match the initiating command",
+            ));
+        }
+        let mut latest = BTreeMap::<NamespaceId, Ident>::new();
+        for (index, step) in self.steps.iter().enumerate() {
+            if step.from() == step.to() {
+                return Err(invalid(
+                    "a receipt transition does not change machine state",
+                ));
+            }
+            let expected_shape = if index == 0 {
+                step.phase() == nomos_projection::Phase::Local
+                    && matches!(step.cause(), TransitionCause::Command(_))
+            } else {
+                step.phase() == nomos_projection::Phase::Causal
+                    && matches!(step.cause(), TransitionCause::Event { .. })
+            };
+            if !expected_shape {
+                return Err(invalid(
+                    "receipt transitions are not ordered as one local step followed by causal steps",
+                ));
+            }
+            if latest
+                .get(step.namespace())
+                .is_some_and(|prior| prior != step.from())
+            {
+                return Err(invalid(
+                    "receipt transitions disagree on namespace-local state continuity",
+                ));
+            }
+            latest.insert(step.namespace().clone(), step.to().clone());
+        }
+        validate_fact_reasons(&self.movement_before, &self.light_before)?;
+        validate_fact_reasons(&self.movement_after, &self.light_after)?;
+        let expected = projection_deltas(
+            &self.movement_before,
+            &self.movement_after,
+            &self.light_before,
+            &self.light_after,
+        )?;
+        if self.projection_deltas != expected {
+            return Err(invalid(
+                "causal receipt projection deltas disagree with its effective facts",
+            ));
+        }
+        Ok(())
+    }
 }
 
 fn projection_deltas(
-    plan: &SimulationPlan,
     movement_before: &ResolvedMovementFacts,
     movement_after: &ResolvedMovementFacts,
     light_before: &ResolvedLightFacts,
@@ -307,9 +463,13 @@ fn projection_deltas(
             };
             let before_value = EffectiveFactValue::from_light(before);
             let after_value = EffectiveFactValue::from_light(after);
-            for consumer in plan.light_resolver().consumers() {
+            for projection in [
+                diagnostics_schema(),
+                persistence_schema(),
+                simulation_schema(),
+            ] {
                 deltas.push(ProjectionDelta {
-                    projection: consumer.schema(),
+                    projection,
                     fact: fact.clone(),
                     before: before_value.clone(),
                     after: after_value.clone(),
@@ -326,12 +486,60 @@ fn projection_deltas(
     Ok(deltas)
 }
 
-fn command_to_canonical(command: &Command) -> CanonicalValue {
+pub(crate) fn command_to_canonical(command: &Command) -> CanonicalValue {
     CanonicalValue::object_declared([
         ("action", CanonicalValue::text(command.action().as_str())),
         ("argument", argument_to_canonical(command.argument())),
         ("namespace", command.namespace().to_canonical()),
     ])
+}
+
+pub(crate) fn decode_command(value: &CanonicalValue) -> Result<Command, Diagnostic> {
+    let fields = object(value, "typed command")?;
+    require_fields(
+        fields,
+        &["action", "argument", "namespace"],
+        "typed command",
+    )?;
+    let namespace = NamespaceId::parse(text(
+        field(fields, "namespace")?,
+        "typed command namespace",
+    )?)
+    .map_err(|error| invalid(error.message()))?;
+    let action = Ident::new(text(field(fields, "action")?, "typed command action")?)
+        .map_err(|error| invalid(error.message()))?;
+    let argument = decode_argument(field(fields, "argument")?)?;
+    Ok(Command::new(namespace, action, argument))
+}
+
+fn decode_argument(value: &CanonicalValue) -> Result<CommandArgument, Diagnostic> {
+    let fields = object(value, "typed command argument")?;
+    match text(field(fields, "kind")?, "typed command argument kind")? {
+        "none" => {
+            require_fields(fields, &["kind"], "empty command argument")?;
+            Ok(CommandArgument::None)
+        }
+        "credential" => {
+            require_fields(
+                fields,
+                &["credential", "kind"],
+                "credential command argument",
+            )?;
+            let credential = nomos_core::CatalogValueId::parse(text(
+                field(fields, "credential")?,
+                "command credential",
+            )?)
+            .map_err(|error| invalid(error.message()))?;
+            Ok(CommandArgument::Credential(credential))
+        }
+        "event" => {
+            require_fields(fields, &["kind", "payload"], "event command argument")?;
+            Ok(CommandArgument::Event(decode_payload(field(
+                fields, "payload",
+            )?)?))
+        }
+        _ => Err(invalid("typed command argument kind is unsupported")),
+    }
 }
 
 fn argument_to_canonical(argument: &CommandArgument) -> CanonicalValue {
@@ -446,6 +654,262 @@ fn movement_to_canonical(disposition: &MovementDisposition) -> CanonicalValue {
             ),
         ]),
     }
+}
+
+fn decode_transitions(value: &CanonicalValue) -> Result<Vec<TransitionStep>, Diagnostic> {
+    array(value, "causal receipt transitions")?
+        .iter()
+        .map(|row| {
+            let fields = object(row, "causal receipt transition")?;
+            require_fields(
+                fields,
+                &["cause", "from", "namespace", "phase", "to"],
+                "causal receipt transition",
+            )?;
+            let phase = match text(field(fields, "phase")?, "transition phase")? {
+                "local" => nomos_projection::Phase::Local,
+                "causal" => nomos_projection::Phase::Causal,
+                _ => return Err(invalid("receipt transition phase is unsupported")),
+            };
+            let namespace =
+                NamespaceId::parse(text(field(fields, "namespace")?, "transition namespace")?)
+                    .map_err(|error| invalid(error.message()))?;
+            let from = Ident::new(text(field(fields, "from")?, "transition source state")?)
+                .map_err(|error| invalid(error.message()))?;
+            let to = Ident::new(text(field(fields, "to")?, "transition target state")?)
+                .map_err(|error| invalid(error.message()))?;
+            let cause = decode_cause(field(fields, "cause")?)?;
+            Ok(TransitionStep::from_parts(
+                phase, namespace, from, to, cause,
+            ))
+        })
+        .collect()
+}
+
+fn decode_cause(value: &CanonicalValue) -> Result<TransitionCause, Diagnostic> {
+    let fields = object(value, "transition cause")?;
+    match text(field(fields, "kind")?, "transition cause kind")? {
+        "command" => {
+            require_fields(fields, &["action", "kind"], "command transition cause")?;
+            let action = Ident::new(text(field(fields, "action")?, "cause action")?)
+                .map_err(|error| invalid(error.message()))?;
+            Ok(TransitionCause::Command(action))
+        }
+        "event" => {
+            require_fields(
+                fields,
+                &["handler", "kind", "payload"],
+                "event transition cause",
+            )?;
+            let handler = Ident::new(text(field(fields, "handler")?, "event handler")?)
+                .map_err(|error| invalid(error.message()))?;
+            Ok(TransitionCause::Event {
+                handler,
+                payload: decode_payload(field(fields, "payload")?)?,
+            })
+        }
+        _ => Err(invalid("transition cause kind is unsupported")),
+    }
+}
+
+fn decode_payload(value: &CanonicalValue) -> Result<EventPayload, Diagnostic> {
+    let fields = object(value, "event payload")?;
+    match text(field(fields, "kind")?, "event payload kind")? {
+        "damage" => {
+            require_fields(fields, &["amount", "channel", "kind"], "damage payload")?;
+            let amount = u32::try_from(uint(field(fields, "amount")?, "damage amount")?)
+                .map_err(|_| invalid("damage amount exceeds u32"))?;
+            let channel = Ident::new(text(field(fields, "channel")?, "damage channel")?)
+                .map_err(|error| invalid(error.message()))?;
+            Ok(EventPayload::Damage { channel, amount })
+        }
+        _ => Err(invalid("event payload kind is unsupported")),
+    }
+}
+
+fn decode_facts(
+    value: &CanonicalValue,
+) -> Result<(ResolvedMovementFacts, ResolvedLightFacts), Diagnostic> {
+    let fields = object(value, "effective facts")?;
+    require_fields(fields, &["light", "movement"], "effective facts")?;
+    let movement = array(field(fields, "movement")?, "movement facts")?
+        .iter()
+        .map(|row| {
+            let fields = object(row, "movement fact")?;
+            require_fields(fields, &["disposition", "entity"], "movement fact")?;
+            let entity = entity(field(fields, "entity")?, "movement fact entity")?;
+            let disposition = decode_movement(field(fields, "disposition")?)?;
+            Ok(ResolvedMovement::new(entity, disposition))
+        })
+        .collect::<Result<Vec<_>, Diagnostic>>()?;
+    let light = array(field(fields, "light")?, "light facts")?
+        .iter()
+        .map(|row| {
+            let fields = object(row, "light fact")?;
+            require_fields(fields, &["emitting", "entity", "reasons"], "light fact")?;
+            ResolvedLight::new(
+                entity(field(fields, "entity")?, "light fact entity")?,
+                boolean(field(fields, "emitting")?, "light emitting value")?,
+                claim_refs(field(fields, "reasons")?, "light reasons")?,
+            )
+            .map_err(|error| invalid(error.message()))
+        })
+        .collect::<Result<Vec<_>, Diagnostic>>()?;
+    Ok((
+        ResolvedMovementFacts::new(movement).map_err(|error| invalid(error.message()))?,
+        ResolvedLightFacts::new(light).map_err(|error| invalid(error.message()))?,
+    ))
+}
+
+fn decode_movement(value: &CanonicalValue) -> Result<MovementDisposition, Diagnostic> {
+    let fields = object(value, "movement disposition")?;
+    match text(field(fields, "kind")?, "movement disposition kind")? {
+        "blocked" => {
+            require_fields(fields, &["kind", "reasons"], "blocked disposition")?;
+            MovementDisposition::blocked(claim_refs(field(fields, "reasons")?, "movement reasons")?)
+                .map_err(|error| invalid(error.message()))
+        }
+        "traversable" => {
+            require_fields(
+                fields,
+                &["cost", "kind", "reasons"],
+                "traversable disposition",
+            )?;
+            let cost = u32::try_from(uint(field(fields, "cost")?, "traversal cost")?)
+                .map_err(|_| invalid("traversal cost exceeds u32"))?;
+            MovementDisposition::traversable(
+                cost,
+                claim_refs(field(fields, "reasons")?, "movement reasons")?,
+            )
+            .map_err(|error| invalid(error.message()))
+        }
+        _ => Err(invalid("movement disposition kind is unsupported")),
+    }
+}
+
+fn decode_projection_deltas(value: &CanonicalValue) -> Result<Vec<ProjectionDelta>, Diagnostic> {
+    array(value, "projection deltas")?
+        .iter()
+        .map(|row| {
+            let fields = object(row, "projection delta")?;
+            require_fields(
+                fields,
+                &["after", "before", "fact", "projection"],
+                "projection delta",
+            )?;
+            let fact = decode_fact_ref(field(fields, "fact")?)?;
+            let before = decode_fact_value(field(fields, "before")?)?;
+            let after = decode_fact_value(field(fields, "after")?)?;
+            if !fact_matches_value(&fact, &before) || !fact_matches_value(&fact, &after) {
+                return Err(invalid(
+                    "projection delta fact identity and value variants disagree",
+                ));
+            }
+            Ok(ProjectionDelta {
+                projection: schema(field(fields, "projection")?, "projection delta schema")?,
+                fact,
+                before,
+                after,
+            })
+        })
+        .collect()
+}
+
+fn decode_fact_ref(value: &CanonicalValue) -> Result<EffectiveFactRef, Diagnostic> {
+    let fields = object(value, "effective fact identity")?;
+    require_fields(fields, &["entity", "kind"], "effective fact identity")?;
+    let entity = entity(field(fields, "entity")?, "effective fact entity")?;
+    match text(field(fields, "kind")?, "effective fact kind")? {
+        "ground_movement" => Ok(EffectiveFactRef::GroundMovement { entity }),
+        "emits_light" => Ok(EffectiveFactRef::EmitsLight { entity }),
+        _ => Err(invalid("effective fact identity kind is unsupported")),
+    }
+}
+
+fn decode_fact_value(value: &CanonicalValue) -> Result<EffectiveFactValue, Diagnostic> {
+    let fields = object(value, "effective fact value")?;
+    match text(field(fields, "kind")?, "effective fact value kind")? {
+        "blocked" | "traversable" => {
+            Ok(EffectiveFactValue::GroundMovement(decode_movement(value)?))
+        }
+        "emits_light" => {
+            require_fields(
+                fields,
+                &["emitting", "kind", "reasons"],
+                "light effective value",
+            )?;
+            let emitting = boolean(field(fields, "emitting")?, "light effective value")?;
+            let reasons = claim_refs(field(fields, "reasons")?, "light effective reasons")?;
+            if emitting != !reasons.is_empty() {
+                return Err(invalid(
+                    "effective light value disagrees with its active reasons",
+                ));
+            }
+            Ok(EffectiveFactValue::EmitsLight { emitting, reasons })
+        }
+        _ => Err(invalid("effective fact value kind is unsupported")),
+    }
+}
+
+fn fact_matches_value(fact: &EffectiveFactRef, value: &EffectiveFactValue) -> bool {
+    matches!(
+        (fact, value),
+        (
+            EffectiveFactRef::GroundMovement { .. },
+            EffectiveFactValue::GroundMovement(_)
+        ) | (
+            EffectiveFactRef::EmitsLight { .. },
+            EffectiveFactValue::EmitsLight { .. }
+        )
+    )
+}
+
+fn validate_fact_reasons(
+    movement: &ResolvedMovementFacts,
+    light: &ResolvedLightFacts,
+) -> Result<(), Diagnostic> {
+    for fact in movement.facts() {
+        if fact
+            .disposition()
+            .reasons()
+            .iter()
+            .any(|reason| reason.namespace().entity() != fact.entity())
+        {
+            return Err(invalid(
+                "movement fact carries a reason owned by a different entity",
+            ));
+        }
+    }
+    for fact in light.facts() {
+        if fact
+            .reasons()
+            .iter()
+            .any(|reason| reason.namespace().entity() != fact.entity())
+        {
+            return Err(invalid(
+                "light fact carries a reason owned by a different entity",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn claim_refs(value: &CanonicalValue, label: &str) -> Result<Vec<ClaimRef>, Diagnostic> {
+    array(value, label)?
+        .iter()
+        .map(|value| ClaimRef::parse(text(value, label)?).map_err(|error| invalid(error.message())))
+        .collect()
+}
+
+fn entity(value: &CanonicalValue, label: &str) -> Result<EntityId, Diagnostic> {
+    EntityId::parse(text(value, label)?).map_err(|error| invalid(error.message()))
+}
+
+fn boolean(value: &CanonicalValue, label: &str) -> Result<bool, Diagnostic> {
+    let CanonicalValue::Bool(value) = value else {
+        return Err(invalid(format!("{label} is not a boolean")));
+    };
+    Ok(*value)
 }
 
 fn projection_mismatch() -> Diagnostic {

--- a/crates/nomos-sim/src/receipt.rs
+++ b/crates/nomos-sim/src/receipt.rs
@@ -325,6 +325,10 @@ impl CausalReceipt {
     /// Canonical receipt bytes suitable for the separate run output.
     #[must_use]
     pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        self.to_canonical().to_canonical_bytes()
+    }
+
+    pub(crate) fn to_canonical(&self) -> CanonicalValue {
         CanonicalValue::object_declared([
             ("command", command_to_canonical(&self.command)),
             (
@@ -352,7 +356,6 @@ impl CausalReceipt {
                 CanonicalValue::Array(self.steps.iter().map(transition_to_canonical).collect()),
             ),
         ])
-        .to_canonical_bytes()
     }
 
     fn validate_semantics(&self) -> Result<(), Diagnostic> {

--- a/crates/nomos-sim/src/run_evidence.rs
+++ b/crates/nomos-sim/src/run_evidence.rs
@@ -1,0 +1,945 @@
+//! Typed persisted evidence shared by future run and replay orchestration.
+
+use std::collections::BTreeSet;
+
+use nomos_core::canonical::read::parse_canonical;
+use nomos_core::{
+    CanonicalValue, Diagnostic, DiagnosticCode, RepairClass, SchemaId, Sha256Digest, StateHash,
+};
+use nomos_projection::{Command, CommandArgument};
+
+use crate::receipt::{command_to_canonical, decode_command};
+use crate::state_persistence::{
+    array, digest, field, invalid, object, require_fields, schema, state_hash, text, uint,
+};
+use crate::{CausalReceipt, CommandRequest};
+
+/// One committed command and the exact evidence identities surrounding it.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CommandLogRow {
+    ordinal: u64,
+    request: CommandRequest,
+    resolved_command: Command,
+    input_state_hash: StateHash,
+    resulting_state_hash: StateHash,
+    causal_receipt_digest: Sha256Digest,
+}
+
+impl CommandLogRow {
+    /// Binds one authored request and resolved command to its committed receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` when the request and typed command disagree.
+    pub fn new(
+        ordinal: u64,
+        request: CommandRequest,
+        resolved_command: Command,
+        input_state_hash: StateHash,
+        receipt: &CausalReceipt,
+    ) -> Result<Self, Diagnostic> {
+        let row = Self {
+            ordinal,
+            request,
+            resolved_command,
+            input_state_hash,
+            resulting_state_hash: receipt.state_hash(),
+            causal_receipt_digest: receipt.digest(),
+        };
+        row.validate_request_command()?;
+        if row.resolved_command != *receipt.command() {
+            return Err(inconsistent(
+                "command-log resolved command disagrees with its causal receipt",
+            ));
+        }
+        Ok(row)
+    }
+
+    /// Zero-based committed-command ordinal.
+    #[must_use]
+    pub const fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+
+    /// Authored unresolved request.
+    #[must_use]
+    pub const fn request(&self) -> &CommandRequest {
+        &self.request
+    }
+
+    /// Compiler-projection-resolved typed command.
+    #[must_use]
+    pub const fn resolved_command(&self) -> &Command {
+        &self.resolved_command
+    }
+
+    /// State hash consumed by this command.
+    #[must_use]
+    pub const fn input_state_hash(&self) -> StateHash {
+        self.input_state_hash
+    }
+
+    /// State hash produced by this command.
+    #[must_use]
+    pub const fn resulting_state_hash(&self) -> StateHash {
+        self.resulting_state_hash
+    }
+
+    /// SHA-256 identity of the exact canonical causal receipt.
+    #[must_use]
+    pub const fn causal_receipt_digest(&self) -> Sha256Digest {
+        self.causal_receipt_digest
+    }
+
+    fn from_canonical(value: &CanonicalValue) -> Result<Self, Diagnostic> {
+        let fields = object(value, "command-log row")?;
+        require_fields(
+            fields,
+            &[
+                "causal_receipt_digest",
+                "input_state_hash",
+                "ordinal",
+                "request",
+                "resolved_command",
+                "resulting_state_hash",
+            ],
+            "command-log row",
+        )?;
+        let row = Self {
+            ordinal: uint(field(fields, "ordinal")?, "command-log ordinal")?,
+            request: CommandRequest::from_canonical(field(fields, "request")?)?,
+            resolved_command: decode_command(field(fields, "resolved_command")?)?,
+            input_state_hash: state_hash(field(fields, "input_state_hash")?)?,
+            resulting_state_hash: state_hash(field(fields, "resulting_state_hash")?)?,
+            causal_receipt_digest: digest(
+                field(fields, "causal_receipt_digest")?,
+                "causal receipt digest",
+            )?,
+        };
+        row.validate_request_command()?;
+        Ok(row)
+    }
+
+    fn validate_request_command(&self) -> Result<(), Diagnostic> {
+        let argument_matches = match (self.request.argument(), self.resolved_command.argument()) {
+            (None, CommandArgument::None) => true,
+            (Some(requested), CommandArgument::Credential(resolved)) => requested == resolved,
+            _ => false,
+        };
+        if self.request.entity() != self.resolved_command.namespace().entity()
+            || self.request.action() != self.resolved_command.action()
+            || !argument_matches
+        {
+            return Err(inconsistent(
+                "command-log request disagrees with its resolved typed command",
+            ));
+        }
+        Ok(())
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            (
+                "causal_receipt_digest",
+                CanonicalValue::text(self.causal_receipt_digest.to_hex()),
+            ),
+            (
+                "input_state_hash",
+                CanonicalValue::text(self.input_state_hash.to_hex()),
+            ),
+            ("ordinal", CanonicalValue::Uint(self.ordinal)),
+            ("request", self.request.to_canonical()),
+            (
+                "resolved_command",
+                command_to_canonical(&self.resolved_command),
+            ),
+            (
+                "resulting_state_hash",
+                CanonicalValue::text(self.resulting_state_hash.to_hex()),
+            ),
+        ])
+    }
+}
+
+/// Canonical ordered log of successfully committed commands.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CommandLog {
+    schema: SchemaId,
+    rows: Vec<CommandLogRow>,
+}
+
+impl CommandLog {
+    /// Builds a log whose ordinals and state-hash chain are contiguous.
+    ///
+    /// An empty log is valid evidence for a run rejected before its first
+    /// command committed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` for an ordinal or hash-chain disagreement.
+    pub fn new(rows: Vec<CommandLogRow>) -> Result<Self, Diagnostic> {
+        for (index, row) in rows.iter().enumerate() {
+            let expected = u64::try_from(index)
+                .map_err(|_| inconsistent("command-log row count exceeds u64"))?;
+            if row.ordinal != expected {
+                return Err(inconsistent(
+                    "command-log ordinals are not contiguous from zero",
+                ));
+            }
+            row.validate_request_command()?;
+            if index > 0 && rows[index - 1].resulting_state_hash != row.input_state_hash {
+                return Err(inconsistent(
+                    "command-log input and resulting state hashes do not form one chain",
+                ));
+            }
+        }
+        Ok(Self {
+            schema: crate::command_log_schema(),
+            rows,
+        })
+    }
+
+    /// Committed rows in execution order.
+    #[must_use]
+    pub fn rows(&self) -> &[CommandLogRow] {
+        &self.rows
+    }
+
+    /// Strictly reconstructs one canonical command log.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first canonical, schema, typed-value, ordinal, or chain
+    /// disagreement diagnostic.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, Diagnostic> {
+        let value = parse_canonical(bytes)?;
+        let fields = object(&value, "command log")?;
+        require_fields(fields, &["rows", "schema"], "command log")?;
+        let schema = schema(field(fields, "schema")?, "command-log schema")?;
+        if schema != crate::command_log_schema() {
+            return Err(invalid("command log names an unsupported schema"));
+        }
+        let rows = array(field(fields, "rows")?, "command-log rows")?
+            .iter()
+            .map(CommandLogRow::from_canonical)
+            .collect::<Result<Vec<_>, _>>()?;
+        let log = Self::new(rows)?;
+        if log.to_canonical_bytes() != bytes {
+            return Err(invalid(
+                "command log does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(log)
+    }
+
+    /// Verifies every row against one exact typed causal receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` for count, command, tick, state-hash, or digest
+    /// disagreement.
+    pub fn validate_receipts(&self, receipts: &[CausalReceipt]) -> Result<(), Diagnostic> {
+        if receipts.len() != self.rows.len() {
+            return Err(inconsistent(
+                "command-log and causal-receipt counts disagree",
+            ));
+        }
+        for (index, (row, receipt)) in self.rows.iter().zip(receipts).enumerate() {
+            if row.resolved_command != *receipt.command()
+                || row.resulting_state_hash != receipt.state_hash()
+                || row.causal_receipt_digest != receipt.digest()
+            {
+                return Err(inconsistent(
+                    "command-log row disagrees with its typed causal receipt",
+                ));
+            }
+            if index > 0 {
+                let expected_tick = receipts[index - 1]
+                    .tick()
+                    .checked_add(1)
+                    .ok_or_else(|| inconsistent("causal-receipt tick chain overflows u64"))?;
+                if receipt.tick() != expected_tick {
+                    return Err(inconsistent(
+                        "causal-receipt ticks are not contiguous in command-log order",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Exact canonical command-log bytes.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        CanonicalValue::object_declared([
+            (
+                "rows",
+                CanonicalValue::Array(self.rows.iter().map(CommandLogRow::to_canonical).collect()),
+            ),
+            ("schema", self.schema.to_canonical()),
+        ])
+        .to_canonical_bytes()
+    }
+}
+
+/// One ordinal runtime snapshot identity in a run's state-hash chain.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StateHashRow {
+    ordinal: u64,
+    state_hash: StateHash,
+}
+
+impl StateHashRow {
+    /// Snapshot ordinal, where zero identifies the initial state.
+    #[must_use]
+    pub const fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+
+    /// Authoritative snapshot hash.
+    #[must_use]
+    pub const fn state_hash(&self) -> StateHash {
+        self.state_hash
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            ("ordinal", CanonicalValue::Uint(self.ordinal)),
+            ("state_hash", CanonicalValue::text(self.state_hash.to_hex())),
+        ])
+    }
+}
+
+/// Initial state hash followed by one resulting hash per committed command.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StateHashSequence {
+    schema: SchemaId,
+    rows: Vec<StateHashRow>,
+}
+
+impl StateHashSequence {
+    /// Builds the exact snapshot chain represented by one command log.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` when the supplied initial hash disagrees with the first
+    /// committed row or the collection size cannot be represented.
+    pub fn from_command_log(
+        initial_state_hash: StateHash,
+        log: &CommandLog,
+    ) -> Result<Self, Diagnostic> {
+        let capacity = log
+            .rows
+            .len()
+            .checked_add(1)
+            .ok_or_else(|| inconsistent("state-hash row count exceeds usize"))?;
+        let mut rows = Vec::with_capacity(capacity);
+        rows.push(StateHashRow {
+            ordinal: 0,
+            state_hash: initial_state_hash,
+        });
+        rows.extend(
+            log.rows
+                .iter()
+                .enumerate()
+                .map(|(index, row)| StateHashRow {
+                    ordinal: u64::try_from(index + 1).expect("an in-memory row count fits u64"),
+                    state_hash: row.resulting_state_hash,
+                }),
+        );
+        let sequence = Self {
+            schema: crate::state_hash_sequence_schema(),
+            rows,
+        };
+        sequence.validate_command_log(log)?;
+        Ok(sequence)
+    }
+
+    /// Snapshot identities from the initial state through the final commit.
+    #[must_use]
+    pub fn rows(&self) -> &[StateHashRow] {
+        &self.rows
+    }
+
+    /// First state hash in the sequence.
+    #[must_use]
+    pub fn first_state_hash(&self) -> StateHash {
+        self.rows[0].state_hash
+    }
+
+    /// Final state hash in the sequence.
+    #[must_use]
+    pub fn final_state_hash(&self) -> StateHash {
+        self.rows[self.rows.len() - 1].state_hash
+    }
+
+    /// Strictly reconstructs a nonempty canonical state-hash sequence.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first canonical, schema, hash, or contiguous-ordinal
+    /// disagreement diagnostic.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, Diagnostic> {
+        let value = parse_canonical(bytes)?;
+        let fields = object(&value, "state-hash sequence")?;
+        require_fields(fields, &["rows", "schema"], "state-hash sequence")?;
+        let schema = schema(field(fields, "schema")?, "state-hash-sequence schema")?;
+        if schema != crate::state_hash_sequence_schema() {
+            return Err(invalid("state-hash sequence names an unsupported schema"));
+        }
+        let rows = array(field(fields, "rows")?, "state-hash rows")?
+            .iter()
+            .map(|row| {
+                let fields = object(row, "state-hash row")?;
+                require_fields(fields, &["ordinal", "state_hash"], "state-hash row")?;
+                Ok(StateHashRow {
+                    ordinal: uint(field(fields, "ordinal")?, "state-hash ordinal")?,
+                    state_hash: state_hash(field(fields, "state_hash")?)?,
+                })
+            })
+            .collect::<Result<Vec<_>, Diagnostic>>()?;
+        validate_hash_rows(&rows)?;
+        let sequence = Self { schema, rows };
+        if sequence.to_canonical_bytes() != bytes {
+            return Err(invalid(
+                "state-hash sequence does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(sequence)
+    }
+
+    /// Verifies this sequence against every command-log input and result.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` for a count or row-by-row hash disagreement.
+    pub fn validate_command_log(&self, log: &CommandLog) -> Result<(), Diagnostic> {
+        if self.rows.len() != log.rows.len() + 1 {
+            return Err(inconsistent(
+                "state-hash sequence length does not match the command log",
+            ));
+        }
+        for (index, row) in log.rows.iter().enumerate() {
+            if self.rows[index].state_hash != row.input_state_hash
+                || self.rows[index + 1].state_hash != row.resulting_state_hash
+            {
+                return Err(inconsistent(
+                    "state-hash sequence disagrees with a command-log row",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Exact canonical state-hash-sequence bytes.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        CanonicalValue::object_declared([
+            (
+                "rows",
+                CanonicalValue::Array(self.rows.iter().map(StateHashRow::to_canonical).collect()),
+            ),
+            ("schema", self.schema.to_canonical()),
+        ])
+        .to_canonical_bytes()
+    }
+}
+
+/// Run-bundle artifact names bound by `result.json`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum RunArtifactName {
+    /// Persisted initial state.
+    InitialState,
+    /// Persisted final state.
+    FinalState,
+    /// Typed command log.
+    CommandLog,
+    /// Typed causal-receipt collection.
+    CausalReceipts,
+    /// Typed state-hash sequence.
+    StateHashes,
+}
+
+impl RunArtifactName {
+    /// Fixed root-level file name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InitialState => "initial-state.json",
+            Self::FinalState => "final-state.json",
+            Self::CommandLog => "command-log.json",
+            Self::CausalReceipts => "causal-receipts.json",
+            Self::StateHashes => "state-hashes.json",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "initial-state.json" => Some(Self::InitialState),
+            "final-state.json" => Some(Self::FinalState),
+            "command-log.json" => Some(Self::CommandLog),
+            "causal-receipts.json" => Some(Self::CausalReceipts),
+            "state-hashes.json" => Some(Self::StateHashes),
+            _ => None,
+        }
+    }
+
+    const ALL: [Self; 5] = [
+        Self::CausalReceipts,
+        Self::CommandLog,
+        Self::FinalState,
+        Self::InitialState,
+        Self::StateHashes,
+    ];
+}
+
+/// SHA-256 binding for one non-result run artifact.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RunArtifactDigest {
+    name: RunArtifactName,
+    digest: Sha256Digest,
+}
+
+impl RunArtifactDigest {
+    /// Builds one typed artifact binding.
+    #[must_use]
+    pub const fn new(name: RunArtifactName, digest: Sha256Digest) -> Self {
+        Self { name, digest }
+    }
+
+    /// Fixed artifact name.
+    #[must_use]
+    pub const fn name(&self) -> RunArtifactName {
+        self.name
+    }
+
+    /// SHA-256 of the artifact's exact canonical bytes.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            ("digest", CanonicalValue::text(self.digest.to_hex())),
+            ("name", CanonicalValue::text(self.name.as_str())),
+        ])
+    }
+}
+
+/// Terminal status of a future run bundle.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RunStatus {
+    /// Every requested command committed.
+    Completed,
+    /// Execution stopped on a stable rejection diagnostic.
+    Rejected,
+}
+
+impl RunStatus {
+    /// Stable wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Rejected => "rejected",
+        }
+    }
+}
+
+/// Content-binding record written as a future run bundle's `result.json`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RunResult {
+    schema: SchemaId,
+    input_package_digest: Sha256Digest,
+    runtime_semantics_digest: Sha256Digest,
+    status: RunStatus,
+    artifacts: Vec<RunArtifactDigest>,
+    first_state_hash: StateHash,
+    final_state_hash: StateHash,
+    committed_command_count: u64,
+    rejection_diagnostic: Option<DiagnosticCode>,
+}
+
+impl RunResult {
+    /// Builds content-binding evidence for a completed command script.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` when artifact coverage or the typed log/hash evidence
+    /// disagrees.
+    pub fn completed(
+        input_package_digest: Sha256Digest,
+        runtime_semantics_digest: Sha256Digest,
+        artifacts: Vec<RunArtifactDigest>,
+        log: &CommandLog,
+        hashes: &StateHashSequence,
+    ) -> Result<Self, Diagnostic> {
+        Self::build(
+            input_package_digest,
+            runtime_semantics_digest,
+            RunStatus::Completed,
+            artifacts,
+            log,
+            hashes,
+            None,
+        )
+    }
+
+    /// Builds content-binding evidence for a run stopped by rejection.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` under the same conditions as [`Self::completed`].
+    pub fn rejected(
+        input_package_digest: Sha256Digest,
+        runtime_semantics_digest: Sha256Digest,
+        artifacts: Vec<RunArtifactDigest>,
+        log: &CommandLog,
+        hashes: &StateHashSequence,
+        rejection_diagnostic: DiagnosticCode,
+    ) -> Result<Self, Diagnostic> {
+        Self::build(
+            input_package_digest,
+            runtime_semantics_digest,
+            RunStatus::Rejected,
+            artifacts,
+            log,
+            hashes,
+            Some(rejection_diagnostic),
+        )
+    }
+
+    fn build(
+        input_package_digest: Sha256Digest,
+        runtime_semantics_digest: Sha256Digest,
+        status: RunStatus,
+        artifacts: Vec<RunArtifactDigest>,
+        log: &CommandLog,
+        hashes: &StateHashSequence,
+        rejection_diagnostic: Option<DiagnosticCode>,
+    ) -> Result<Self, Diagnostic> {
+        hashes.validate_command_log(log)?;
+        let committed_command_count = u64::try_from(log.rows.len())
+            .map_err(|_| inconsistent("committed command count exceeds u64"))?;
+        let result = Self {
+            schema: crate::run_result_schema(),
+            input_package_digest,
+            runtime_semantics_digest,
+            status,
+            artifacts: normalize_artifacts(artifacts)?,
+            first_state_hash: hashes.first_state_hash(),
+            final_state_hash: hashes.final_state_hash(),
+            committed_command_count,
+            rejection_diagnostic,
+        };
+        result.validate_internal()?;
+        result.validate_typed_artifact_digests(log, hashes)?;
+        Ok(result)
+    }
+
+    /// Terminal run status.
+    #[must_use]
+    pub const fn status(&self) -> RunStatus {
+        self.status
+    }
+
+    /// Verified package digest recorded by the input package manifest.
+    #[must_use]
+    pub const fn input_package_digest(&self) -> Sha256Digest {
+        self.input_package_digest
+    }
+
+    /// Digest identifying the exact canonical simulation projection bytes.
+    #[must_use]
+    pub const fn runtime_semantics_digest(&self) -> Sha256Digest {
+        self.runtime_semantics_digest
+    }
+
+    /// Exact required non-result artifact bindings in file-name order.
+    #[must_use]
+    pub fn artifacts(&self) -> &[RunArtifactDigest] {
+        &self.artifacts
+    }
+
+    /// State hash from `initial-state.json`.
+    #[must_use]
+    pub const fn first_state_hash(&self) -> StateHash {
+        self.first_state_hash
+    }
+
+    /// State hash from `final-state.json`.
+    #[must_use]
+    pub const fn final_state_hash(&self) -> StateHash {
+        self.final_state_hash
+    }
+
+    /// Exact number of successfully committed commands.
+    #[must_use]
+    pub const fn committed_command_count(&self) -> u64 {
+        self.committed_command_count
+    }
+
+    /// Stable rejection code, present only for a rejected run.
+    #[must_use]
+    pub const fn rejection_diagnostic(&self) -> Option<DiagnosticCode> {
+        self.rejection_diagnostic
+    }
+
+    /// Strictly reconstructs one canonical run-result record.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first canonical, schema, artifact, status, count, or hash
+    /// consistency diagnostic.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, Diagnostic> {
+        let value = parse_canonical(bytes)?;
+        let fields = object(&value, "run result")?;
+        require_fields(
+            fields,
+            &[
+                "artifacts",
+                "committed_command_count",
+                "final_state_hash",
+                "first_state_hash",
+                "input_package_digest",
+                "rejection_diagnostic",
+                "runtime_semantics_digest",
+                "schema",
+                "status",
+            ],
+            "run result",
+        )?;
+        let schema = schema(field(fields, "schema")?, "run-result schema")?;
+        if schema != crate::run_result_schema() {
+            return Err(invalid("run result names an unsupported schema"));
+        }
+        let status = match text(field(fields, "status")?, "run status")? {
+            "completed" => RunStatus::Completed,
+            "rejected" => RunStatus::Rejected,
+            _ => return Err(invalid("run status is unsupported")),
+        };
+        let artifacts = array(field(fields, "artifacts")?, "run artifacts")?
+            .iter()
+            .map(|row| {
+                let fields = object(row, "run artifact")?;
+                require_fields(fields, &["digest", "name"], "run artifact")?;
+                let name =
+                    RunArtifactName::parse(text(field(fields, "name")?, "run artifact name")?)
+                        .ok_or_else(|| invalid("run artifact name is unsupported"))?;
+                Ok(RunArtifactDigest {
+                    name,
+                    digest: digest(field(fields, "digest")?, "run artifact digest")?,
+                })
+            })
+            .collect::<Result<Vec<_>, Diagnostic>>()?;
+        let rejection_diagnostic = match field(fields, "rejection_diagnostic")? {
+            CanonicalValue::Null => None,
+            value => {
+                let fields = object(value, "run rejection diagnostic")?;
+                require_fields(fields, &["code"], "run rejection diagnostic")?;
+                Some(
+                    DiagnosticCode::parse(text(field(fields, "code")?, "rejection code")?)
+                        .ok_or_else(|| invalid("run rejection diagnostic code is unknown"))?,
+                )
+            }
+        };
+        let result = Self {
+            schema,
+            input_package_digest: digest(
+                field(fields, "input_package_digest")?,
+                "input package digest",
+            )?,
+            runtime_semantics_digest: digest(
+                field(fields, "runtime_semantics_digest")?,
+                "runtime semantics digest",
+            )?,
+            status,
+            artifacts: normalize_artifacts(artifacts)?,
+            first_state_hash: state_hash(field(fields, "first_state_hash")?)?,
+            final_state_hash: state_hash(field(fields, "final_state_hash")?)?,
+            committed_command_count: uint(
+                field(fields, "committed_command_count")?,
+                "committed command count",
+            )?,
+            rejection_diagnostic,
+        };
+        result.validate_internal()?;
+        if result.to_canonical_bytes() != bytes {
+            return Err(invalid(
+                "run result does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(result)
+    }
+
+    /// Verifies count and endpoint hashes against typed log/hash evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` for any cross-object disagreement.
+    pub fn validate_evidence(
+        &self,
+        log: &CommandLog,
+        hashes: &StateHashSequence,
+    ) -> Result<(), Diagnostic> {
+        hashes.validate_command_log(log)?;
+        let count = u64::try_from(log.rows.len())
+            .map_err(|_| inconsistent("committed command count exceeds u64"))?;
+        if self.committed_command_count != count
+            || self.first_state_hash != hashes.first_state_hash()
+            || self.final_state_hash != hashes.final_state_hash()
+        {
+            return Err(inconsistent(
+                "run result disagrees with command-log or state-hash evidence",
+            ));
+        }
+        self.validate_typed_artifact_digests(log, hashes)?;
+        Ok(())
+    }
+
+    /// Exact canonical run-result bytes.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        let rejection = self
+            .rejection_diagnostic
+            .map_or(CanonicalValue::Null, |code| {
+                CanonicalValue::object_declared([("code", CanonicalValue::text(code.as_str()))])
+            });
+        CanonicalValue::object_declared([
+            (
+                "artifacts",
+                CanonicalValue::Array(
+                    self.artifacts
+                        .iter()
+                        .map(RunArtifactDigest::to_canonical)
+                        .collect(),
+                ),
+            ),
+            (
+                "committed_command_count",
+                CanonicalValue::Uint(self.committed_command_count),
+            ),
+            (
+                "final_state_hash",
+                CanonicalValue::text(self.final_state_hash.to_hex()),
+            ),
+            (
+                "first_state_hash",
+                CanonicalValue::text(self.first_state_hash.to_hex()),
+            ),
+            (
+                "input_package_digest",
+                CanonicalValue::text(self.input_package_digest.to_hex()),
+            ),
+            ("rejection_diagnostic", rejection),
+            (
+                "runtime_semantics_digest",
+                CanonicalValue::text(self.runtime_semantics_digest.to_hex()),
+            ),
+            ("schema", self.schema.to_canonical()),
+            ("status", CanonicalValue::text(self.status.as_str())),
+        ])
+        .to_canonical_bytes()
+    }
+
+    fn validate_internal(&self) -> Result<(), Diagnostic> {
+        match (self.status, self.rejection_diagnostic) {
+            (RunStatus::Completed, None) | (RunStatus::Rejected, Some(_)) => {}
+            _ => {
+                return Err(inconsistent(
+                    "run status and rejection diagnostic presence disagree",
+                ));
+            }
+        }
+        if self.status == RunStatus::Completed && self.committed_command_count == 0 {
+            return Err(inconsistent(
+                "a completed nonempty command script must commit at least one command",
+            ));
+        }
+        if self.committed_command_count == 0 && self.first_state_hash != self.final_state_hash {
+            return Err(inconsistent(
+                "a zero-commit run has different first and final state hashes",
+            ));
+        }
+        if self.committed_command_count > 0 && self.first_state_hash == self.final_state_hash {
+            return Err(inconsistent(
+                "a committed run has identical first and final state hashes",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_typed_artifact_digests(
+        &self,
+        log: &CommandLog,
+        hashes: &StateHashSequence,
+    ) -> Result<(), Diagnostic> {
+        let expected = [
+            (
+                RunArtifactName::CommandLog,
+                Sha256Digest::of_bytes(&log.to_canonical_bytes()),
+            ),
+            (
+                RunArtifactName::StateHashes,
+                Sha256Digest::of_bytes(&hashes.to_canonical_bytes()),
+            ),
+        ];
+        for (name, digest) in expected {
+            let recorded = self
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.name == name)
+                .expect("run-result artifact coverage was already validated");
+            if recorded.digest != digest {
+                return Err(inconsistent(
+                    "run result artifact digest disagrees with typed run evidence",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_hash_rows(rows: &[StateHashRow]) -> Result<(), Diagnostic> {
+    if rows.is_empty() {
+        return Err(inconsistent(
+            "a state-hash sequence must contain its initial state",
+        ));
+    }
+    for (index, row) in rows.iter().enumerate() {
+        let expected =
+            u64::try_from(index).map_err(|_| inconsistent("state-hash row count exceeds u64"))?;
+        if row.ordinal != expected {
+            return Err(inconsistent(
+                "state-hash ordinals are not contiguous from zero",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn normalize_artifacts(
+    mut artifacts: Vec<RunArtifactDigest>,
+) -> Result<Vec<RunArtifactDigest>, Diagnostic> {
+    let actual = artifacts
+        .iter()
+        .map(|artifact| artifact.name)
+        .collect::<BTreeSet<_>>();
+    let expected = RunArtifactName::ALL.into_iter().collect::<BTreeSet<_>>();
+    if artifacts.len() != RunArtifactName::ALL.len() || actual != expected {
+        return Err(inconsistent(
+            "run result does not bind each required non-result artifact exactly once",
+        ));
+    }
+    artifacts.sort_by_key(|artifact| artifact.name.as_str());
+    Ok(artifacts)
+}
+
+fn inconsistent(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT,
+        message,
+    )
+    .with_repair(RepairClass::RebuildFromSource)
+}

--- a/crates/nomos-sim/src/run_evidence.rs
+++ b/crates/nomos-sim/src/run_evidence.rs
@@ -1,16 +1,12 @@
 //! Typed persisted evidence shared by future run and replay orchestration.
 
-use std::collections::BTreeSet;
-
 use nomos_core::canonical::read::parse_canonical;
-use nomos_core::{
-    CanonicalValue, Diagnostic, DiagnosticCode, RepairClass, SchemaId, Sha256Digest, StateHash,
-};
+use nomos_core::{CanonicalValue, Diagnostic, RepairClass, SchemaId, Sha256Digest, StateHash};
 use nomos_projection::{Command, CommandArgument};
 
 use crate::receipt::{command_to_canonical, decode_command};
 use crate::state_persistence::{
-    array, digest, field, invalid, object, require_fields, schema, state_hash, text, uint,
+    array, digest, field, invalid, object, require_fields, schema, state_hash, uint,
 };
 use crate::{CausalReceipt, CommandRequest};
 
@@ -238,7 +234,11 @@ impl CommandLog {
     ///
     /// Returns `EK0816` for count, command, tick, state-hash, or digest
     /// disagreement.
-    pub fn validate_receipts(&self, receipts: &[CausalReceipt]) -> Result<(), Diagnostic> {
+    pub fn validate_receipts(
+        &self,
+        initial_tick: u64,
+        receipts: &[CausalReceipt],
+    ) -> Result<(), Diagnostic> {
         if receipts.len() != self.rows.len() {
             return Err(inconsistent(
                 "command-log and causal-receipt counts disagree",
@@ -253,16 +253,17 @@ impl CommandLog {
                     "command-log row disagrees with its typed causal receipt",
                 ));
             }
-            if index > 0 {
-                let expected_tick = receipts[index - 1]
-                    .tick()
-                    .checked_add(1)
-                    .ok_or_else(|| inconsistent("causal-receipt tick chain overflows u64"))?;
-                if receipt.tick() != expected_tick {
-                    return Err(inconsistent(
-                        "causal-receipt ticks are not contiguous in command-log order",
-                    ));
-                }
+            let offset = u64::try_from(index)
+                .map_err(|_| inconsistent("causal-receipt count exceeds u64"))?
+                .checked_add(1)
+                .ok_or_else(|| inconsistent("causal-receipt tick offset overflows u64"))?;
+            let expected_tick = initial_tick
+                .checked_add(offset)
+                .ok_or_else(|| inconsistent("causal-receipt tick chain overflows u64"))?;
+            if receipt.tick() != expected_tick {
+                return Err(inconsistent(
+                    "causal-receipt ticks do not continue from the initial state",
+                ));
             }
         }
         Ok(())
@@ -280,6 +281,115 @@ impl CommandLog {
         ])
         .to_canonical_bytes()
     }
+}
+
+/// Canonical ordered collection written as `causal-receipts.json`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CausalReceiptSequence {
+    schema: SchemaId,
+    receipts: Vec<CausalReceipt>,
+}
+
+impl CausalReceiptSequence {
+    /// Builds a receipt collection anchored to one initial tick and command log.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` when count, command, tick, state-hash, or digest
+    /// evidence disagrees.
+    pub fn new(
+        initial_tick: u64,
+        log: &CommandLog,
+        receipts: Vec<CausalReceipt>,
+    ) -> Result<Self, Diagnostic> {
+        log.validate_receipts(initial_tick, &receipts)?;
+        Ok(Self {
+            schema: crate::causal_receipt_sequence_schema(),
+            receipts,
+        })
+    }
+
+    /// Strictly decoded causal receipts in committed-command order.
+    #[must_use]
+    pub fn receipts(&self) -> &[CausalReceipt] {
+        &self.receipts
+    }
+
+    /// Strictly reconstructs one canonical receipt sequence.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first canonical, schema, nested-receipt, or tick-order
+    /// disagreement diagnostic.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, Diagnostic> {
+        let value = parse_canonical(bytes)?;
+        let fields = object(&value, "causal-receipt sequence")?;
+        require_fields(fields, &["receipts", "schema"], "causal-receipt sequence")?;
+        let schema = schema(field(fields, "schema")?, "causal-receipt-sequence schema")?;
+        if schema != crate::causal_receipt_sequence_schema() {
+            return Err(invalid(
+                "causal-receipt sequence names an unsupported schema",
+            ));
+        }
+        let receipts = array(field(fields, "receipts")?, "causal receipts")?
+            .iter()
+            .map(|receipt| CausalReceipt::from_canonical_bytes(&receipt.to_canonical_bytes()))
+            .collect::<Result<Vec<_>, _>>()?;
+        validate_receipt_tick_continuity(&receipts)?;
+        let sequence = Self { schema, receipts };
+        if sequence.to_canonical_bytes() != bytes {
+            return Err(invalid(
+                "causal-receipt sequence does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(sequence)
+    }
+
+    /// Verifies this sequence against a command log and its input state's tick.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` for any cross-object disagreement.
+    pub fn validate_command_log(
+        &self,
+        initial_tick: u64,
+        log: &CommandLog,
+    ) -> Result<(), Diagnostic> {
+        log.validate_receipts(initial_tick, &self.receipts)
+    }
+
+    /// Exact canonical causal-receipt-sequence bytes.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        CanonicalValue::object_declared([
+            (
+                "receipts",
+                CanonicalValue::Array(
+                    self.receipts
+                        .iter()
+                        .map(CausalReceipt::to_canonical)
+                        .collect(),
+                ),
+            ),
+            ("schema", self.schema.to_canonical()),
+        ])
+        .to_canonical_bytes()
+    }
+}
+
+fn validate_receipt_tick_continuity(receipts: &[CausalReceipt]) -> Result<(), Diagnostic> {
+    for pair in receipts.windows(2) {
+        let expected = pair[0]
+            .tick()
+            .checked_add(1)
+            .ok_or_else(|| inconsistent("causal-receipt tick chain overflows u64"))?;
+        if pair[1].tick() != expected {
+            return Err(inconsistent(
+                "causal-receipt ticks are not contiguous in sequence order",
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// One ordinal runtime snapshot identity in a run's state-hash chain.
@@ -445,462 +555,6 @@ impl StateHashSequence {
     }
 }
 
-/// Run-bundle artifact names bound by `result.json`.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub enum RunArtifactName {
-    /// Persisted initial state.
-    InitialState,
-    /// Persisted final state.
-    FinalState,
-    /// Typed command log.
-    CommandLog,
-    /// Typed causal-receipt collection.
-    CausalReceipts,
-    /// Typed state-hash sequence.
-    StateHashes,
-}
-
-impl RunArtifactName {
-    /// Fixed root-level file name.
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::InitialState => "initial-state.json",
-            Self::FinalState => "final-state.json",
-            Self::CommandLog => "command-log.json",
-            Self::CausalReceipts => "causal-receipts.json",
-            Self::StateHashes => "state-hashes.json",
-        }
-    }
-
-    fn parse(value: &str) -> Option<Self> {
-        match value {
-            "initial-state.json" => Some(Self::InitialState),
-            "final-state.json" => Some(Self::FinalState),
-            "command-log.json" => Some(Self::CommandLog),
-            "causal-receipts.json" => Some(Self::CausalReceipts),
-            "state-hashes.json" => Some(Self::StateHashes),
-            _ => None,
-        }
-    }
-
-    const ALL: [Self; 5] = [
-        Self::CausalReceipts,
-        Self::CommandLog,
-        Self::FinalState,
-        Self::InitialState,
-        Self::StateHashes,
-    ];
-}
-
-/// SHA-256 binding for one non-result run artifact.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct RunArtifactDigest {
-    name: RunArtifactName,
-    digest: Sha256Digest,
-}
-
-impl RunArtifactDigest {
-    /// Builds one typed artifact binding.
-    #[must_use]
-    pub const fn new(name: RunArtifactName, digest: Sha256Digest) -> Self {
-        Self { name, digest }
-    }
-
-    /// Fixed artifact name.
-    #[must_use]
-    pub const fn name(&self) -> RunArtifactName {
-        self.name
-    }
-
-    /// SHA-256 of the artifact's exact canonical bytes.
-    #[must_use]
-    pub const fn digest(&self) -> Sha256Digest {
-        self.digest
-    }
-
-    fn to_canonical(&self) -> CanonicalValue {
-        CanonicalValue::object_declared([
-            ("digest", CanonicalValue::text(self.digest.to_hex())),
-            ("name", CanonicalValue::text(self.name.as_str())),
-        ])
-    }
-}
-
-/// Terminal status of a future run bundle.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum RunStatus {
-    /// Every requested command committed.
-    Completed,
-    /// Execution stopped on a stable rejection diagnostic.
-    Rejected,
-}
-
-impl RunStatus {
-    /// Stable wire spelling.
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Completed => "completed",
-            Self::Rejected => "rejected",
-        }
-    }
-}
-
-/// Content-binding record written as a future run bundle's `result.json`.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct RunResult {
-    schema: SchemaId,
-    input_package_digest: Sha256Digest,
-    runtime_semantics_digest: Sha256Digest,
-    status: RunStatus,
-    artifacts: Vec<RunArtifactDigest>,
-    first_state_hash: StateHash,
-    final_state_hash: StateHash,
-    committed_command_count: u64,
-    rejection_diagnostic: Option<DiagnosticCode>,
-}
-
-impl RunResult {
-    /// Builds content-binding evidence for a completed command script.
-    ///
-    /// # Errors
-    ///
-    /// Returns `EK0816` when artifact coverage or the typed log/hash evidence
-    /// disagrees.
-    pub fn completed(
-        input_package_digest: Sha256Digest,
-        runtime_semantics_digest: Sha256Digest,
-        artifacts: Vec<RunArtifactDigest>,
-        log: &CommandLog,
-        hashes: &StateHashSequence,
-    ) -> Result<Self, Diagnostic> {
-        Self::build(
-            input_package_digest,
-            runtime_semantics_digest,
-            RunStatus::Completed,
-            artifacts,
-            log,
-            hashes,
-            None,
-        )
-    }
-
-    /// Builds content-binding evidence for a run stopped by rejection.
-    ///
-    /// # Errors
-    ///
-    /// Returns `EK0816` under the same conditions as [`Self::completed`].
-    pub fn rejected(
-        input_package_digest: Sha256Digest,
-        runtime_semantics_digest: Sha256Digest,
-        artifacts: Vec<RunArtifactDigest>,
-        log: &CommandLog,
-        hashes: &StateHashSequence,
-        rejection_diagnostic: DiagnosticCode,
-    ) -> Result<Self, Diagnostic> {
-        Self::build(
-            input_package_digest,
-            runtime_semantics_digest,
-            RunStatus::Rejected,
-            artifacts,
-            log,
-            hashes,
-            Some(rejection_diagnostic),
-        )
-    }
-
-    fn build(
-        input_package_digest: Sha256Digest,
-        runtime_semantics_digest: Sha256Digest,
-        status: RunStatus,
-        artifacts: Vec<RunArtifactDigest>,
-        log: &CommandLog,
-        hashes: &StateHashSequence,
-        rejection_diagnostic: Option<DiagnosticCode>,
-    ) -> Result<Self, Diagnostic> {
-        hashes.validate_command_log(log)?;
-        let committed_command_count = u64::try_from(log.rows.len())
-            .map_err(|_| inconsistent("committed command count exceeds u64"))?;
-        let result = Self {
-            schema: crate::run_result_schema(),
-            input_package_digest,
-            runtime_semantics_digest,
-            status,
-            artifacts: normalize_artifacts(artifacts)?,
-            first_state_hash: hashes.first_state_hash(),
-            final_state_hash: hashes.final_state_hash(),
-            committed_command_count,
-            rejection_diagnostic,
-        };
-        result.validate_internal()?;
-        result.validate_typed_artifact_digests(log, hashes)?;
-        Ok(result)
-    }
-
-    /// Terminal run status.
-    #[must_use]
-    pub const fn status(&self) -> RunStatus {
-        self.status
-    }
-
-    /// Verified package digest recorded by the input package manifest.
-    #[must_use]
-    pub const fn input_package_digest(&self) -> Sha256Digest {
-        self.input_package_digest
-    }
-
-    /// Digest identifying the exact canonical simulation projection bytes.
-    #[must_use]
-    pub const fn runtime_semantics_digest(&self) -> Sha256Digest {
-        self.runtime_semantics_digest
-    }
-
-    /// Exact required non-result artifact bindings in file-name order.
-    #[must_use]
-    pub fn artifacts(&self) -> &[RunArtifactDigest] {
-        &self.artifacts
-    }
-
-    /// State hash from `initial-state.json`.
-    #[must_use]
-    pub const fn first_state_hash(&self) -> StateHash {
-        self.first_state_hash
-    }
-
-    /// State hash from `final-state.json`.
-    #[must_use]
-    pub const fn final_state_hash(&self) -> StateHash {
-        self.final_state_hash
-    }
-
-    /// Exact number of successfully committed commands.
-    #[must_use]
-    pub const fn committed_command_count(&self) -> u64 {
-        self.committed_command_count
-    }
-
-    /// Stable rejection code, present only for a rejected run.
-    #[must_use]
-    pub const fn rejection_diagnostic(&self) -> Option<DiagnosticCode> {
-        self.rejection_diagnostic
-    }
-
-    /// Strictly reconstructs one canonical run-result record.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first canonical, schema, artifact, status, count, or hash
-    /// consistency diagnostic.
-    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, Diagnostic> {
-        let value = parse_canonical(bytes)?;
-        let fields = object(&value, "run result")?;
-        require_fields(
-            fields,
-            &[
-                "artifacts",
-                "committed_command_count",
-                "final_state_hash",
-                "first_state_hash",
-                "input_package_digest",
-                "rejection_diagnostic",
-                "runtime_semantics_digest",
-                "schema",
-                "status",
-            ],
-            "run result",
-        )?;
-        let schema = schema(field(fields, "schema")?, "run-result schema")?;
-        if schema != crate::run_result_schema() {
-            return Err(invalid("run result names an unsupported schema"));
-        }
-        let status = match text(field(fields, "status")?, "run status")? {
-            "completed" => RunStatus::Completed,
-            "rejected" => RunStatus::Rejected,
-            _ => return Err(invalid("run status is unsupported")),
-        };
-        let artifacts = array(field(fields, "artifacts")?, "run artifacts")?
-            .iter()
-            .map(|row| {
-                let fields = object(row, "run artifact")?;
-                require_fields(fields, &["digest", "name"], "run artifact")?;
-                let name =
-                    RunArtifactName::parse(text(field(fields, "name")?, "run artifact name")?)
-                        .ok_or_else(|| invalid("run artifact name is unsupported"))?;
-                Ok(RunArtifactDigest {
-                    name,
-                    digest: digest(field(fields, "digest")?, "run artifact digest")?,
-                })
-            })
-            .collect::<Result<Vec<_>, Diagnostic>>()?;
-        let rejection_diagnostic = match field(fields, "rejection_diagnostic")? {
-            CanonicalValue::Null => None,
-            value => {
-                let fields = object(value, "run rejection diagnostic")?;
-                require_fields(fields, &["code"], "run rejection diagnostic")?;
-                Some(
-                    DiagnosticCode::parse(text(field(fields, "code")?, "rejection code")?)
-                        .ok_or_else(|| invalid("run rejection diagnostic code is unknown"))?,
-                )
-            }
-        };
-        let result = Self {
-            schema,
-            input_package_digest: digest(
-                field(fields, "input_package_digest")?,
-                "input package digest",
-            )?,
-            runtime_semantics_digest: digest(
-                field(fields, "runtime_semantics_digest")?,
-                "runtime semantics digest",
-            )?,
-            status,
-            artifacts: normalize_artifacts(artifacts)?,
-            first_state_hash: state_hash(field(fields, "first_state_hash")?)?,
-            final_state_hash: state_hash(field(fields, "final_state_hash")?)?,
-            committed_command_count: uint(
-                field(fields, "committed_command_count")?,
-                "committed command count",
-            )?,
-            rejection_diagnostic,
-        };
-        result.validate_internal()?;
-        if result.to_canonical_bytes() != bytes {
-            return Err(invalid(
-                "run result does not exactly re-encode from its typed meaning",
-            ));
-        }
-        Ok(result)
-    }
-
-    /// Verifies count and endpoint hashes against typed log/hash evidence.
-    ///
-    /// # Errors
-    ///
-    /// Returns `EK0816` for any cross-object disagreement.
-    pub fn validate_evidence(
-        &self,
-        log: &CommandLog,
-        hashes: &StateHashSequence,
-    ) -> Result<(), Diagnostic> {
-        hashes.validate_command_log(log)?;
-        let count = u64::try_from(log.rows.len())
-            .map_err(|_| inconsistent("committed command count exceeds u64"))?;
-        if self.committed_command_count != count
-            || self.first_state_hash != hashes.first_state_hash()
-            || self.final_state_hash != hashes.final_state_hash()
-        {
-            return Err(inconsistent(
-                "run result disagrees with command-log or state-hash evidence",
-            ));
-        }
-        self.validate_typed_artifact_digests(log, hashes)?;
-        Ok(())
-    }
-
-    /// Exact canonical run-result bytes.
-    #[must_use]
-    pub fn to_canonical_bytes(&self) -> Vec<u8> {
-        let rejection = self
-            .rejection_diagnostic
-            .map_or(CanonicalValue::Null, |code| {
-                CanonicalValue::object_declared([("code", CanonicalValue::text(code.as_str()))])
-            });
-        CanonicalValue::object_declared([
-            (
-                "artifacts",
-                CanonicalValue::Array(
-                    self.artifacts
-                        .iter()
-                        .map(RunArtifactDigest::to_canonical)
-                        .collect(),
-                ),
-            ),
-            (
-                "committed_command_count",
-                CanonicalValue::Uint(self.committed_command_count),
-            ),
-            (
-                "final_state_hash",
-                CanonicalValue::text(self.final_state_hash.to_hex()),
-            ),
-            (
-                "first_state_hash",
-                CanonicalValue::text(self.first_state_hash.to_hex()),
-            ),
-            (
-                "input_package_digest",
-                CanonicalValue::text(self.input_package_digest.to_hex()),
-            ),
-            ("rejection_diagnostic", rejection),
-            (
-                "runtime_semantics_digest",
-                CanonicalValue::text(self.runtime_semantics_digest.to_hex()),
-            ),
-            ("schema", self.schema.to_canonical()),
-            ("status", CanonicalValue::text(self.status.as_str())),
-        ])
-        .to_canonical_bytes()
-    }
-
-    fn validate_internal(&self) -> Result<(), Diagnostic> {
-        match (self.status, self.rejection_diagnostic) {
-            (RunStatus::Completed, None) | (RunStatus::Rejected, Some(_)) => {}
-            _ => {
-                return Err(inconsistent(
-                    "run status and rejection diagnostic presence disagree",
-                ));
-            }
-        }
-        if self.status == RunStatus::Completed && self.committed_command_count == 0 {
-            return Err(inconsistent(
-                "a completed nonempty command script must commit at least one command",
-            ));
-        }
-        if self.committed_command_count == 0 && self.first_state_hash != self.final_state_hash {
-            return Err(inconsistent(
-                "a zero-commit run has different first and final state hashes",
-            ));
-        }
-        if self.committed_command_count > 0 && self.first_state_hash == self.final_state_hash {
-            return Err(inconsistent(
-                "a committed run has identical first and final state hashes",
-            ));
-        }
-        Ok(())
-    }
-
-    fn validate_typed_artifact_digests(
-        &self,
-        log: &CommandLog,
-        hashes: &StateHashSequence,
-    ) -> Result<(), Diagnostic> {
-        let expected = [
-            (
-                RunArtifactName::CommandLog,
-                Sha256Digest::of_bytes(&log.to_canonical_bytes()),
-            ),
-            (
-                RunArtifactName::StateHashes,
-                Sha256Digest::of_bytes(&hashes.to_canonical_bytes()),
-            ),
-        ];
-        for (name, digest) in expected {
-            let recorded = self
-                .artifacts
-                .iter()
-                .find(|artifact| artifact.name == name)
-                .expect("run-result artifact coverage was already validated");
-            if recorded.digest != digest {
-                return Err(inconsistent(
-                    "run result artifact digest disagrees with typed run evidence",
-                ));
-            }
-        }
-        Ok(())
-    }
-}
-
 fn validate_hash_rows(rows: &[StateHashRow]) -> Result<(), Diagnostic> {
     if rows.is_empty() {
         return Err(inconsistent(
@@ -919,24 +573,7 @@ fn validate_hash_rows(rows: &[StateHashRow]) -> Result<(), Diagnostic> {
     Ok(())
 }
 
-fn normalize_artifacts(
-    mut artifacts: Vec<RunArtifactDigest>,
-) -> Result<Vec<RunArtifactDigest>, Diagnostic> {
-    let actual = artifacts
-        .iter()
-        .map(|artifact| artifact.name)
-        .collect::<BTreeSet<_>>();
-    let expected = RunArtifactName::ALL.into_iter().collect::<BTreeSet<_>>();
-    if artifacts.len() != RunArtifactName::ALL.len() || actual != expected {
-        return Err(inconsistent(
-            "run result does not bind each required non-result artifact exactly once",
-        ));
-    }
-    artifacts.sort_by_key(|artifact| artifact.name.as_str());
-    Ok(artifacts)
-}
-
-fn inconsistent(message: impl Into<String>) -> Diagnostic {
+pub(crate) fn inconsistent(message: impl Into<String>) -> Diagnostic {
     Diagnostic::new(
         nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT,
         message,

--- a/crates/nomos-sim/src/run_result.rs
+++ b/crates/nomos-sim/src/run_result.rs
@@ -1,0 +1,518 @@
+//! Content binding for the complete typed evidence of one future run bundle.
+
+use std::collections::BTreeSet;
+
+use nomos_core::canonical::read::parse_canonical;
+use nomos_core::{CanonicalValue, Diagnostic, DiagnosticCode, SchemaId, Sha256Digest, StateHash};
+
+use crate::run_evidence::inconsistent;
+use crate::state_persistence::{
+    array, digest, field, invalid, object, require_fields, schema, state_hash, text, uint,
+};
+use crate::{CausalReceiptSequence, CommandLog, PersistedRuntimeState, StateHashSequence};
+
+/// Run-bundle artifact names bound by `result.json`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum RunArtifactName {
+    /// Persisted initial state.
+    InitialState,
+    /// Persisted final state.
+    FinalState,
+    /// Typed command log.
+    CommandLog,
+    /// Typed causal-receipt collection.
+    CausalReceipts,
+    /// Typed state-hash sequence.
+    StateHashes,
+}
+
+impl RunArtifactName {
+    /// Fixed root-level file name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InitialState => "initial-state.json",
+            Self::FinalState => "final-state.json",
+            Self::CommandLog => "command-log.json",
+            Self::CausalReceipts => "causal-receipts.json",
+            Self::StateHashes => "state-hashes.json",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "initial-state.json" => Some(Self::InitialState),
+            "final-state.json" => Some(Self::FinalState),
+            "command-log.json" => Some(Self::CommandLog),
+            "causal-receipts.json" => Some(Self::CausalReceipts),
+            "state-hashes.json" => Some(Self::StateHashes),
+            _ => None,
+        }
+    }
+
+    const ALL: [Self; 5] = [
+        Self::CausalReceipts,
+        Self::CommandLog,
+        Self::FinalState,
+        Self::InitialState,
+        Self::StateHashes,
+    ];
+}
+
+/// SHA-256 binding for one non-result run artifact.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RunArtifactDigest {
+    name: RunArtifactName,
+    digest: Sha256Digest,
+}
+
+impl RunArtifactDigest {
+    /// Fixed artifact name.
+    #[must_use]
+    pub const fn name(&self) -> RunArtifactName {
+        self.name
+    }
+
+    /// SHA-256 of the artifact's exact canonical bytes.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+
+    fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            ("digest", CanonicalValue::text(self.digest.to_hex())),
+            ("name", CanonicalValue::text(self.name.as_str())),
+        ])
+    }
+}
+
+/// Terminal status of a future run bundle.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RunStatus {
+    /// Every requested command committed.
+    Completed,
+    /// Execution stopped on a stable rejection diagnostic.
+    Rejected,
+}
+
+impl RunStatus {
+    /// Stable wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Rejected => "rejected",
+        }
+    }
+}
+
+/// Content-binding record written as a future run bundle's `result.json`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RunResult {
+    schema: SchemaId,
+    input_package_digest: Sha256Digest,
+    runtime_semantics_digest: Sha256Digest,
+    status: RunStatus,
+    artifacts: Vec<RunArtifactDigest>,
+    first_state_hash: StateHash,
+    final_state_hash: StateHash,
+    committed_command_count: u64,
+    rejection_diagnostic: Option<DiagnosticCode>,
+}
+
+impl RunResult {
+    /// Builds content-binding evidence for a completed command script.
+    ///
+    /// Every artifact digest is derived from the supplied typed artifact; a
+    /// caller cannot inject an unverified digest.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` when any typed artifact disagrees with the others.
+    pub fn completed(
+        input_package_digest: Sha256Digest,
+        initial: &PersistedRuntimeState,
+        final_state: &PersistedRuntimeState,
+        log: &CommandLog,
+        receipts: &CausalReceiptSequence,
+        hashes: &StateHashSequence,
+    ) -> Result<Self, Diagnostic> {
+        Self::build(
+            input_package_digest,
+            RunStatus::Completed,
+            initial,
+            final_state,
+            log,
+            receipts,
+            hashes,
+            None,
+        )
+    }
+
+    /// Builds content-binding evidence for a run stopped by rejection.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` under the same conditions as [`Self::completed`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn rejected(
+        input_package_digest: Sha256Digest,
+        initial: &PersistedRuntimeState,
+        final_state: &PersistedRuntimeState,
+        log: &CommandLog,
+        receipts: &CausalReceiptSequence,
+        hashes: &StateHashSequence,
+        rejection_diagnostic: DiagnosticCode,
+    ) -> Result<Self, Diagnostic> {
+        Self::build(
+            input_package_digest,
+            RunStatus::Rejected,
+            initial,
+            final_state,
+            log,
+            receipts,
+            hashes,
+            Some(rejection_diagnostic),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        input_package_digest: Sha256Digest,
+        status: RunStatus,
+        initial: &PersistedRuntimeState,
+        final_state: &PersistedRuntimeState,
+        log: &CommandLog,
+        receipts: &CausalReceiptSequence,
+        hashes: &StateHashSequence,
+        rejection_diagnostic: Option<DiagnosticCode>,
+    ) -> Result<Self, Diagnostic> {
+        validate_typed_evidence(initial, final_state, log, receipts, hashes)?;
+        let committed_command_count = u64::try_from(log.rows().len())
+            .map_err(|_| inconsistent("committed command count exceeds u64"))?;
+        let result = Self {
+            schema: crate::run_result_schema(),
+            input_package_digest,
+            runtime_semantics_digest: initial.runtime_semantics_digest(),
+            status,
+            artifacts: artifact_digests(initial, final_state, log, receipts, hashes),
+            first_state_hash: initial.state_hash(),
+            final_state_hash: final_state.state_hash(),
+            committed_command_count,
+            rejection_diagnostic,
+        };
+        result.validate_internal()?;
+        Ok(result)
+    }
+
+    /// Terminal run status.
+    #[must_use]
+    pub const fn status(&self) -> RunStatus {
+        self.status
+    }
+
+    /// Verified package digest recorded by the input package manifest.
+    #[must_use]
+    pub const fn input_package_digest(&self) -> Sha256Digest {
+        self.input_package_digest
+    }
+
+    /// Digest identifying the exact canonical simulation projection bytes.
+    #[must_use]
+    pub const fn runtime_semantics_digest(&self) -> Sha256Digest {
+        self.runtime_semantics_digest
+    }
+
+    /// Exact required non-result artifact bindings in file-name order.
+    #[must_use]
+    pub fn artifacts(&self) -> &[RunArtifactDigest] {
+        &self.artifacts
+    }
+
+    /// State hash from `initial-state.json`.
+    #[must_use]
+    pub const fn first_state_hash(&self) -> StateHash {
+        self.first_state_hash
+    }
+
+    /// State hash from `final-state.json`.
+    #[must_use]
+    pub const fn final_state_hash(&self) -> StateHash {
+        self.final_state_hash
+    }
+
+    /// Exact number of successfully committed commands.
+    #[must_use]
+    pub const fn committed_command_count(&self) -> u64 {
+        self.committed_command_count
+    }
+
+    /// Stable rejection code, present only for a rejected run.
+    #[must_use]
+    pub const fn rejection_diagnostic(&self) -> Option<DiagnosticCode> {
+        self.rejection_diagnostic
+    }
+
+    /// Strictly reconstructs one canonical run-result record.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first canonical, schema, artifact, status, count, or hash
+    /// consistency diagnostic.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, Diagnostic> {
+        let value = parse_canonical(bytes)?;
+        let fields = object(&value, "run result")?;
+        require_fields(
+            fields,
+            &[
+                "artifacts",
+                "committed_command_count",
+                "final_state_hash",
+                "first_state_hash",
+                "input_package_digest",
+                "rejection_diagnostic",
+                "runtime_semantics_digest",
+                "schema",
+                "status",
+            ],
+            "run result",
+        )?;
+        let schema = schema(field(fields, "schema")?, "run-result schema")?;
+        if schema != crate::run_result_schema() {
+            return Err(invalid("run result names an unsupported schema"));
+        }
+        let status = match text(field(fields, "status")?, "run status")? {
+            "completed" => RunStatus::Completed,
+            "rejected" => RunStatus::Rejected,
+            _ => return Err(invalid("run status is unsupported")),
+        };
+        let artifacts = array(field(fields, "artifacts")?, "run artifacts")?
+            .iter()
+            .map(|row| {
+                let fields = object(row, "run artifact")?;
+                require_fields(fields, &["digest", "name"], "run artifact")?;
+                let name =
+                    RunArtifactName::parse(text(field(fields, "name")?, "run artifact name")?)
+                        .ok_or_else(|| invalid("run artifact name is unsupported"))?;
+                Ok(RunArtifactDigest {
+                    name,
+                    digest: digest(field(fields, "digest")?, "run artifact digest")?,
+                })
+            })
+            .collect::<Result<Vec<_>, Diagnostic>>()?;
+        let rejection_diagnostic = match field(fields, "rejection_diagnostic")? {
+            CanonicalValue::Null => None,
+            value => {
+                let fields = object(value, "run rejection diagnostic")?;
+                require_fields(fields, &["code"], "run rejection diagnostic")?;
+                Some(
+                    DiagnosticCode::parse(text(field(fields, "code")?, "rejection code")?)
+                        .ok_or_else(|| invalid("run rejection diagnostic code is unknown"))?,
+                )
+            }
+        };
+        let result = Self {
+            schema,
+            input_package_digest: digest(
+                field(fields, "input_package_digest")?,
+                "input package digest",
+            )?,
+            runtime_semantics_digest: digest(
+                field(fields, "runtime_semantics_digest")?,
+                "runtime semantics digest",
+            )?,
+            status,
+            artifacts: normalize_artifacts(artifacts)?,
+            first_state_hash: state_hash(field(fields, "first_state_hash")?)?,
+            final_state_hash: state_hash(field(fields, "final_state_hash")?)?,
+            committed_command_count: uint(
+                field(fields, "committed_command_count")?,
+                "committed command count",
+            )?,
+            rejection_diagnostic,
+        };
+        result.validate_internal()?;
+        if result.to_canonical_bytes() != bytes {
+            return Err(invalid(
+                "run result does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(result)
+    }
+
+    /// Verifies every recorded binding against all five typed artifacts.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` for any cross-object or content-digest disagreement.
+    pub fn validate_evidence(
+        &self,
+        initial: &PersistedRuntimeState,
+        final_state: &PersistedRuntimeState,
+        log: &CommandLog,
+        receipts: &CausalReceiptSequence,
+        hashes: &StateHashSequence,
+    ) -> Result<(), Diagnostic> {
+        validate_typed_evidence(initial, final_state, log, receipts, hashes)?;
+        let count = u64::try_from(log.rows().len())
+            .map_err(|_| inconsistent("committed command count exceeds u64"))?;
+        if self.committed_command_count != count
+            || self.runtime_semantics_digest != initial.runtime_semantics_digest()
+            || self.first_state_hash != initial.state_hash()
+            || self.final_state_hash != final_state.state_hash()
+            || self.artifacts != artifact_digests(initial, final_state, log, receipts, hashes)
+        {
+            return Err(inconsistent(
+                "run result disagrees with its typed run evidence",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Exact canonical run-result bytes.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        let rejection = self
+            .rejection_diagnostic
+            .map_or(CanonicalValue::Null, |code| {
+                CanonicalValue::object_declared([("code", CanonicalValue::text(code.as_str()))])
+            });
+        CanonicalValue::object_declared([
+            (
+                "artifacts",
+                CanonicalValue::Array(
+                    self.artifacts
+                        .iter()
+                        .map(RunArtifactDigest::to_canonical)
+                        .collect(),
+                ),
+            ),
+            (
+                "committed_command_count",
+                CanonicalValue::Uint(self.committed_command_count),
+            ),
+            (
+                "final_state_hash",
+                CanonicalValue::text(self.final_state_hash.to_hex()),
+            ),
+            (
+                "first_state_hash",
+                CanonicalValue::text(self.first_state_hash.to_hex()),
+            ),
+            (
+                "input_package_digest",
+                CanonicalValue::text(self.input_package_digest.to_hex()),
+            ),
+            ("rejection_diagnostic", rejection),
+            (
+                "runtime_semantics_digest",
+                CanonicalValue::text(self.runtime_semantics_digest.to_hex()),
+            ),
+            ("schema", self.schema.to_canonical()),
+            ("status", CanonicalValue::text(self.status.as_str())),
+        ])
+        .to_canonical_bytes()
+    }
+
+    fn validate_internal(&self) -> Result<(), Diagnostic> {
+        match (self.status, self.rejection_diagnostic) {
+            (RunStatus::Completed, None) | (RunStatus::Rejected, Some(_)) => {}
+            _ => {
+                return Err(inconsistent(
+                    "run status and rejection diagnostic presence disagree",
+                ));
+            }
+        }
+        if self.status == RunStatus::Completed && self.committed_command_count == 0 {
+            return Err(inconsistent(
+                "a completed nonempty command script must commit at least one command",
+            ));
+        }
+        if self.committed_command_count == 0 && self.first_state_hash != self.final_state_hash {
+            return Err(inconsistent(
+                "a zero-commit run has different first and final state hashes",
+            ));
+        }
+        if self.committed_command_count > 0 && self.first_state_hash == self.final_state_hash {
+            return Err(inconsistent(
+                "a committed run has identical first and final state hashes",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_typed_evidence(
+    initial: &PersistedRuntimeState,
+    final_state: &PersistedRuntimeState,
+    log: &CommandLog,
+    receipts: &CausalReceiptSequence,
+    hashes: &StateHashSequence,
+) -> Result<(), Diagnostic> {
+    hashes.validate_command_log(log)?;
+    receipts.validate_command_log(initial.state().tick(), log)?;
+    if initial.runtime_semantics_digest() != final_state.runtime_semantics_digest() {
+        return Err(inconsistent(
+            "initial and final states name different runtime semantics",
+        ));
+    }
+    if initial.state_hash() != hashes.first_state_hash()
+        || final_state.state_hash() != hashes.final_state_hash()
+    {
+        return Err(inconsistent(
+            "persisted state hashes disagree with the state-hash sequence endpoints",
+        ));
+    }
+    Ok(())
+}
+
+fn artifact_digests(
+    initial: &PersistedRuntimeState,
+    final_state: &PersistedRuntimeState,
+    log: &CommandLog,
+    receipts: &CausalReceiptSequence,
+    hashes: &StateHashSequence,
+) -> Vec<RunArtifactDigest> {
+    let mut artifacts = vec![
+        RunArtifactDigest {
+            name: RunArtifactName::InitialState,
+            digest: Sha256Digest::of_bytes(&initial.to_canonical_bytes()),
+        },
+        RunArtifactDigest {
+            name: RunArtifactName::FinalState,
+            digest: Sha256Digest::of_bytes(&final_state.to_canonical_bytes()),
+        },
+        RunArtifactDigest {
+            name: RunArtifactName::CommandLog,
+            digest: Sha256Digest::of_bytes(&log.to_canonical_bytes()),
+        },
+        RunArtifactDigest {
+            name: RunArtifactName::CausalReceipts,
+            digest: Sha256Digest::of_bytes(&receipts.to_canonical_bytes()),
+        },
+        RunArtifactDigest {
+            name: RunArtifactName::StateHashes,
+            digest: Sha256Digest::of_bytes(&hashes.to_canonical_bytes()),
+        },
+    ];
+    artifacts.sort_by_key(|artifact| artifact.name.as_str());
+    artifacts
+}
+
+fn normalize_artifacts(
+    mut artifacts: Vec<RunArtifactDigest>,
+) -> Result<Vec<RunArtifactDigest>, Diagnostic> {
+    let actual = artifacts
+        .iter()
+        .map(|artifact| artifact.name)
+        .collect::<BTreeSet<_>>();
+    let expected = RunArtifactName::ALL.into_iter().collect::<BTreeSet<_>>();
+    if artifacts.len() != RunArtifactName::ALL.len() || actual != expected {
+        return Err(inconsistent(
+            "run result does not bind each required non-result artifact exactly once",
+        ));
+    }
+    artifacts.sort_by_key(|artifact| artifact.name.as_str());
+    Ok(artifacts)
+}

--- a/crates/nomos-sim/src/state_persistence.rs
+++ b/crates/nomos-sim/src/state_persistence.rs
@@ -246,7 +246,7 @@ fn simulation_digest(plan: &SimulationPlan) -> Sha256Digest {
     Sha256Digest::of_bytes(&plan.to_canonical_bytes())
 }
 
-fn schema(value: &CanonicalValue, label: &str) -> Result<SchemaId, Diagnostic> {
+pub(crate) fn schema(value: &CanonicalValue, label: &str) -> Result<SchemaId, Diagnostic> {
     let fields = object(value, label)?;
     require_fields(fields, &["name", "version"], label)?;
     let version = u32::try_from(uint(field(fields, "version")?, label)?)
@@ -255,12 +255,12 @@ fn schema(value: &CanonicalValue, label: &str) -> Result<SchemaId, Diagnostic> {
         .map_err(|error| invalid(error.message()))
 }
 
-fn digest(value: &CanonicalValue, label: &str) -> Result<Sha256Digest, Diagnostic> {
+pub(crate) fn digest(value: &CanonicalValue, label: &str) -> Result<Sha256Digest, Diagnostic> {
     Sha256Digest::from_hex(text(value, label)?)
         .ok_or_else(|| invalid(format!("{label} is invalid")))
 }
 
-fn state_hash(value: &CanonicalValue) -> Result<StateHash, Diagnostic> {
+pub(crate) fn state_hash(value: &CanonicalValue) -> Result<StateHash, Diagnostic> {
     StateHash::from_hex(text(value, "state hash")?).ok_or_else(|| invalid("state hash is invalid"))
 }
 
@@ -274,7 +274,7 @@ fn int32(value: &CanonicalValue, label: &str) -> Result<i32, Diagnostic> {
     i32::try_from(value).map_err(|_| invalid(format!("{label} exceeds i32")))
 }
 
-fn uint(value: &CanonicalValue, label: &str) -> Result<u64, Diagnostic> {
+pub(crate) fn uint(value: &CanonicalValue, label: &str) -> Result<u64, Diagnostic> {
     match value {
         CanonicalValue::Uint(value) => Ok(*value),
         CanonicalValue::Int(value) => {
@@ -292,7 +292,7 @@ fn require_empty_array(value: &CanonicalValue, label: &str) -> Result<(), Diagno
     }
 }
 
-fn object<'a>(
+pub(crate) fn object<'a>(
     value: &'a CanonicalValue,
     label: &str,
 ) -> Result<&'a BTreeMap<FieldName, CanonicalValue>, Diagnostic> {
@@ -302,21 +302,24 @@ fn object<'a>(
     Ok(fields)
 }
 
-fn array<'a>(value: &'a CanonicalValue, label: &str) -> Result<&'a [CanonicalValue], Diagnostic> {
+pub(crate) fn array<'a>(
+    value: &'a CanonicalValue,
+    label: &str,
+) -> Result<&'a [CanonicalValue], Diagnostic> {
     let CanonicalValue::Array(values) = value else {
         return Err(invalid(format!("{label} is not an array")));
     };
     Ok(values)
 }
 
-fn text<'a>(value: &'a CanonicalValue, label: &str) -> Result<&'a str, Diagnostic> {
+pub(crate) fn text<'a>(value: &'a CanonicalValue, label: &str) -> Result<&'a str, Diagnostic> {
     let CanonicalValue::Text(value) = value else {
         return Err(invalid(format!("{label} is not text")));
     };
     Ok(value)
 }
 
-fn field<'a>(
+pub(crate) fn field<'a>(
     fields: &'a BTreeMap<FieldName, CanonicalValue>,
     name: &'static str,
 ) -> Result<&'a CanonicalValue, Diagnostic> {
@@ -325,7 +328,7 @@ fn field<'a>(
         .ok_or_else(|| invalid(format!("persisted runtime value has no `{name}` field")))
 }
 
-fn require_fields(
+pub(crate) fn require_fields(
     fields: &BTreeMap<FieldName, CanonicalValue>,
     expected: &[&str],
     label: &str,
@@ -342,7 +345,7 @@ fn require_fields(
     }
 }
 
-fn invalid(message: impl Into<String>) -> Diagnostic {
+pub(crate) fn invalid(message: impl Into<String>) -> Diagnostic {
     Diagnostic::new(
         nomos_core::diagnostic::codes::RUNTIME_PERSISTED_INVALID,
         message,

--- a/crates/nomos-sim/src/state_persistence.rs
+++ b/crates/nomos-sim/src/state_persistence.rs
@@ -1,0 +1,351 @@
+//! Strict persisted runtime-state evidence.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use nomos_core::canonical::read::parse_canonical;
+use nomos_core::{
+    CanonicalValue, Diagnostic, EntityId, FieldName, Ident, NamespaceId, RepairClass, SchemaId,
+    Sha256Digest, StateHash,
+};
+use nomos_projection::{LatticeCell, ProjectedDirection, RuntimeBinding, SimulationPlan};
+
+use crate::{RuntimeEntityState, SimulationState};
+
+/// One standalone runtime state bound to the complete simulation semantics
+/// under which it was produced.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct PersistedRuntimeState {
+    schema: SchemaId,
+    runtime_semantics_digest: Sha256Digest,
+    state: SimulationState,
+    state_hash: StateHash,
+}
+
+impl PersistedRuntimeState {
+    /// Binds a validated state to the exact canonical simulation projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0809` when the state does not conform to the supplied plan.
+    pub fn new(plan: &SimulationPlan, state: SimulationState) -> Result<Self, Diagnostic> {
+        state.validate_against(plan)?;
+        Ok(Self {
+            schema: crate::persisted_runtime_state_schema(),
+            runtime_semantics_digest: simulation_digest(plan),
+            state_hash: state.state_hash(),
+            state,
+        })
+    }
+
+    /// Strictly reconstructs and verifies one persisted state envelope.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first canonical, schema, state-hash, plan, or runtime-
+    /// semantics disagreement diagnostic.
+    pub fn from_canonical_bytes(bytes: &[u8], plan: &SimulationPlan) -> Result<Self, Diagnostic> {
+        let value = parse_canonical(bytes)?;
+        let fields = object(&value, "persisted runtime state")?;
+        require_fields(
+            fields,
+            &["runtime_semantics_digest", "schema", "state", "state_hash"],
+            "persisted runtime state",
+        )?;
+        let schema = schema(field(fields, "schema")?, "persisted runtime state schema")?;
+        if schema != crate::persisted_runtime_state_schema() {
+            return Err(invalid("persisted state names an unsupported schema"));
+        }
+        let runtime_semantics_digest = digest(
+            field(fields, "runtime_semantics_digest")?,
+            "runtime semantics digest",
+        )?;
+        if runtime_semantics_digest != simulation_digest(plan) {
+            return Err(Diagnostic::new(
+                nomos_core::diagnostic::codes::RUNTIME_SEMANTICS_MISMATCH,
+                "persisted state belongs to different simulation semantics",
+            )
+            .with_repair(RepairClass::RebuildFromSource));
+        }
+        let state_bytes = field(fields, "state")?.to_canonical_bytes();
+        let state = decode_state(&state_bytes, plan)?;
+        let state_hash = state_hash(field(fields, "state_hash")?)?;
+        state.verify_hash(state_hash)?;
+        let persisted = Self {
+            schema,
+            runtime_semantics_digest,
+            state,
+            state_hash,
+        };
+        if persisted.to_canonical_bytes() != bytes {
+            return Err(invalid(
+                "persisted state does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(persisted)
+    }
+
+    /// Exact simulation-projection digest binding this state file.
+    #[must_use]
+    pub const fn runtime_semantics_digest(&self) -> Sha256Digest {
+        self.runtime_semantics_digest
+    }
+
+    /// Verified authoritative runtime snapshot.
+    #[must_use]
+    pub const fn state(&self) -> &SimulationState {
+        &self.state
+    }
+
+    /// Verified hash of the inner runtime-state envelope only.
+    #[must_use]
+    pub const fn state_hash(&self) -> StateHash {
+        self.state_hash
+    }
+
+    /// Exact canonical persisted bytes.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        CanonicalValue::object_declared([
+            (
+                "runtime_semantics_digest",
+                CanonicalValue::text(self.runtime_semantics_digest.to_hex()),
+            ),
+            ("schema", self.schema.to_canonical()),
+            ("state", self.state.to_canonical()),
+            ("state_hash", CanonicalValue::text(self.state_hash.to_hex())),
+        ])
+        .to_canonical_bytes()
+    }
+}
+
+pub(crate) fn decode_state(
+    bytes: &[u8],
+    plan: &SimulationPlan,
+) -> Result<SimulationState, Diagnostic> {
+    let value = parse_canonical(bytes)?;
+    let fields = object(&value, "runtime state")?;
+    require_fields(
+        fields,
+        &[
+            "counters",
+            "entities",
+            "machines",
+            "scheduled_events",
+            "schema",
+            "tick",
+        ],
+        "runtime state",
+    )?;
+    let schema = schema(field(fields, "schema")?, "runtime-state schema")?;
+    if schema != crate::runtime_state_schema() {
+        return Err(invalid("runtime state names an unsupported schema"));
+    }
+    require_empty_array(field(fields, "counters")?, "runtime counters")?;
+    require_empty_array(
+        field(fields, "scheduled_events")?,
+        "scheduled runtime events",
+    )?;
+    let tick = uint(field(fields, "tick")?, "runtime tick")?;
+    let entities = decode_entities(field(fields, "entities")?)?;
+    let machines = decode_machines(field(fields, "machines")?)?;
+    let state = SimulationState::from_parts(schema, tick, entities, machines);
+    state.validate_against(plan)?;
+    if state.to_canonical_bytes() != bytes {
+        return Err(invalid(
+            "runtime state does not exactly re-encode from its typed meaning",
+        ));
+    }
+    Ok(state)
+}
+
+fn decode_entities(value: &CanonicalValue) -> Result<Vec<RuntimeEntityState>, Diagnostic> {
+    let rows = array(value, "runtime entities")?;
+    let mut entities = Vec::with_capacity(rows.len());
+    let mut seen = BTreeSet::new();
+    for row in rows {
+        let fields = object(row, "runtime entity")?;
+        require_fields(fields, &["binding", "id"], "runtime entity")?;
+        let id = EntityId::parse(text(field(fields, "id")?, "runtime entity id")?)
+            .map_err(|error| invalid(error.message()))?;
+        if !seen.insert(id.clone()) {
+            return Err(invalid("runtime entity identity occurs more than once"));
+        }
+        entities.push(RuntimeEntityState::from_parts(
+            id,
+            binding(field(fields, "binding")?)?,
+        ));
+    }
+    Ok(entities)
+}
+
+fn decode_machines(value: &CanonicalValue) -> Result<BTreeMap<NamespaceId, Ident>, Diagnostic> {
+    let rows = array(value, "runtime machines")?;
+    let mut machines = BTreeMap::new();
+    for row in rows {
+        let fields = object(row, "runtime machine")?;
+        require_fields(fields, &["namespace", "state"], "runtime machine")?;
+        let namespace = NamespaceId::parse(text(
+            field(fields, "namespace")?,
+            "runtime machine namespace",
+        )?)
+        .map_err(|error| invalid(error.message()))?;
+        let state = Ident::new(text(field(fields, "state")?, "runtime machine state")?)
+            .map_err(|error| invalid(error.message()))?;
+        if machines.insert(namespace, state).is_some() {
+            return Err(invalid("runtime machine namespace occurs more than once"));
+        }
+    }
+    Ok(machines)
+}
+
+fn binding(value: &CanonicalValue) -> Result<RuntimeBinding, Diagnostic> {
+    let fields = object(value, "runtime binding")?;
+    match text(field(fields, "kind")?, "runtime binding kind")? {
+        "cell" => {
+            require_fields(fields, &["cell", "kind"], "cell binding")?;
+            Ok(RuntimeBinding::Cell(cell(field(fields, "cell")?)?))
+        }
+        "face" => {
+            require_fields(fields, &["cell", "direction", "kind"], "face binding")?;
+            let direction = match text(field(fields, "direction")?, "face direction")? {
+                "north" => ProjectedDirection::North,
+                "east" => ProjectedDirection::East,
+                "south" => ProjectedDirection::South,
+                "west" => ProjectedDirection::West,
+                "up" => ProjectedDirection::Up,
+                "down" => ProjectedDirection::Down,
+                _ => return Err(invalid("runtime face direction is unsupported")),
+            };
+            Ok(RuntimeBinding::Face {
+                cell: cell(field(fields, "cell")?)?,
+                direction,
+            })
+        }
+        "region" => {
+            require_fields(fields, &["kind", "max", "min"], "region binding")?;
+            Ok(RuntimeBinding::Region {
+                min: cell(field(fields, "min")?)?,
+                max: cell(field(fields, "max")?)?,
+            })
+        }
+        _ => Err(invalid("runtime binding kind is unsupported")),
+    }
+}
+
+fn cell(value: &CanonicalValue) -> Result<LatticeCell, Diagnostic> {
+    let fields = object(value, "lattice cell")?;
+    require_fields(fields, &["x", "y", "z"], "lattice cell")?;
+    Ok(LatticeCell::new(
+        int32(field(fields, "x")?, "cell x")?,
+        int32(field(fields, "y")?, "cell y")?,
+        int32(field(fields, "z")?, "cell z")?,
+    ))
+}
+
+fn simulation_digest(plan: &SimulationPlan) -> Sha256Digest {
+    Sha256Digest::of_bytes(&plan.to_canonical_bytes())
+}
+
+fn schema(value: &CanonicalValue, label: &str) -> Result<SchemaId, Diagnostic> {
+    let fields = object(value, label)?;
+    require_fields(fields, &["name", "version"], label)?;
+    let version = u32::try_from(uint(field(fields, "version")?, label)?)
+        .map_err(|_| invalid(format!("{label} version exceeds u32")))?;
+    SchemaId::new(text(field(fields, "name")?, label)?, version)
+        .map_err(|error| invalid(error.message()))
+}
+
+fn digest(value: &CanonicalValue, label: &str) -> Result<Sha256Digest, Diagnostic> {
+    Sha256Digest::from_hex(text(value, label)?)
+        .ok_or_else(|| invalid(format!("{label} is invalid")))
+}
+
+fn state_hash(value: &CanonicalValue) -> Result<StateHash, Diagnostic> {
+    StateHash::from_hex(text(value, "state hash")?).ok_or_else(|| invalid("state hash is invalid"))
+}
+
+fn int32(value: &CanonicalValue, label: &str) -> Result<i32, Diagnostic> {
+    let value = match value {
+        CanonicalValue::Int(value) => *value,
+        CanonicalValue::Uint(value) => i64::try_from(*value)
+            .map_err(|_| invalid(format!("{label} exceeds signed integer range")))?,
+        _ => return Err(invalid(format!("{label} is not an integer"))),
+    };
+    i32::try_from(value).map_err(|_| invalid(format!("{label} exceeds i32")))
+}
+
+fn uint(value: &CanonicalValue, label: &str) -> Result<u64, Diagnostic> {
+    match value {
+        CanonicalValue::Uint(value) => Ok(*value),
+        CanonicalValue::Int(value) => {
+            u64::try_from(*value).map_err(|_| invalid(format!("{label} is negative")))
+        }
+        _ => Err(invalid(format!("{label} is not an unsigned integer"))),
+    }
+}
+
+fn require_empty_array(value: &CanonicalValue, label: &str) -> Result<(), Diagnostic> {
+    if array(value, label)?.is_empty() {
+        Ok(())
+    } else {
+        Err(invalid(format!("{label} are unsupported in Gate K")))
+    }
+}
+
+fn object<'a>(
+    value: &'a CanonicalValue,
+    label: &str,
+) -> Result<&'a BTreeMap<FieldName, CanonicalValue>, Diagnostic> {
+    let CanonicalValue::Object(fields) = value else {
+        return Err(invalid(format!("{label} is not an object")));
+    };
+    Ok(fields)
+}
+
+fn array<'a>(value: &'a CanonicalValue, label: &str) -> Result<&'a [CanonicalValue], Diagnostic> {
+    let CanonicalValue::Array(values) = value else {
+        return Err(invalid(format!("{label} is not an array")));
+    };
+    Ok(values)
+}
+
+fn text<'a>(value: &'a CanonicalValue, label: &str) -> Result<&'a str, Diagnostic> {
+    let CanonicalValue::Text(value) = value else {
+        return Err(invalid(format!("{label} is not text")));
+    };
+    Ok(value)
+}
+
+fn field<'a>(
+    fields: &'a BTreeMap<FieldName, CanonicalValue>,
+    name: &'static str,
+) -> Result<&'a CanonicalValue, Diagnostic> {
+    fields
+        .get(&FieldName::declared(name))
+        .ok_or_else(|| invalid(format!("persisted runtime value has no `{name}` field")))
+}
+
+fn require_fields(
+    fields: &BTreeMap<FieldName, CanonicalValue>,
+    expected: &[&str],
+    label: &str,
+) -> Result<(), Diagnostic> {
+    let actual = fields.keys().map(FieldName::as_str).collect::<Vec<_>>();
+    let mut expected = expected.to_vec();
+    expected.sort_unstable();
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(invalid(format!(
+            "{label} fields are {actual:?}; expected {expected:?}"
+        )))
+    }
+}
+
+fn invalid(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RUNTIME_PERSISTED_INVALID,
+        message,
+    )
+    .with_repair(RepairClass::RebuildFromSource)
+}

--- a/crates/nomos-sim/src/transaction.rs
+++ b/crates/nomos-sim/src/transaction.rs
@@ -291,6 +291,22 @@ pub struct TransitionStep {
 }
 
 impl TransitionStep {
+    pub(crate) fn from_parts(
+        phase: Phase,
+        namespace: NamespaceId,
+        from: Ident,
+        to: Ident,
+        cause: TransitionCause,
+    ) -> Self {
+        Self {
+            phase,
+            namespace,
+            from,
+            to,
+            cause,
+        }
+    }
+
     /// Settlement phase.
     #[must_use]
     pub const fn phase(&self) -> Phase {

--- a/crates/nomos-sim/src/transaction.rs
+++ b/crates/nomos-sim/src/transaction.rs
@@ -610,6 +610,22 @@ pub(crate) fn validate_current_state(
             "current state machine set does not match the simulation plan",
         ));
     }
+    let owned_namespaces = plan
+        .entities()
+        .iter()
+        .flat_map(|entity| entity.machines().iter().cloned())
+        .collect::<std::collections::BTreeSet<_>>();
+    let machine_namespaces = plan
+        .machines()
+        .iter()
+        .map(|machine| machine.namespace().clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    if owned_namespaces != machine_namespaces {
+        return Err(Diagnostic::new(
+            nomos_core::diagnostic::codes::RUNTIME_STATE_INVALID,
+            "simulation entity ownership does not match the runtime machine set",
+        ));
+    }
     for machine in plan.machines() {
         let Some(state) = current.machine(machine.namespace()) else {
             return Err(Diagnostic::new(

--- a/crates/nomos-sim/src/transaction.rs
+++ b/crates/nomos-sim/src/transaction.rs
@@ -32,6 +32,10 @@ pub struct RuntimeEntityState {
 }
 
 impl RuntimeEntityState {
+    pub(crate) fn from_parts(id: EntityId, binding: RuntimeBinding) -> Self {
+        Self { id, binding }
+    }
+
     /// Stable entity ID.
     #[must_use]
     pub const fn id(&self) -> &EntityId {
@@ -53,6 +57,20 @@ impl RuntimeEntityState {
 }
 
 impl SimulationState {
+    pub(crate) fn from_parts(
+        schema: SchemaId,
+        tick: u64,
+        entities: Vec<RuntimeEntityState>,
+        machines: BTreeMap<NamespaceId, Ident>,
+    ) -> Self {
+        Self {
+            schema,
+            tick,
+            entities,
+            machines,
+        }
+    }
+
     /// Initializes every runtime machine from its projected initial state.
     ///
     /// # Errors
@@ -170,6 +188,24 @@ impl SimulationState {
     #[must_use]
     pub fn to_canonical_bytes(&self) -> Vec<u8> {
         self.to_canonical().to_canonical_bytes()
+    }
+
+    /// Reconstructs one exact canonical state and validates it against its plan.
+    ///
+    /// # Errors
+    ///
+    /// Returns a canonical, persisted-runtime, or plan disagreement diagnostic.
+    pub fn from_canonical_bytes(bytes: &[u8], plan: &SimulationPlan) -> Result<Self, Diagnostic> {
+        crate::state_persistence::decode_state(bytes, plan)
+    }
+
+    /// Validates this snapshot against the supplied runtime semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0809` when identities, bindings, namespaces, or states differ.
+    pub fn validate_against(&self, plan: &SimulationPlan) -> Result<(), Diagnostic> {
+        validate_current_state(plan, self)
     }
 
     /// SHA-256 identity of the canonical runtime-state envelope only.
@@ -528,7 +564,7 @@ pub fn prepare_transaction_with_budget(
     })
 }
 
-fn validate_current_state(
+pub(crate) fn validate_current_state(
     plan: &SimulationPlan,
     current: &SimulationState,
 ) -> Result<(), Diagnostic> {

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,8 +1,8 @@
 # Handoff — state of the repository
 
-Updated 2026-08-22 for the issue #52 filesystem-authoring CLI integration.
-The SW-G semantic-open repair is merged; SW-H is rebased onto that boundary and
-its refreshed proof and exact-head disposition remain pending.
+Updated 2026-08-22 for the issue #56 persisted-runtime evidence slice.
+The semantic opener and filesystem-authoring CLI are merged and green; SW-I is
+the active feature branch.
 This file orients a fresh session; it is rewritten at each slice boundary and
 never accumulates history (git has that).
 
@@ -203,7 +203,7 @@ never accumulates history (git has that).
   disagreement. Exact repair head `d43150a736cd91c7307da22c16992c720e8827e6`
   passed PR CI and a clean non-author rerun; PR #55 merged as `15661d2`, and
   post-merge CI run `32550461102` passed.
-- **SW-H is implemented on issue #52's feature branch:** the `nomos` binary now
+- **SW-H is merged (#52/#53):** the `nomos` binary now
   exposes exact dependency-free `validate`, `compile`, and `inspect` command
   grammars. Non-help results are one canonical JSON value; source, argv,
   package, and host failures use the fixed four exit classes. Compilation uses
@@ -214,17 +214,26 @@ never accumulates history (git has that).
   `nomos-schema` to the CLI.
   The end-to-end subprocess suite proves all four exits, determinism,
   no-artifact validation, tamper/extra-entry refusal, symlink policy, staging
-  cleanup, and existing-output preservation. Draft PR #53 must receive a fresh
-  author proof, PR CI, and non-author exact-head rerun after this rebase before
-  the slice is green.
+  cleanup, and existing-output preservation. Exact head `8288e71` passed the
+  complete author proof, PR CI run `32550761498`, and a clean non-author rerun
+  with no findings. PR #53 merged as `54e5dd2`, issue #52 closed, and post-merge
+  CI run `32551021136` passed.
+- **SW-I is in progress (#56):** the accepted slice defines strict persisted
+  runtime state/receipt evidence, the exact command-script language and typed
+  namespace resolution, command logs, state-hash chains, and the future run
+  result binding record without exposing runtime CLI commands. The first
+  checkpoint implements strict `SimulationState` rehydration, a separate
+  `nomos.persisted_runtime_state@1` envelope bound to canonical simulation
+  bytes, and exact command-script parsing/resolution while preserving the
+  frozen `nomos.runtime_state@1` hash domain.
 
 ## What is next
 
-Finish issue #52 through refreshed author proof, PR CI, non-author exact-head
-rerun, and owner merge. Do not begin another semantic implementation without a
-new issue. After SW-H, the next slice defines persisted runtime types and the
-command language before runtime `run`/`command`; later work includes verified
-run bundles, replay, explanations, the required stable v1-to-v2 movement
+Finish issue #56: complete causal-receipt decoding and the typed command-log,
+state-hash-sequence, and run-result evidence records; add refreshed-integrity
+mutation proof; then run the full author/CI/non-author chain. The following
+slice may publish verified run bundles and expose runtime `run`/`command`.
+Later work includes replay, explanations, the required stable v1-to-v2 movement
 migration, direct v2 runtime loading/refusal evidence, the Linux aarch64 and
 ten-run matrix, measured Gate K budgets, final schema-ownership review, and the
 formal cold-agent gates.
@@ -257,9 +266,8 @@ owner disposition before any formal launch.
 
 The issue #54 repair author proof, PR CI, non-author exact-head rerun, and
 post-merge CI passed as recorded above and externally in PR #55. SW-H's
-refreshed author proof passes all four workspace commands plus the exact CLI
-smoke commands after rebasing onto that repair; final PR CI and non-author
-exact-head disposition are recorded externally in PR #53. SW-G's original
+refreshed author proof, PR CI, non-author rerun, and post-merge CI passed as
+recorded above and externally in PR #53. SW-G's original
 author proof, Luna max exact-head rerun, PR CI, and post-merge CI also passed all
 four commands; the focused release SW-G test passed. SW-F, SW-D, and
 issue #24 have the same author/non-author/CI chain as recorded above. Earlier

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -225,7 +225,11 @@ never accumulates history (git has that).
   checkpoint implements strict `SimulationState` rehydration, a separate
   `nomos.persisted_runtime_state@1` envelope bound to canonical simulation
   bytes, and exact command-script parsing/resolution while preserving the
-  frozen `nomos.runtime_state@1` hash domain.
+  frozen `nomos.runtime_state@1` hash domain. Draft PR #57 is open at clean
+  checkpoint `dbde21d`; checkpoint CI run `32551494771` passed. The PR remains
+  draft and explicitly lists causal-receipt decoding, command logs, state-hash
+  chains, run-result evidence, mutation proof, and final exact-head review as
+  unfinished.
 
 ## What is next
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -234,13 +234,17 @@ never accumulates history (git has that).
   `1d5da43` closes all three findings: `RunResult` now derives and revalidates
   all five hashes from typed artifacts, receipt sequences anchor to the actual
   initial tick, and state validation checks ownership. Refreshed-integrity
-  mutations cover every artifact binding. The four pre-SW-I receipt digests and
-  state hashes were compared against untouched checkpoint `94f60eb` and remain
-  frozen as regression goldens. The repaired implementation passed the complete
-  four-command author proof with a clean tree. Draft PR #57 remains open for
-  final-head CI and a fresh non-author audit/rerun; exact-head disposition is
-  recorded externally in that PR so updating this handoff cannot invalidate
-  it. No runtime CLI command or run-directory publisher was added.
+  mutations cover every artifact binding. A second audit of `845cc1f` confirmed
+  the implementation repairs and all four proof commands but rejected the test
+  evidence because it showed only tick-zero success. The following repair adds
+  a successful command/evidence chain beginning from the fixture's persisted
+  tick-5 state, plus a wrong-zero-anchor rejection. The four pre-SW-I receipt
+  digests and state hashes were compared against untouched checkpoint `94f60eb`
+  and remain frozen as regression goldens. Draft PR #57 remains open for a
+  complete final-head author proof, CI, and a fresh non-author audit/rerun;
+  exact-head disposition is recorded externally in that PR so updating this
+  handoff cannot invalidate it. No runtime CLI command or run-directory
+  publisher was added.
 
 ## What is next
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -218,28 +218,36 @@ never accumulates history (git has that).
   complete author proof, PR CI run `32550761498`, and a clean non-author rerun
   with no findings. PR #53 merged as `54e5dd2`, issue #52 closed, and post-merge
   CI run `32551021136` passed.
-- **SW-I implementation is complete (#56/#57):** strict typed decoders now
+- **SW-I implementation is repaired and author-green (#56/#57):** strict typed decoders now
   reconstruct `nomos.runtime_state@1` and every nested value in
   `nomos.causal_receipt@1`. `nomos.persisted_runtime_state@1` binds the unchanged
   inner state hash to exact simulation semantics; `nomos.command_script@1`
   resolves requests through entity-owned external machines; and the distinct
-  `nomos.command_log@1`, `nomos.state_hash_sequence@1`, and
-  `nomos.run_result@1` types enforce receipt digests, contiguous ordinals and
-  ticks, row-by-row state hashes, exact non-result artifact coverage,
-  status/diagnostic consistency, and typed artifact hashes. Refreshed-integrity
-  mutations still fail on semantic disagreement. The four pre-SW-I receipt
-  digests and state hashes were compared against untouched checkpoint
-  `94f60eb` and are now frozen as regression goldens. Implementation commit
-  `f5bbb41` passed the four-command author proof with a clean tree. Draft PR #57
-  remains open pending final-head CI and non-author audit/rerun; no runtime CLI
-  command or run-directory publisher was added.
+  `nomos.command_log@1`, `nomos.causal_receipt_sequence@1`,
+  `nomos.state_hash_sequence@1`, and `nomos.run_result@1` types enforce receipt
+  digests, contiguous ordinals and ticks, row-by-row state hashes, exact
+  non-result artifact coverage, status/diagnostic consistency, and typed
+  artifact hashes. A first non-author audit rejected head `943828c` because
+  three artifact digests were caller-supplied rather than verified, receipt
+  ticks were not anchored to the persisted input tick, and current-state
+  validation omitted the plan's namespace-ownership-set check. Repair commit
+  `1d5da43` closes all three findings: `RunResult` now derives and revalidates
+  all five hashes from typed artifacts, receipt sequences anchor to the actual
+  initial tick, and state validation checks ownership. Refreshed-integrity
+  mutations cover every artifact binding. The four pre-SW-I receipt digests and
+  state hashes were compared against untouched checkpoint `94f60eb` and remain
+  frozen as regression goldens. The repaired implementation passed the complete
+  four-command author proof with a clean tree. Draft PR #57 remains open for
+  final-head CI and a fresh non-author audit/rerun; exact-head disposition is
+  recorded externally in that PR so updating this handoff cannot invalidate
+  it. No runtime CLI command or run-directory publisher was added.
 
 ## What is next
 
-Finish issue #56's evidence chain: publish the final documentation head, obtain
-green PR CI, and obtain the required non-author exact-head audit/rerun before
-marking PR #57 ready. The following slice may publish verified run bundles and
-expose runtime `run`/`command`.
+Finish issue #56's evidence chain: publish this documentation head, obtain green
+PR CI, and obtain the required fresh non-author exact-head audit/rerun before
+marking PR #57 ready. Record that immutable disposition in PR #57. The following
+slice may publish verified run bundles and expose runtime `run`/`command`.
 Later work includes replay, explanations, the required stable v1-to-v2 movement
 migration, direct v2 runtime loading/refusal evidence, the Linux aarch64 and
 ten-run matrix, measured Gate K budgets, final schema-ownership review, and the

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -218,25 +218,28 @@ never accumulates history (git has that).
   complete author proof, PR CI run `32550761498`, and a clean non-author rerun
   with no findings. PR #53 merged as `54e5dd2`, issue #52 closed, and post-merge
   CI run `32551021136` passed.
-- **SW-I is in progress (#56):** the accepted slice defines strict persisted
-  runtime state/receipt evidence, the exact command-script language and typed
-  namespace resolution, command logs, state-hash chains, and the future run
-  result binding record without exposing runtime CLI commands. The first
-  checkpoint implements strict `SimulationState` rehydration, a separate
-  `nomos.persisted_runtime_state@1` envelope bound to canonical simulation
-  bytes, and exact command-script parsing/resolution while preserving the
-  frozen `nomos.runtime_state@1` hash domain. Draft PR #57 is open at clean
-  checkpoint `dbde21d`; checkpoint CI run `32551494771` passed. The PR remains
-  draft and explicitly lists causal-receipt decoding, command logs, state-hash
-  chains, run-result evidence, mutation proof, and final exact-head review as
-  unfinished.
+- **SW-I implementation is complete (#56/#57):** strict typed decoders now
+  reconstruct `nomos.runtime_state@1` and every nested value in
+  `nomos.causal_receipt@1`. `nomos.persisted_runtime_state@1` binds the unchanged
+  inner state hash to exact simulation semantics; `nomos.command_script@1`
+  resolves requests through entity-owned external machines; and the distinct
+  `nomos.command_log@1`, `nomos.state_hash_sequence@1`, and
+  `nomos.run_result@1` types enforce receipt digests, contiguous ordinals and
+  ticks, row-by-row state hashes, exact non-result artifact coverage,
+  status/diagnostic consistency, and typed artifact hashes. Refreshed-integrity
+  mutations still fail on semantic disagreement. The four pre-SW-I receipt
+  digests and state hashes were compared against untouched checkpoint
+  `94f60eb` and are now frozen as regression goldens. Implementation commit
+  `f5bbb41` passed the four-command author proof with a clean tree. Draft PR #57
+  remains open pending final-head CI and non-author audit/rerun; no runtime CLI
+  command or run-directory publisher was added.
 
 ## What is next
 
-Finish issue #56: complete causal-receipt decoding and the typed command-log,
-state-hash-sequence, and run-result evidence records; add refreshed-integrity
-mutation proof; then run the full author/CI/non-author chain. The following
-slice may publish verified run bundles and expose runtime `run`/`command`.
+Finish issue #56's evidence chain: publish the final documentation head, obtain
+green PR CI, and obtain the required non-author exact-head audit/rerun before
+marking PR #57 ready. The following slice may publish verified run bundles and
+expose runtime `run`/`command`.
 Later work includes replay, explanations, the required stable v1-to-v2 movement
 migration, direct v2 runtime loading/refusal evidence, the Linux aarch64 and
 ten-run matrix, measured Gate K budgets, final schema-ownership review, and the

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,15 +1,17 @@
 ---
-title: Gate K light resolution and runtime commit evidence
-status: Implementation reference for SW-F
+title: Gate K runtime commit and persisted evidence
+status: Implementation reference through SW-I
 date: 2026-08-22
 applies_to: KERNEL.md sections 2, 3, 5, 7, and 9; acceptance 5, 9, 10, and 12
 ---
 
-# Gate K light resolution and runtime commit evidence
+# Gate K runtime commit and persisted evidence
 
 SW-F closes the in-memory transaction boundary. SW-G subsequently assigns
 stable World IR and packages the simulation plan that supplies initial-state
-material; CLI commands, run outputs, replay, and migration remain later. The path is:
+material. SW-I defines the strict persisted values needed by later filesystem
+execution without publishing run outputs or adding runtime CLI commands. The
+path is:
 
 ```text
 nomos-schema construction@3 light-union plan
@@ -75,11 +77,59 @@ tick, and resulting state hash. Extinguishing `brazier_02` emits one light fact
 change to simulation, persistence, and diagnostics. Human-readable explanation
 remains downstream and is not part of the canonical semantic receipt.
 
+SW-I adds the inverse boundary. `CausalReceipt::from_canonical_bytes` strictly
+reconstructs every nested typed command, transition cause and payload,
+effective movement/light fact, claim reason, projection target and delta, tick,
+and state hash. It refuses unknown or missing fields, incompatible schemas,
+wrong variants, noncanonical ordering, invalid IDs, and numeric overflow. It
+also re-derives projection deltas from the decoded before/after facts so a
+canonical JSON tree is not accepted merely because it parses.
+
+## Persisted state binding
+
+`nomos.runtime_state@1` and its constitutional hash domain remain byte-for-byte
+unchanged. A standalone state file uses a separate
+`nomos.persisted_runtime_state@1` envelope containing the inner typed state, its
+state hash, and SHA-256 of the exact canonical `simulation.json` bytes. Opening
+requires a caller-supplied typed `SimulationPlan`; strict state reconstruction
+checks entity identity and binding, namespace ownership, legal machine states,
+empty Gate K counter/event collections, the inner state hash, and the complete
+simulation digest. Same-shape state from different semantics therefore fails.
+
+## Command and run evidence types
+
+The schema-headed `nomos.command_script@1` language preserves the exact request
+text semantics accepted by issue #56. Resolution searches only external
+commands on machines owned by the requested entity and produces one explicit
+typed namespace command; it never reads source or guesses among namespaces.
+
+Three independently versioned canonical evidence types prepare the later run
+publisher:
+
+- `nomos.command_log@1` records zero-based contiguous committed rows. Each row
+  binds the unresolved request, resolved typed command, input/result state
+  hashes, and SHA-256 of one strictly decoded causal receipt.
+- `nomos.state_hash_sequence@1` records snapshot ordinal zero for the initial
+  state and one following hash for each committed command. Validation checks
+  every command-log input and result rather than trusting an untyped hash list.
+- `nomos.run_result@1` binds the input-package digest, simulation-semantics
+  digest, completed/rejected status, first/final hashes, committed count,
+  optional stable rejection code, and exact hashes for `initial-state.json`,
+  `final-state.json`, `command-log.json`, `causal-receipts.json`, and
+  `state-hashes.json`. `result.json` cannot hash itself, so it is deliberately
+  the one run artifact not listed in its own binding rows.
+
+Constructors and decoders enforce ordinal, hash-chain, status/diagnostic,
+artifact-set, count, endpoint, command/receipt, receipt-digest, and tick-chain
+agreement. Human diagnostic wording remains outside `RunResult`; its rejection
+identity is the stable diagnostic code.
+
 ## Evidence boundary
 
 SW-F proves in-memory snapshot immutability and commit evidence; SW-G proves the
 package contains deterministic material for the same initial snapshot; SW-H
-exposes filesystem validation, compilation, and inspection. No slice yet writes
-run directories or command logs, executes runtime commands through the CLI,
-replays, performs the required World IR migration, runs the multi-target ten-run
-matrix, or performs formal cold-agent gates.
+exposes filesystem validation, compilation, and inspection; SW-I proves the
+strict typed values and their cross-object integrity rules. No slice yet writes
+run directories, executes runtime commands through the CLI, replays, performs
+the required World IR migration, runs the multi-target ten-run matrix, or
+performs formal cold-agent gates.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -103,12 +103,16 @@ text semantics accepted by issue #56. Resolution searches only external
 commands on machines owned by the requested entity and produces one explicit
 typed namespace command; it never reads source or guesses among namespaces.
 
-Three independently versioned canonical evidence types prepare the later run
+Four independently versioned canonical evidence types prepare the later run
 publisher:
 
 - `nomos.command_log@1` records zero-based contiguous committed rows. Each row
   binds the unresolved request, resolved typed command, input/result state
   hashes, and SHA-256 of one strictly decoded causal receipt.
+- `nomos.causal_receipt_sequence@1` is the schema-headed canonical value for
+  `causal-receipts.json`. It strictly reconstructs each nested receipt, preserves
+  commit order, and anchors receipt ticks to the supplied initial state's tick
+  when checked against a command log.
 - `nomos.state_hash_sequence@1` records snapshot ordinal zero for the initial
   state and one following hash for each committed command. Validation checks
   every command-log input and result rather than trusting an untyped hash list.
@@ -121,8 +125,10 @@ publisher:
 
 Constructors and decoders enforce ordinal, hash-chain, status/diagnostic,
 artifact-set, count, endpoint, command/receipt, receipt-digest, and tick-chain
-agreement. Human diagnostic wording remains outside `RunResult`; its rejection
-identity is the stable diagnostic code.
+agreement. `RunResult` accepts all five typed artifacts rather than caller-made
+digest rows and derives every binding from their exact canonical bytes; later
+validation recomputes all five digests. Human diagnostic wording remains
+outside `RunResult`; its rejection identity is the stable diagnostic code.
 
 ## Evidence boundary
 


### PR DESCRIPTION
## Summary

- strictly reconstruct canonical `nomos.runtime_state@1` and every nested typed value in `nomos.causal_receipt@1`
- bind standalone state to exact canonical simulation semantics with `nomos.persisted_runtime_state@1` while preserving the frozen inner state-hash domain
- define the exact schema-headed command language and resolve requests through entity-owned external machine namespaces
- add strict `nomos.command_log@1`, `nomos.causal_receipt_sequence@1`, `nomos.state_hash_sequence@1`, and `nomos.run_result@1` evidence with persisted-tick anchoring, row-by-row state hashes, receipt digests, and cross-object validation
- derive and revalidate all five non-result artifact hashes from typed canonical artifacts; callers cannot inject digest rows
- retain the scope boundary: no runtime CLI command, run-directory publisher, replay, migration, package member, or dependency change

Refs #56.

## Author evidence

Final exact head: `e890e69b9110d0f837f285d32fd791ee6df69a32`

Passed locally on a clean Rust/Cargo 1.98.0 tree:

    cargo fmt --all -- --check
    cargo clippy --workspace --all-targets --locked -- -D warnings
    cargo test --workspace --locked
    cargo xtask boundary

The focused SW-I suite has ten tests. It covers exact typed round trips; nested unknown/missing fields; semantic ordering; schema, ID, variant, digest, hash, and overflow refusal; same-shape cross-semantics refusal; exact command-script grammar; zero/multiple namespace resolution; argument typing; contiguous command/state chains; completed/rejected result consistency; all five typed artifact hashes; refreshed-integrity mutations; and a successful evidence chain starting from persisted tick 5 with wrong-zero-anchor rejection.

The four pre-SW-I causal-receipt digests and resulting state hashes were measured in an isolated worktree at untouched checkpoint `94f60eb`, matched the final implementation exactly, and are frozen as regression goldens.

## Review history and disposition

- The first non-author audit rejected `943828c` with three material findings: three caller-supplied artifact digests, unanchored receipt ticks, and missing current-state namespace-ownership validation. Repair `1d5da43` closed all three.
- The next audit rejected `845cc1f` because the implementation supported persisted nonzero ticks but the test evidence showed only tick-zero success. Repair `e890e69` adds a complete tick-5 to tick-6 evidence chain and proves a zero anchor rejects.
- Fresh non-author Codex 0.149.0 session `01a027f8-2329-7710-9399-0208aafbd4a6`, explicitly invoked with `gpt-5.6-luna` at max effort, audited the live issue acceptance and full diff, reran all four commands, and returned PASS on exact head `e890e69`. Rust/Cargo 1.98.0, Arch Linux x86_64; detached tree clean before and after.
- PR CI run `32554756895` passed exact head `e890e69`.

All issue #56 acceptance for this slice is covered. Merge and issue disposition remain with the owner.
