### PR TITLE
SW-J: publish verified run bundles and expose runtime execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ any renderer is built.
 ## Status
 
 - **Architecture status:** exploratory and non-authoritative
-- **Implementation status:** implemented through SW-I: foundations, source and
+- **Implementation status:** implemented through SW-J: foundations, source and
   preserved construction IR, stable `nomos.world_ir@1`, compiled transitions,
   shared movement and light resolution, all four projections, immutable runtime
   commits, complete hash-verified world packages, the filesystem `validate`,
-  `compile`, and `inspect` commands, and strict persisted runtime evidence; no
-  filesystem runtime execution, replay, or migration
+  `compile`, `inspect`, `run`, and `command` commands, strict persisted runtime
+  evidence, and atomic verified run bundles; no replay, migration, or
+  explanation commands
 - **Contract revision:** 6, owner-authorized in decision 0007
 - **Cold-agent protocol revision:** 2, owner-authorized in decision 0008
 - **Scope:** greenfield / vacuum architecture exercise

--- a/crates/nomos-cli/src/command.rs
+++ b/crates/nomos-cli/src/command.rs
@@ -7,14 +7,22 @@ use std::path::{Path, PathBuf};
 use nomos_compiler::{compile_world_package, inspect_compiled_package};
 use nomos_core::package::MANIFEST_FILE;
 use nomos_core::{CanonicalValue, Diagnostic, RepairClass, SourcePath};
+use nomos_sim::{
+    CommandRequest, CommandScript, PersistedRuntimeState, RunExecution, execute_requests,
+};
 
-use crate::{ExitCode, compile_and_write_world, render_rejection};
+use crate::{
+    ExitCode, OpenedRunBundle, compile_and_write_world, initial_state_from_package,
+    open_compiled_world, render_rejection, require_available_run_output, write_run_bundle,
+};
 
-const ROOT_HELP: &str = "Nomos Gate K filesystem authoring\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos --help\n";
+const ROOT_HELP: &str = "Nomos Gate K semantic runtime\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos run <world/> --commands <commands> --out <new-run/>\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n  nomos --help\n";
 const VALIDATE_HELP: &str = "Validate one Nomos source file without writing artifacts.\n\nUsage:\n  nomos validate <source.nomos>\n";
 const COMPILE_HELP: &str = "Compile one Nomos source file into a new immutable world package.\n\nUsage:\n  nomos compile <source.nomos> --out <new.world/>\n";
 const INSPECT_HELP: &str =
     "Inspect one verified immutable world package.\n\nUsage:\n  nomos inspect <world/>\n";
+const RUN_HELP: &str = "Execute one strict command script from a compiled world's initial state.\n\nUsage:\n  nomos run <world/> --commands <commands> --out <new-run/>\n";
+const COMMAND_HELP: &str = "Execute one command from a verified persisted runtime state.\n\nUsage:\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n";
 
 /// One completed command-line execution, including its exact stdout bytes.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -40,9 +48,27 @@ impl Execution {
 #[derive(Clone, PartialEq, Eq, Debug)]
 enum Command {
     Help(&'static str),
-    Validate { source: String },
-    Compile { source: String, output: String },
-    Inspect { package: String },
+    Validate {
+        source: String,
+    },
+    Compile {
+        source: String,
+        output: String,
+    },
+    Inspect {
+        package: String,
+    },
+    Run {
+        package: String,
+        commands: String,
+        output: String,
+    },
+    Single {
+        package: String,
+        state: String,
+        request: String,
+        output: String,
+    },
 }
 
 /// Parses and executes exactly one supported command.
@@ -96,6 +122,51 @@ fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Command, Diagnostic
         [name, package] if name == "inspect" && !is_option(package) => Command::Inspect {
             package: package.clone(),
         },
+        [name, help] if name == "run" && help == "--help" => Command::Help(RUN_HELP),
+        [
+            name,
+            package,
+            commands_option,
+            commands,
+            output_option,
+            output,
+        ] if name == "run"
+            && !is_option(package)
+            && commands_option == "--commands"
+            && !is_option(commands)
+            && output_option == "--out"
+            && !is_option(output) =>
+        {
+            Command::Run {
+                package: package.clone(),
+                commands: commands.clone(),
+                output: output.clone(),
+            }
+        }
+        [name, help] if name == "command" && help == "--help" => Command::Help(COMMAND_HELP),
+        [
+            name,
+            package,
+            state_option,
+            state,
+            request,
+            output_option,
+            output,
+        ] if name == "command"
+            && !is_option(package)
+            && state_option == "--state"
+            && !is_option(state)
+            && !is_option(request)
+            && output_option == "--out"
+            && !is_option(output) =>
+        {
+            Command::Single {
+                package: package.clone(),
+                state: state.clone(),
+                request: request.clone(),
+                output: output.clone(),
+            }
+        }
         _ => {
             return Err(usage(
                 "arguments do not match a supported Nomos command; use `nomos --help`",
@@ -112,13 +183,52 @@ fn is_option(argument: &str) -> bool {
 fn execute_command(command: Command) -> Execution {
     let result = match command {
         Command::Help(_) => unreachable!("help is returned before command execution"),
-        Command::Validate { source } => validate(&source),
-        Command::Compile { source, output } => compile(&source, &output),
-        Command::Inspect { package } => inspect(&package),
+        Command::Validate { source } => validate(&source).map(RuntimeOutcome::completed),
+        Command::Compile { source, output } => {
+            compile(&source, &output).map(RuntimeOutcome::completed)
+        }
+        Command::Inspect { package } => inspect(&package).map(RuntimeOutcome::completed),
+        Command::Run {
+            package,
+            commands,
+            output,
+        } => run_script(&package, &commands, &output),
+        Command::Single {
+            package,
+            state,
+            request,
+            output,
+        } => command_once(&package, &state, &request, &output),
     };
     match result {
-        Ok(value) => completed(value),
+        Ok(outcome) => outcome.into_execution(),
         Err(diagnostic) => rejected(ExitCode::for_diagnostic(&diagnostic), &diagnostic),
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct RuntimeOutcome {
+    value: CanonicalValue,
+    rejection: Option<Diagnostic>,
+}
+
+impl RuntimeOutcome {
+    fn completed(value: CanonicalValue) -> Self {
+        Self {
+            value,
+            rejection: None,
+        }
+    }
+
+    fn into_execution(self) -> Execution {
+        let exit = if self.rejection.is_some() {
+            ExitCode::Rejected
+        } else {
+            ExitCode::Completed
+        };
+        let mut stdout = self.value.to_canonical_bytes();
+        stdout.push(b'\n');
+        Execution { exit, stdout }
     }
 }
 
@@ -177,6 +287,135 @@ fn inspect(package: &str) -> Result<CanonicalValue, Diagnostic> {
     inspect_compiled_package(&package)
 }
 
+fn run_script(package: &str, commands: &str, output: &str) -> Result<RuntimeOutcome, Diagnostic> {
+    let package_path = relative_filesystem_path(package)?;
+    let commands_path = relative_filesystem_path(commands)?;
+    let output_path = relative_filesystem_path(output)?;
+    require_available_run_output(&output_path)?;
+    let world = open_compiled_world(&package_path)?;
+    let script = CommandScript::from_bytes(&read_regular_bytes(&commands_path, "command script")?)?;
+    let initial =
+        PersistedRuntimeState::new(world.simulation(), initial_state_from_package(&world)?)?;
+    publish_execution(
+        "run",
+        output,
+        &output_path,
+        &world,
+        execute_requests(
+            world.simulation(),
+            world.package_digest(),
+            initial,
+            script.requests(),
+        )?,
+    )
+}
+
+fn command_once(
+    package: &str,
+    state: &str,
+    request: &str,
+    output: &str,
+) -> Result<RuntimeOutcome, Diagnostic> {
+    let package_path = relative_filesystem_path(package)?;
+    let state_path = relative_filesystem_path(state)?;
+    let output_path = relative_filesystem_path(output)?;
+    require_available_run_output(&output_path)?;
+    let world = open_compiled_world(&package_path)?;
+    let request = CommandRequest::from_line(request)?;
+    let initial = PersistedRuntimeState::from_canonical_bytes(
+        &read_regular_bytes(&state_path, "persisted runtime state")?,
+        world.simulation(),
+    )?;
+    publish_execution(
+        "command",
+        output,
+        &output_path,
+        &world,
+        execute_requests(
+            world.simulation(),
+            world.package_digest(),
+            initial,
+            &[request],
+        )?,
+    )
+}
+
+fn publish_execution(
+    command: &'static str,
+    output_spelling: &str,
+    output_path: &Path,
+    world: &nomos_compiler::OpenedCompiledWorld,
+    execution: RunExecution,
+) -> Result<RuntimeOutcome, Diagnostic> {
+    let rejection = execution.rejection().cloned();
+    let opened = write_run_bundle(&execution, world, output_path)?;
+    Ok(RuntimeOutcome {
+        value: runtime_report(command, output_spelling, &opened, rejection.as_ref()),
+        rejection,
+    })
+}
+
+fn runtime_report(
+    command: &'static str,
+    output: &str,
+    bundle: &OpenedRunBundle,
+    rejection: Option<&Diagnostic>,
+) -> CanonicalValue {
+    let artifacts = [
+        "causal-receipts.json",
+        "command-log.json",
+        "final-state.json",
+        "initial-state.json",
+        "result.json",
+        "state-hashes.json",
+    ]
+    .into_iter()
+    .map(|name| CanonicalValue::text(artifact_path(output, name)))
+    .collect();
+    let diagnostics =
+        rejection.map(|diagnostic| CanonicalValue::Array(vec![diagnostic.to_canonical()]));
+    let mut fields = vec![
+        ("artifacts", CanonicalValue::Array(artifacts)),
+        (
+            "committed_command_count",
+            CanonicalValue::Uint(bundle.result().committed_command_count()),
+        ),
+        ("command", CanonicalValue::text(command)),
+        (
+            "final_state_hash",
+            CanonicalValue::text(bundle.result().final_state_hash().to_hex()),
+        ),
+        (
+            "first_state_hash",
+            CanonicalValue::text(bundle.result().first_state_hash().to_hex()),
+        ),
+        ("output", CanonicalValue::text(output)),
+        (
+            "result_digest",
+            CanonicalValue::text(bundle.result_digest().to_hex()),
+        ),
+        (
+            "status",
+            CanonicalValue::text(bundle.result().status().as_str()),
+        ),
+    ];
+    if let Some(diagnostics) = diagnostics {
+        fields.push(("diagnostics", diagnostics));
+    }
+    CanonicalValue::object_declared(fields)
+}
+
+fn read_regular_bytes(path: &Path, kind: &str) -> Result<Vec<u8>, Diagnostic> {
+    let metadata = fs::metadata(path).map_err(|error| io_failure(path, &error))?;
+    if !metadata.is_file() {
+        return Err(Diagnostic::new(
+            nomos_core::diagnostic::codes::CLI_IO,
+            format!("`{}` is not a regular {kind} file", path.display()),
+        ));
+    }
+    fs::read(path).map_err(|error| io_failure(path, &error))
+}
+
 fn read_source(source: &str) -> Result<String, Diagnostic> {
     let path = Path::new(source);
     let metadata = fs::metadata(path).map_err(|error| io_failure(path, &error))?;
@@ -225,15 +464,6 @@ fn io_failure(path: &Path, error: &std::io::Error) -> Diagnostic {
         nomos_core::diagnostic::codes::CLI_IO,
         format!("`{}`: {error}", path.display()),
     )
-}
-
-fn completed(value: CanonicalValue) -> Execution {
-    let mut stdout = value.to_canonical_bytes();
-    stdout.push(b'\n');
-    Execution {
-        exit: ExitCode::Completed,
-        stdout,
-    }
 }
 
 fn rejected(exit: ExitCode, diagnostic: &Diagnostic) -> Execution {

--- a/crates/nomos-cli/src/command.rs
+++ b/crates/nomos-cli/src/command.rs
@@ -293,6 +293,7 @@ fn run_script(package: &str, commands: &str, output: &str) -> Result<RuntimeOutc
     let output_path = relative_filesystem_path(output)?;
     require_available_run_output(&output_path)?;
     let world = open_compiled_world(&package_path)?;
+    require_output_outside_package(&package_path, &output_path)?;
     let script = CommandScript::from_bytes(&read_regular_bytes(&commands_path, "command script")?)?;
     let initial =
         PersistedRuntimeState::new(world.simulation(), initial_state_from_package(&world)?)?;
@@ -321,6 +322,8 @@ fn command_once(
     let output_path = relative_filesystem_path(output)?;
     require_available_run_output(&output_path)?;
     let world = open_compiled_world(&package_path)?;
+    require_output_outside_package(&package_path, &output_path)?;
+    require_output_outside_state_bundle(&state_path, &output_path)?;
     let request = CommandRequest::from_line(request)?;
     let initial = PersistedRuntimeState::from_canonical_bytes(
         &read_regular_bytes(&state_path, "persisted runtime state")?,
@@ -449,6 +452,63 @@ fn relative_filesystem_path(spelling: &str) -> Result<PathBuf, Diagnostic> {
         .with_repair(RepairClass::UseSupportedIdentifierShape));
     }
     Ok(PathBuf::from(spelling))
+}
+
+fn require_output_outside_package(package: &Path, output: &Path) -> Result<(), Diagnostic> {
+    let package = fs::canonicalize(package).map_err(|error| io_failure(package, &error))?;
+    let output = resolve_with_missing_tail(output)?;
+    if output.starts_with(&package) {
+        return Err(output_overlap("package"));
+    }
+    Ok(())
+}
+
+fn require_output_outside_state_bundle(state: &Path, output: &Path) -> Result<(), Diagnostic> {
+    let state = fs::canonicalize(state).map_err(|error| io_failure(state, &error))?;
+    let parent = state
+        .parent()
+        .expect("a canonical absolute state path has a parent")
+        .to_path_buf();
+    let output = resolve_with_missing_tail(output)?;
+    if output.starts_with(&parent) && crate::run_bundle::has_run_bundle_shape(&parent)? {
+        return Err(output_overlap("run bundle"));
+    }
+    Ok(())
+}
+
+fn output_overlap(kind: &str) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RUN_BUNDLE_OUTPUT_OVERLAPS_INPUT,
+        format!("run-bundle output overlaps an immutable input {kind}"),
+    )
+    .with_repair(RepairClass::WriteToNewOutputPath)
+}
+
+fn resolve_with_missing_tail(path: &Path) -> Result<PathBuf, Diagnostic> {
+    let mut existing = path.to_path_buf();
+    let mut missing = Vec::new();
+    loop {
+        match fs::symlink_metadata(&existing) {
+            Ok(_) => {
+                let mut resolved =
+                    fs::canonicalize(&existing).map_err(|error| io_failure(&existing, &error))?;
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let Some(name) = existing.file_name() else {
+                    return Err(io_failure(&existing, &error));
+                };
+                missing.push(name.to_os_string());
+                if !existing.pop() || existing.as_os_str().is_empty() {
+                    existing = PathBuf::from(".");
+                }
+            }
+            Err(error) => return Err(io_failure(&existing, &error)),
+        }
+    }
 }
 
 fn artifact_path(root: &str, member: &str) -> String {

--- a/crates/nomos-cli/src/lib.rs
+++ b/crates/nomos-cli/src/lib.rs
@@ -3,8 +3,9 @@
 //! `KERNEL.md` section 10 assigns this crate *command-line surface and artifact
 //! orchestration*, and section 8 fixes the exit codes every command must use.
 //! SW-H implements the filesystem-authoring commands (`validate`, `compile`,
-//! and `inspect`) over that boundary. Runtime execution, explanation, replay,
-//! and migration commands belong to later accepted slices.
+//! and `inspect`) over that boundary. SW-J adds atomic verified run bundles and
+//! the `run` and `command` operations. Explanation, replay, and migration
+//! commands belong to later accepted slices.
 //!
 //! # Boundary
 //!
@@ -33,10 +34,14 @@ use nomos_core::Diagnostic;
 
 mod command;
 mod package;
+mod run_bundle;
 
 pub use command::{Execution, execute};
 pub use package::{
     compile_and_write_world, initial_state_from_package, open_compiled_world, write_compiled_world,
+};
+pub use run_bundle::{
+    OpenedRunBundle, open_run_bundle, require_available_run_output, write_run_bundle,
 };
 
 /// The process exit codes fixed by `KERNEL.md` section 8.
@@ -73,7 +78,9 @@ impl ExitCode {
     pub fn for_diagnostic(diagnostic: &Diagnostic) -> Self {
         if matches!(
             diagnostic.code(),
-            nomos_core::diagnostic::codes::PACKAGE_IO | nomos_core::diagnostic::codes::CLI_IO
+            nomos_core::diagnostic::codes::PACKAGE_IO
+                | nomos_core::diagnostic::codes::CLI_IO
+                | nomos_core::diagnostic::codes::RUN_BUNDLE_IO
         ) {
             Self::Environment
         } else {

--- a/crates/nomos-cli/src/main.rs
+++ b/crates/nomos-cli/src/main.rs
@@ -1,7 +1,8 @@
 //! The `nomos` binary.
 //!
-//! SW-H exposes the Gate K filesystem-authoring commands while leaving runtime,
-//! replay, migration, and explanation commands for their accepted slices.
+//! SW-H exposes the Gate K filesystem-authoring commands. SW-J adds immutable
+//! runtime run bundles while leaving replay, migration, and explanations for
+//! their accepted slices.
 
 use std::io::{self, Write};
 use std::process::ExitCode as ProcessExitCode;

--- a/crates/nomos-cli/src/run_bundle.rs
+++ b/crates/nomos-cli/src/run_bundle.rs
@@ -1,0 +1,523 @@
+//! Atomic filesystem publication and strict opening of runtime run bundles.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use nomos_compiler::OpenedCompiledWorld;
+use nomos_core::{Diagnostic, RepairClass, Sha256Digest};
+use nomos_sim::{
+    CausalReceiptSequence, CommandLog, PersistedRuntimeState, RunExecution, RunResult,
+    StateHashSequence,
+};
+
+const INITIAL_STATE_FILE: &str = "initial-state.json";
+const FINAL_STATE_FILE: &str = "final-state.json";
+const COMMAND_LOG_FILE: &str = "command-log.json";
+const CAUSAL_RECEIPTS_FILE: &str = "causal-receipts.json";
+const STATE_HASHES_FILE: &str = "state-hashes.json";
+const RESULT_FILE: &str = "result.json";
+const RUN_FILES: [&str; 6] = [
+    CAUSAL_RECEIPTS_FILE,
+    COMMAND_LOG_FILE,
+    FINAL_STATE_FILE,
+    INITIAL_STATE_FILE,
+    RESULT_FILE,
+    STATE_HASHES_FILE,
+];
+
+static STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// One completely decoded and cross-validated filesystem run bundle.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct OpenedRunBundle {
+    root: PathBuf,
+    initial: PersistedRuntimeState,
+    final_state: PersistedRuntimeState,
+    log: CommandLog,
+    receipts: CausalReceiptSequence,
+    hashes: StateHashSequence,
+    result: RunResult,
+    result_digest: Sha256Digest,
+}
+
+impl OpenedRunBundle {
+    /// Verified bundle directory.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Verified initial persisted state.
+    #[must_use]
+    pub const fn initial(&self) -> &PersistedRuntimeState {
+        &self.initial
+    }
+
+    /// Verified final persisted state.
+    #[must_use]
+    pub const fn final_state(&self) -> &PersistedRuntimeState {
+        &self.final_state
+    }
+
+    /// Verified committed command log.
+    #[must_use]
+    pub const fn command_log(&self) -> &CommandLog {
+        &self.log
+    }
+
+    /// Verified causal receipt sequence.
+    #[must_use]
+    pub const fn causal_receipts(&self) -> &CausalReceiptSequence {
+        &self.receipts
+    }
+
+    /// Verified state-hash sequence.
+    #[must_use]
+    pub const fn state_hashes(&self) -> &StateHashSequence {
+        &self.hashes
+    }
+
+    /// Verified content-binding result.
+    #[must_use]
+    pub const fn result(&self) -> &RunResult {
+        &self.result
+    }
+
+    /// SHA-256 identity of the exact `result.json` bytes.
+    #[must_use]
+    pub const fn result_digest(&self) -> Sha256Digest {
+        self.result_digest
+    }
+}
+
+/// Proves that a run output path does not exist before runtime work begins.
+///
+/// # Errors
+///
+/// Returns `EK0817` for any existing filesystem entry or `EK0820` when the
+/// host refuses the check.
+pub fn require_available_run_output(root: &Path) -> Result<(), Diagnostic> {
+    let root = lexical_path(root);
+    match fs::symlink_metadata(&root) {
+        Ok(_) => Err(Diagnostic::new(
+            nomos_core::diagnostic::codes::RUN_BUNDLE_OUTPUT_EXISTS,
+            format!(
+                "`{}` already exists; run bundles are immutable evidence and are never written over",
+                root.display()
+            ),
+        )
+        .with_repair(RepairClass::WriteToNewOutputPath)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_failure(&root, &error)),
+    }
+}
+
+/// Publishes one complete typed execution through a verified sibling staging
+/// directory and one final rename.
+///
+/// # Errors
+///
+/// Returns the first destination, I/O, entry-shape, typed decoding, digest, or
+/// cross-artifact diagnostic. Failure removes the staging directory and never
+/// changes an existing destination.
+pub fn write_run_bundle(
+    execution: &RunExecution,
+    world: &OpenedCompiledWorld,
+    root: &Path,
+) -> Result<OpenedRunBundle, Diagnostic> {
+    write_run_bundle_steps(execution, world, root, None, false)
+}
+
+fn write_run_bundle_steps(
+    execution: &RunExecution,
+    world: &OpenedCompiledWorld,
+    root: &Path,
+    fail_after_member_writes: Option<usize>,
+    fail_staged_verification: bool,
+) -> Result<OpenedRunBundle, Diagnostic> {
+    let root = lexical_path(root);
+    require_available_run_output(&root)?;
+    let parent = bundle_parent(&root);
+    fs::create_dir_all(parent).map_err(|error| io_failure(parent, &error))?;
+    let staging = create_staging_directory(&root)?;
+    let members = execution_members(execution);
+    let staged = (|| {
+        for (written, (name, bytes)) in members.iter().enumerate() {
+            if fail_after_member_writes == Some(written) {
+                return Err(io_failure(
+                    &staging.join(name),
+                    &io::Error::other("injected run-bundle write failure"),
+                ));
+            }
+            let path = staging.join(name);
+            fs::write(&path, bytes).map_err(|error| io_failure(&path, &error))?;
+        }
+        if fail_staged_verification {
+            let path = staging.join(RESULT_FILE);
+            fs::write(&path, b"{}").map_err(|error| io_failure(&path, &error))?;
+        }
+        let mut opened = open_run_bundle(&staging, world)?;
+        require_available_run_output(&root)?;
+        fs::rename(&staging, &root).map_err(|error| publication_failure(&root, &error))?;
+        opened.root = root.clone();
+        Ok(opened)
+    })();
+
+    match staged {
+        Ok(opened) => Ok(opened),
+        Err(diagnostic) => {
+            cleanup_staging(&staging).map_err(|cleanup| {
+                Diagnostic::new(
+                    nomos_core::diagnostic::codes::RUN_BUNDLE_IO,
+                    format!(
+                        "run-bundle write failed ({diagnostic}); staging cleanup also failed: {}",
+                        cleanup.message()
+                    ),
+                )
+            })?;
+            Err(diagnostic)
+        }
+    }
+}
+
+/// Opens and strictly verifies all six artifacts in one run bundle against an
+/// already verified compiled world.
+///
+/// The caller must keep both trees quiescent during verification. Existing
+/// symlinks are rejected, but this is not a race-safe hostile-filesystem API.
+///
+/// # Errors
+///
+/// Returns the first filesystem-entry, typed decoding, package identity,
+/// digest, or cross-artifact consistency diagnostic.
+pub fn open_run_bundle(
+    root: &Path,
+    world: &OpenedCompiledWorld,
+) -> Result<OpenedRunBundle, Diagnostic> {
+    let root = lexical_path(root);
+    require_bundle_root(&root)?;
+    require_exact_entries(&root)?;
+    let members = read_members(&root)?;
+
+    let initial = PersistedRuntimeState::from_canonical_bytes(
+        member(&members, INITIAL_STATE_FILE)?,
+        world.simulation(),
+    )?;
+    let final_state = PersistedRuntimeState::from_canonical_bytes(
+        member(&members, FINAL_STATE_FILE)?,
+        world.simulation(),
+    )?;
+    let log = CommandLog::from_canonical_bytes(member(&members, COMMAND_LOG_FILE)?)?;
+    let receipts =
+        CausalReceiptSequence::from_canonical_bytes(member(&members, CAUSAL_RECEIPTS_FILE)?)?;
+    let hashes = StateHashSequence::from_canonical_bytes(member(&members, STATE_HASHES_FILE)?)?;
+    let result_bytes = member(&members, RESULT_FILE)?;
+    let result = RunResult::from_canonical_bytes(result_bytes)?;
+    result.validate_evidence(&initial, &final_state, &log, &receipts, &hashes)?;
+    if result.input_package_digest() != world.package_digest() {
+        return Err(inconsistent(
+            "run result belongs to a different compiled package",
+        ));
+    }
+
+    Ok(OpenedRunBundle {
+        root,
+        initial,
+        final_state,
+        log,
+        receipts,
+        hashes,
+        result,
+        result_digest: Sha256Digest::of_bytes(result_bytes),
+    })
+}
+
+fn execution_members(execution: &RunExecution) -> BTreeMap<&'static str, Vec<u8>> {
+    BTreeMap::from([
+        (
+            CAUSAL_RECEIPTS_FILE,
+            execution.causal_receipts().to_canonical_bytes(),
+        ),
+        (
+            COMMAND_LOG_FILE,
+            execution.command_log().to_canonical_bytes(),
+        ),
+        (
+            FINAL_STATE_FILE,
+            execution.final_state().to_canonical_bytes(),
+        ),
+        (INITIAL_STATE_FILE, execution.initial().to_canonical_bytes()),
+        (RESULT_FILE, execution.result().to_canonical_bytes()),
+        (
+            STATE_HASHES_FILE,
+            execution.state_hashes().to_canonical_bytes(),
+        ),
+    ])
+}
+
+fn read_members(root: &Path) -> Result<BTreeMap<String, Vec<u8>>, Diagnostic> {
+    RUN_FILES
+        .iter()
+        .map(|name| {
+            let path = root.join(name);
+            require_entry_file(&path)?;
+            let bytes = fs::read(&path).map_err(|error| io_failure(&path, &error))?;
+            Ok(((*name).to_owned(), bytes))
+        })
+        .collect()
+}
+
+fn member<'a>(
+    members: &'a BTreeMap<String, Vec<u8>>,
+    name: &'static str,
+) -> Result<&'a [u8], Diagnostic> {
+    members.get(name).map(Vec::as_slice).ok_or_else(|| {
+        Diagnostic::new(
+            nomos_core::diagnostic::codes::RUN_BUNDLE_ENTRY_SET_INVALID,
+            format!("run bundle is missing `{name}`"),
+        )
+        .with_repair(RepairClass::SupplyMissingMember)
+    })
+}
+
+fn require_exact_entries(root: &Path) -> Result<(), Diagnostic> {
+    let mut found = BTreeSet::new();
+    for entry in fs::read_dir(root).map_err(|error| io_failure(root, &error))? {
+        let entry = entry.map_err(|error| io_failure(root, &error))?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            return Err(entry_set_invalid(
+                "run-bundle entry name is not valid UTF-8",
+            ));
+        };
+        let file_type = entry
+            .file_type()
+            .map_err(|error| io_failure(&entry.path(), &error))?;
+        if !file_type.is_file() {
+            return Err(entry_type_invalid(
+                &entry.path(),
+                "run-bundle entries must be regular files",
+            ));
+        }
+        found.insert(name);
+    }
+    let expected = RUN_FILES.iter().map(|name| (*name).to_owned()).collect();
+    if found != expected {
+        return Err(entry_set_invalid(
+            "run bundle must contain exactly the six declared artifacts",
+        ));
+    }
+    Ok(())
+}
+
+fn require_bundle_root(root: &Path) -> Result<(), Diagnostic> {
+    match fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => Err(entry_type_invalid(
+            root,
+            "a run-bundle root must be a directory and not a symlink",
+        )),
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            Err(entry_set_invalid("run-bundle root is missing"))
+        }
+        Err(error) => Err(io_failure(root, &error)),
+    }
+}
+
+fn require_entry_file(path: &Path) -> Result<(), Diagnostic> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(_) => Err(entry_type_invalid(
+            path,
+            "run-bundle artifacts must be regular files",
+        )),
+        Err(error) if error.kind() == ErrorKind::NotFound => Err(entry_set_invalid(format!(
+            "run bundle is missing `{}`",
+            path.file_name().unwrap_or_default().to_string_lossy()
+        ))),
+        Err(error) => Err(io_failure(path, &error)),
+    }
+}
+
+fn create_staging_directory(root: &Path) -> Result<PathBuf, Diagnostic> {
+    let Some(file_name) = root.file_name() else {
+        return Err(Diagnostic::new(
+            nomos_core::diagnostic::codes::RUN_BUNDLE_IO,
+            format!("`{}` has no run-bundle directory name", root.display()),
+        ));
+    };
+    let parent = bundle_parent(root);
+    for _ in 0..64 {
+        let counter = STAGING_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let name = format!(
+            ".{}.staging-{}-{counter}",
+            file_name.to_string_lossy(),
+            std::process::id()
+        );
+        let staging = parent.join(name);
+        match fs::create_dir(&staging) {
+            Ok(()) => return Ok(staging),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(io_failure(&staging, &error)),
+        }
+    }
+    Err(Diagnostic::new(
+        nomos_core::diagnostic::codes::RUN_BUNDLE_IO,
+        format!(
+            "could not allocate a fresh sibling staging directory for `{}`",
+            root.display()
+        ),
+    ))
+}
+
+fn cleanup_staging(staging: &Path) -> Result<(), Diagnostic> {
+    match fs::remove_dir_all(staging) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_failure(staging, &error)),
+    }
+}
+
+fn publication_failure(root: &Path, error: &io::Error) -> Diagnostic {
+    match fs::symlink_metadata(root) {
+        Ok(_) => Diagnostic::new(
+            nomos_core::diagnostic::codes::RUN_BUNDLE_OUTPUT_EXISTS,
+            format!(
+                "`{}` appeared before run-bundle publication and was left untouched",
+                root.display()
+            ),
+        )
+        .with_repair(RepairClass::WriteToNewOutputPath),
+        Err(_) => io_failure(root, error),
+    }
+}
+
+fn bundle_parent(root: &Path) -> &Path {
+    root.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn lexical_path(path: &Path) -> PathBuf {
+    path.components().collect()
+}
+
+fn entry_set_invalid(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RUN_BUNDLE_ENTRY_SET_INVALID,
+        message,
+    )
+    .with_repair(RepairClass::RebuildFromSource)
+}
+
+fn entry_type_invalid(path: &Path, reason: &str) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RUN_BUNDLE_ENTRY_TYPE_INVALID,
+        format!("`{}` has an invalid entry type: {reason}", path.display()),
+    )
+    .with_repair(RepairClass::RebuildFromSource)
+}
+
+fn inconsistent(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT,
+        message,
+    )
+    .with_repair(RepairClass::RebuildFromSource)
+}
+
+fn io_failure(path: &Path, error: &io::Error) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RUN_BUNDLE_IO,
+        format!("`{}`: {error}", path.display()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{initial_state_from_package, open_compiled_world, write_compiled_world};
+    use nomos_compiler::compile_world_package;
+    use nomos_core::SourcePath;
+    use nomos_sim::{CommandScript, PersistedRuntimeState, execute_requests};
+
+    fn fresh_root(label: &str) -> PathBuf {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../target/tmp")
+            .join("sw-j-publication-faults")
+            .join(std::process::id().to_string())
+            .join(label);
+        if root.exists() {
+            fs::remove_dir_all(&root).unwrap();
+        }
+        root
+    }
+
+    fn world_and_execution(root: &Path) -> (OpenedCompiledWorld, RunExecution) {
+        let compiled = compile_world_package(
+            include_str!("../../../fixtures/gaol.nomos"),
+            SourcePath::new("fixtures/gaol.nomos").unwrap(),
+        )
+        .unwrap();
+        write_compiled_world(&compiled, root).unwrap();
+        let world = open_compiled_world(root).unwrap();
+        let initial = PersistedRuntimeState::new(
+            world.simulation(),
+            initial_state_from_package(&world).unwrap(),
+        )
+        .unwrap();
+        let script = CommandScript::from_bytes(
+            b"schema nomos.command_script@1\nunlock north_gate with credential/gaoler_key\n",
+        )
+        .unwrap();
+        let execution = execute_requests(
+            world.simulation(),
+            world.package_digest(),
+            initial,
+            script.requests(),
+        )
+        .unwrap();
+        (world, execution)
+    }
+
+    fn no_staging_entries(root: &Path) -> bool {
+        let parent = bundle_parent(root);
+        !parent.exists()
+            || fs::read_dir(parent).unwrap().all(|entry| {
+                !entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .contains(".staging-")
+            })
+    }
+
+    #[test]
+    fn member_write_failure_removes_staging_and_leaves_destination_absent() {
+        let base = fresh_root("member-write");
+        let world_root = base.join("world");
+        let output = base.join("evidence.run");
+        let (world, execution) = world_and_execution(&world_root);
+        let rejected =
+            write_run_bundle_steps(&execution, &world, &output, Some(2), false).unwrap_err();
+        assert_eq!(
+            rejected.code(),
+            nomos_core::diagnostic::codes::RUN_BUNDLE_IO
+        );
+        assert!(!output.exists());
+        assert!(no_staging_entries(&output));
+    }
+
+    #[test]
+    fn staged_verification_failure_removes_staging_and_leaves_destination_absent() {
+        let base = fresh_root("staged-verification");
+        let world_root = base.join("world");
+        let output = base.join("evidence.run");
+        let (world, execution) = world_and_execution(&world_root);
+        assert!(write_run_bundle_steps(&execution, &world, &output, None, true).is_err());
+        assert!(!output.exists());
+        assert!(no_staging_entries(&output));
+    }
+}

--- a/crates/nomos-cli/src/run_bundle.rs
+++ b/crates/nomos-cli/src/run_bundle.rs
@@ -10,7 +10,7 @@ use nomos_compiler::OpenedCompiledWorld;
 use nomos_core::{Diagnostic, RepairClass, Sha256Digest};
 use nomos_sim::{
     CausalReceiptSequence, CommandLog, PersistedRuntimeState, RunExecution, RunResult,
-    StateHashSequence,
+    StateHashSequence, validate_committed_evidence,
 };
 
 const INITIAL_STATE_FILE: &str = "initial-state.json";
@@ -140,6 +140,7 @@ fn write_run_bundle_steps(
 ) -> Result<OpenedRunBundle, Diagnostic> {
     let root = lexical_path(root);
     require_available_run_output(&root)?;
+    execution.validate(world.simulation())?;
     let parent = bundle_parent(&root);
     fs::create_dir_all(parent).map_err(|error| io_failure(parent, &error))?;
     let staging = create_staging_directory(&root)?;
@@ -217,6 +218,14 @@ pub fn open_run_bundle(
     let result_bytes = member(&members, RESULT_FILE)?;
     let result = RunResult::from_canonical_bytes(result_bytes)?;
     result.validate_evidence(&initial, &final_state, &log, &receipts, &hashes)?;
+    validate_committed_evidence(
+        world.simulation(),
+        &initial,
+        &final_state,
+        &log,
+        &receipts,
+        &hashes,
+    )?;
     if result.input_package_digest() != world.package_digest() {
         return Err(inconsistent(
             "run result belongs to a different compiled package",

--- a/crates/nomos-cli/src/run_bundle.rs
+++ b/crates/nomos-cli/src/run_bundle.rs
@@ -30,6 +30,33 @@ const RUN_FILES: [&str; 6] = [
 
 static STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+pub(crate) fn has_run_bundle_shape(root: &Path) -> Result<bool, Diagnostic> {
+    let metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(io_failure(root, &error)),
+    };
+    if !metadata.file_type().is_dir() {
+        return Ok(false);
+    }
+    let mut names = BTreeSet::new();
+    for entry in fs::read_dir(root).map_err(|error| io_failure(root, &error))? {
+        let entry = entry.map_err(|error| io_failure(root, &error))?;
+        if !entry
+            .file_type()
+            .map_err(|error| io_failure(&entry.path(), &error))?
+            .is_file()
+        {
+            return Ok(false);
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            return Ok(false);
+        };
+        names.insert(name);
+    }
+    Ok(names == RUN_FILES.into_iter().map(str::to_owned).collect())
+}
+
 /// One completely decoded and cross-validated filesystem run bundle.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct OpenedRunBundle {

--- a/crates/nomos-cli/tests/sw_j.rs
+++ b/crates/nomos-cli/tests/sw_j.rs
@@ -1,0 +1,583 @@
+//! SW-J end-to-end proof for immutable filesystem runtime execution.
+
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use nomos_cli::{open_compiled_world, open_run_bundle};
+use nomos_core::canonical::read::parse_canonical;
+use nomos_core::{CanonicalValue, FieldName};
+use nomos_sim::RunStatus;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+const SOURCE: &[u8] = include_bytes!("../../../fixtures/gaol.nomos");
+const COMMANDS: &[u8] = include_bytes!("../../../fixtures/gaol.commands");
+const RUN_FILES: [&str; 6] = [
+    "causal-receipts.json",
+    "command-log.json",
+    "final-state.json",
+    "initial-state.json",
+    "result.json",
+    "state-hashes.json",
+];
+
+fn fresh_workspace(label: &str) -> PathBuf {
+    let index = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+        .join("sw-j-cli")
+        .join(format!("{}-{nonce}-{label}-{index}", std::process::id()));
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("gaol.nomos"), SOURCE).unwrap();
+    fs::write(root.join("gaol.commands"), COMMANDS).unwrap();
+    root
+}
+
+fn run<I, S>(cwd: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new(env!("CARGO_BIN_EXE_nomos"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap()
+}
+
+fn assert_exit(output: &Output, expected: i32) {
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(output.stderr.is_empty());
+}
+
+fn canonical_stdout(output: &Output) -> CanonicalValue {
+    assert_eq!(output.stdout.last(), Some(&b'\n'));
+    parse_canonical(&output.stdout[..output.stdout.len() - 1]).unwrap()
+}
+
+fn object(value: &CanonicalValue) -> &std::collections::BTreeMap<FieldName, CanonicalValue> {
+    let CanonicalValue::Object(fields) = value else {
+        panic!("expected canonical object")
+    };
+    fields
+}
+
+fn field<'a>(value: &'a CanonicalValue, name: &'static str) -> &'a CanonicalValue {
+    object(value).get(&FieldName::declared(name)).unwrap()
+}
+
+fn compile(cwd: &Path, source: &str, output: &str) {
+    let compiled = run(cwd, ["compile", source, "--out", output]);
+    assert_exit(&compiled, 0);
+}
+
+fn directory_bytes(root: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut rows = fs::read_dir(root)
+        .unwrap()
+        .map(|entry| {
+            let entry = entry.unwrap();
+            (
+                entry.file_name().into_string().unwrap(),
+                fs::read(entry.path()).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.0.cmp(&right.0));
+    rows
+}
+
+fn copy_run(source: &Path, destination: &Path) {
+    fs::create_dir(destination).unwrap();
+    for name in RUN_FILES {
+        fs::copy(source.join(name), destination.join(name)).unwrap();
+    }
+}
+
+fn assert_exact_run_files(root: &Path) {
+    let names = fs::read_dir(root)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names,
+        RUN_FILES
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<BTreeSet<_>>()
+    );
+}
+
+fn assert_no_staging_entries(root: &Path) {
+    for entry in fs::read_dir(root).unwrap() {
+        let entry = entry.unwrap();
+        assert!(
+            !entry.file_name().to_string_lossy().contains(".staging-"),
+            "staging entry survived at {}",
+            entry.path().display()
+        );
+        if entry.file_type().unwrap().is_dir() {
+            assert_no_staging_entries(&entry.path());
+        }
+    }
+}
+
+#[test]
+fn run_and_command_publish_reopenable_deterministic_evidence() {
+    let cwd = fresh_workspace("completed");
+    compile(&cwd, "gaol.nomos", "build/gaol.world");
+    let package_before = directory_bytes(&cwd.join("build/gaol.world"));
+    let commands_before = fs::read(cwd.join("gaol.commands")).unwrap();
+
+    let first = run(
+        &cwd,
+        [
+            "run",
+            "build/gaol.world",
+            "--commands",
+            "gaol.commands",
+            "--out",
+            "runs/first",
+        ],
+    );
+    let second = run(
+        &cwd,
+        [
+            "run",
+            "build/gaol.world",
+            "--commands",
+            "gaol.commands",
+            "--out",
+            "runs/second",
+        ],
+    );
+    assert_exit(&first, 0);
+    assert_exit(&second, 0);
+    assert_eq!(
+        directory_bytes(&cwd.join("runs/first")),
+        directory_bytes(&cwd.join("runs/second"))
+    );
+    assert_exact_run_files(&cwd.join("runs/first"));
+
+    let report = canonical_stdout(&first);
+    assert_eq!(field(&report, "command"), &CanonicalValue::text("run"));
+    assert_eq!(field(&report, "status"), &CanonicalValue::text("completed"));
+    assert_eq!(
+        field(&report, "committed_command_count"),
+        &CanonicalValue::Int(5)
+    );
+    let CanonicalValue::Array(artifacts) = field(&report, "artifacts") else {
+        panic!("runtime artifacts must be an array")
+    };
+    assert_eq!(artifacts.len(), 6);
+
+    let world = open_compiled_world(&cwd.join("build/gaol.world")).unwrap();
+    let opened = open_run_bundle(&cwd.join("runs/first"), &world).unwrap();
+    assert_eq!(opened.result().status(), RunStatus::Completed);
+    assert_eq!(opened.command_log().rows().len(), 5);
+    assert_eq!(opened.causal_receipts().receipts().len(), 5);
+    assert_eq!(opened.state_hashes().rows().len(), 6);
+    assert_eq!(opened.initial().state().tick(), 0);
+    assert_eq!(opened.final_state().state().tick(), 5);
+
+    let state_path = cwd.join("runs/first/final-state.json");
+    let state_before = fs::read(&state_path).unwrap();
+    let command = run(
+        &cwd,
+        [
+            "command",
+            "build/gaol.world",
+            "--state",
+            "runs/first/final-state.json",
+            "close north_gate",
+            "--out",
+            "runs/after-close",
+        ],
+    );
+    assert_exit(&command, 0);
+    let command_report = canonical_stdout(&command);
+    assert_eq!(
+        field(&command_report, "command"),
+        &CanonicalValue::text("command")
+    );
+    let reopened = open_run_bundle(&cwd.join("runs/after-close"), &world).unwrap();
+    assert_eq!(reopened.initial().state().tick(), 5);
+    assert_eq!(reopened.final_state().state().tick(), 6);
+    assert_eq!(reopened.command_log().rows().len(), 1);
+
+    assert_eq!(
+        directory_bytes(&cwd.join("build/gaol.world")),
+        package_before
+    );
+    assert_eq!(
+        fs::read(cwd.join("gaol.commands")).unwrap(),
+        commands_before
+    );
+    assert_eq!(fs::read(state_path).unwrap(), state_before);
+}
+
+#[test]
+fn runtime_rejections_publish_empty_or_partial_evidence_and_stop() {
+    let cwd = fresh_workspace("rejected");
+    compile(&cwd, "gaol.nomos", "gaol.world");
+    fs::write(
+        cwd.join("first.commands"),
+        b"schema nomos.command_script@1\nclose north_gate\n",
+    )
+    .unwrap();
+    fs::write(
+        cwd.join("later.commands"),
+        b"schema nomos.command_script@1\nunlock north_gate with credential/gaoler_key\nunlock north_gate with credential/gaoler_key\nopen north_gate\n",
+    )
+    .unwrap();
+
+    let first = run(
+        &cwd,
+        [
+            "run",
+            "gaol.world",
+            "--commands",
+            "first.commands",
+            "--out",
+            "first.run",
+        ],
+    );
+    let later = run(
+        &cwd,
+        [
+            "run",
+            "gaol.world",
+            "--commands",
+            "later.commands",
+            "--out",
+            "later.run",
+        ],
+    );
+    assert_exit(&first, 1);
+    assert_exit(&later, 1);
+    assert_eq!(
+        field(&canonical_stdout(&first), "status"),
+        &CanonicalValue::text("rejected")
+    );
+
+    let world = open_compiled_world(&cwd.join("gaol.world")).unwrap();
+    let first = open_run_bundle(&cwd.join("first.run"), &world).unwrap();
+    assert_eq!(first.result().status(), RunStatus::Rejected);
+    assert_eq!(first.result().committed_command_count(), 0);
+    assert_eq!(
+        first.initial().state_hash(),
+        first.final_state().state_hash()
+    );
+    assert_eq!(
+        first.result().rejection_diagnostic().unwrap().as_str(),
+        "EK0804"
+    );
+
+    let later = open_run_bundle(&cwd.join("later.run"), &world).unwrap();
+    assert_eq!(later.result().status(), RunStatus::Rejected);
+    assert_eq!(later.result().committed_command_count(), 1);
+    assert_eq!(later.command_log().rows().len(), 1);
+    assert_eq!(later.final_state().state().tick(), 1);
+}
+
+#[test]
+fn usage_environment_existing_output_and_cross_semantics_fail_closed() {
+    let cwd = fresh_workspace("failures");
+    compile(&cwd, "gaol.nomos", "one.world");
+    for args in [["run", "--help"], ["command", "--help"]] {
+        let help = run(&cwd, args);
+        assert_exit(&help, 0);
+        assert!(!help.stdout.starts_with(b"{"));
+    }
+    let initial = run(
+        &cwd,
+        [
+            "run",
+            "one.world",
+            "--commands",
+            "gaol.commands",
+            "--out",
+            "initial.run",
+        ],
+    );
+    assert_exit(&initial, 0);
+
+    for args in [
+        vec!["run", "one.world", "gaol.commands", "--out", "bad.run"],
+        vec![
+            "command",
+            "one.world",
+            "--state",
+            "initial.run/final-state.json",
+            "--out",
+            "bad.run",
+            "close north_gate",
+        ],
+    ] {
+        assert_exit(&run(&cwd, args), 2);
+    }
+    assert_exit(
+        &run(
+            &cwd,
+            [
+                "run",
+                "one.world",
+                "--commands",
+                "missing.commands",
+                "--out",
+                "missing.run",
+            ],
+        ),
+        3,
+    );
+    assert!(!cwd.join("missing.run").exists());
+
+    let existing = cwd.join("existing.run");
+    fs::create_dir(&existing).unwrap();
+    fs::write(existing.join("sentinel"), b"unchanged").unwrap();
+    let existing_before = directory_bytes(&existing);
+    let rejected = run(
+        &cwd,
+        [
+            "run",
+            "one.world",
+            "--commands",
+            "gaol.commands",
+            "--out",
+            "existing.run",
+        ],
+    );
+    assert_exit(&rejected, 1);
+    assert_eq!(directory_bytes(&existing), existing_before);
+
+    let package_before = directory_bytes(&cwd.join("one.world"));
+    let collision = run(
+        &cwd,
+        [
+            "run",
+            "one.world",
+            "--commands",
+            "gaol.commands",
+            "--out",
+            "one.world",
+        ],
+    );
+    assert_exit(&collision, 1);
+    assert_eq!(directory_bytes(&cwd.join("one.world")), package_before);
+
+    let changed = String::from_utf8(SOURCE.to_vec())
+        .unwrap()
+        .replace("credential/gaoler_key", "credential/other_key");
+    fs::write(cwd.join("changed.nomos"), changed).unwrap();
+    compile(&cwd, "changed.nomos", "two.world");
+    let cross = run(
+        &cwd,
+        [
+            "command",
+            "two.world",
+            "--state",
+            "initial.run/final-state.json",
+            "close north_gate",
+            "--out",
+            "cross.run",
+        ],
+    );
+    assert_exit(&cross, 1);
+    assert!(!cwd.join("cross.run").exists());
+
+    let state_path = cwd.join("initial.run/final-state.json");
+    let state_before = fs::read(&state_path).unwrap();
+    let state_collision = run(
+        &cwd,
+        [
+            "command",
+            "one.world",
+            "--state",
+            "initial.run/final-state.json",
+            "close north_gate",
+            "--out",
+            "initial.run/final-state.json",
+        ],
+    );
+    assert_exit(&state_collision, 1);
+    assert_eq!(fs::read(state_path).unwrap(), state_before);
+
+    let invalid_request = run(
+        &cwd,
+        [
+            "command",
+            "one.world",
+            "--state",
+            "initial.run/final-state.json",
+            "close  north_gate",
+            "--out",
+            "invalid-request.run",
+        ],
+    );
+    assert_exit(&invalid_request, 1);
+    assert!(!cwd.join("invalid-request.run").exists());
+    assert_no_staging_entries(&cwd);
+}
+
+#[test]
+fn run_open_refuses_tampering_missing_extra_and_nested_entries() {
+    let cwd = fresh_workspace("mutations");
+    compile(&cwd, "gaol.nomos", "gaol.world");
+    let completed = run(
+        &cwd,
+        [
+            "run",
+            "gaol.world",
+            "--commands",
+            "gaol.commands",
+            "--out",
+            "valid.run",
+        ],
+    );
+    assert_exit(&completed, 0);
+    let world = open_compiled_world(&cwd.join("gaol.world")).unwrap();
+
+    let mut same_semantics_source = SOURCE.to_vec();
+    same_semantics_source.push(b'\n');
+    fs::write(cwd.join("gaol.nomos"), same_semantics_source).unwrap();
+    compile(&cwd, "gaol.nomos", "same-semantics.world");
+    let same_semantics = open_compiled_world(&cwd.join("same-semantics.world")).unwrap();
+    assert_ne!(world.package_digest(), same_semantics.package_digest());
+    assert_eq!(
+        world.simulation().to_canonical_bytes(),
+        same_semantics.simulation().to_canonical_bytes()
+    );
+    assert_eq!(
+        open_run_bundle(&cwd.join("valid.run"), &same_semantics)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0816"
+    );
+
+    copy_run(&cwd.join("valid.run"), &cwd.join("tampered.run"));
+    let mut bytes = fs::read(cwd.join("tampered.run/command-log.json")).unwrap();
+    bytes.push(b'\n');
+    fs::write(cwd.join("tampered.run/command-log.json"), bytes).unwrap();
+    assert!(open_run_bundle(&cwd.join("tampered.run"), &world).is_err());
+
+    copy_run(&cwd.join("valid.run"), &cwd.join("digest.run"));
+    fs::copy(
+        cwd.join("digest.run/initial-state.json"),
+        cwd.join("digest.run/final-state.json"),
+    )
+    .unwrap();
+    assert_eq!(
+        open_run_bundle(&cwd.join("digest.run"), &world)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0816"
+    );
+
+    copy_run(&cwd.join("valid.run"), &cwd.join("extra.run"));
+    fs::write(cwd.join("extra.run/extra.json"), b"{}").unwrap();
+    assert_eq!(
+        open_run_bundle(&cwd.join("extra.run"), &world)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0818"
+    );
+
+    copy_run(&cwd.join("valid.run"), &cwd.join("missing.run"));
+    fs::remove_file(cwd.join("missing.run/state-hashes.json")).unwrap();
+    assert_eq!(
+        open_run_bundle(&cwd.join("missing.run"), &world)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0818"
+    );
+
+    copy_run(&cwd.join("valid.run"), &cwd.join("nested.run"));
+    fs::create_dir(cwd.join("nested.run/nested")).unwrap();
+    assert_eq!(
+        open_run_bundle(&cwd.join("nested.run"), &world)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0819"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn run_open_refuses_root_and_entry_symlinks_and_special_files() {
+    use std::os::unix::fs::symlink;
+    use std::os::unix::net::UnixListener;
+
+    let cwd = fresh_workspace("entry-types");
+    compile(&cwd, "gaol.nomos", "gaol.world");
+    let completed = run(
+        &cwd,
+        [
+            "run",
+            "gaol.world",
+            "--commands",
+            "gaol.commands",
+            "--out",
+            "valid.run",
+        ],
+    );
+    assert_exit(&completed, 0);
+    let world = open_compiled_world(&cwd.join("gaol.world")).unwrap();
+
+    symlink("valid.run", cwd.join("alias.run")).unwrap();
+    for alias in [cwd.join("alias.run"), cwd.join("alias.run/")] {
+        assert_eq!(
+            open_run_bundle(&alias, &world).unwrap_err().code().as_str(),
+            "EK0819"
+        );
+    }
+
+    copy_run(&cwd.join("valid.run"), &cwd.join("symlink-entry.run"));
+    fs::remove_file(cwd.join("symlink-entry.run/state-hashes.json")).unwrap();
+    symlink(
+        "../valid.run/state-hashes.json",
+        cwd.join("symlink-entry.run/state-hashes.json"),
+    )
+    .unwrap();
+    assert_eq!(
+        open_run_bundle(&cwd.join("symlink-entry.run"), &world)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0819"
+    );
+
+    copy_run(&cwd.join("valid.run"), &cwd.join("special.run"));
+    fs::remove_file(cwd.join("special.run/state-hashes.json")).unwrap();
+    let short_socket = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target")
+        .join(format!(
+            "nomos-sw-j-{}-{}.sock",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+    let _socket = UnixListener::bind(&short_socket).unwrap();
+    fs::rename(short_socket, cwd.join("special.run/state-hashes.json")).unwrap();
+    assert_eq!(
+        open_run_bundle(&cwd.join("special.run"), &world)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0819"
+    );
+}

--- a/crates/nomos-cli/tests/sw_j.rs
+++ b/crates/nomos-cli/tests/sw_j.rs
@@ -8,9 +8,9 @@ use std::process::{Command, Output};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use nomos_cli::{open_compiled_world, open_run_bundle};
+use nomos_cli::{initial_state_from_package, open_compiled_world, open_run_bundle};
 use nomos_core::canonical::read::parse_canonical;
-use nomos_core::{CanonicalValue, FieldName};
+use nomos_core::{CanonicalValue, FieldName, Sha256Digest};
 use nomos_sim::RunStatus;
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -68,6 +68,15 @@ fn canonical_stdout(output: &Output) -> CanonicalValue {
 }
 
 fn object(value: &CanonicalValue) -> &std::collections::BTreeMap<FieldName, CanonicalValue> {
+    let CanonicalValue::Object(fields) = value else {
+        panic!("expected canonical object")
+    };
+    fields
+}
+
+fn object_mut(
+    value: &mut CanonicalValue,
+) -> &mut std::collections::BTreeMap<FieldName, CanonicalValue> {
     let CanonicalValue::Object(fields) = value else {
         panic!("expected canonical object")
     };
@@ -184,6 +193,12 @@ fn run_and_command_publish_reopenable_deterministic_evidence() {
 
     let world = open_compiled_world(&cwd.join("build/gaol.world")).unwrap();
     let opened = open_run_bundle(&cwd.join("runs/first"), &world).unwrap();
+    let expected_initial = nomos_sim::PersistedRuntimeState::new(
+        world.simulation(),
+        initial_state_from_package(&world).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(opened.initial(), &expected_initial);
     assert_eq!(opened.result().status(), RunStatus::Completed);
     assert_eq!(opened.command_log().rows().len(), 5);
     assert_eq!(opened.causal_receipts().receipts().len(), 5);
@@ -517,11 +532,143 @@ fn run_open_refuses_tampering_missing_extra_and_nested_entries() {
     );
 }
 
+#[test]
+fn run_open_reexecutes_a_fully_rehashed_committed_prefix() {
+    let cwd = fresh_workspace("semantic-reexecution");
+    compile(&cwd, "gaol.nomos", "gaol.world");
+    fs::write(
+        cwd.join("unlock.commands"),
+        b"schema nomos.command_script@1\nunlock north_gate with credential/gaoler_key\n",
+    )
+    .unwrap();
+    let completed = run(
+        &cwd,
+        [
+            "run",
+            "gaol.world",
+            "--commands",
+            "unlock.commands",
+            "--out",
+            "valid.run",
+        ],
+    );
+    assert_exit(&completed, 0);
+    copy_run(&cwd.join("valid.run"), &cwd.join("forged.run"));
+    let world = open_compiled_world(&cwd.join("gaol.world")).unwrap();
+    let forged = cwd.join("forged.run");
+
+    let final_path = forged.join("final-state.json");
+    let final_text = String::from_utf8(fs::read(&final_path).unwrap())
+        .unwrap()
+        .replace("\"state\":\"closed\"", "\"state\":\"locked\"");
+    let mut final_value = parse_canonical(final_text.as_bytes()).unwrap();
+    let state_value = object(&final_value)
+        .get(&FieldName::declared("state"))
+        .unwrap();
+    let forged_state = nomos_sim::SimulationState::from_canonical_bytes(
+        &state_value.to_canonical_bytes(),
+        world.simulation(),
+    )
+    .unwrap();
+    let forged_hash = forged_state.state_hash();
+    object_mut(&mut final_value).insert(
+        FieldName::declared("state_hash"),
+        CanonicalValue::text(forged_hash.to_hex()),
+    );
+    fs::write(&final_path, final_value.to_canonical_bytes()).unwrap();
+
+    let receipts_path = forged.join("causal-receipts.json");
+    let mut receipts_value = parse_canonical(&fs::read(&receipts_path).unwrap()).unwrap();
+    let CanonicalValue::Array(receipts) = object_mut(&mut receipts_value)
+        .get_mut(&FieldName::declared("receipts"))
+        .unwrap()
+    else {
+        panic!("receipt sequence must contain an array")
+    };
+    object_mut(&mut receipts[0]).insert(
+        FieldName::declared("state_hash"),
+        CanonicalValue::text(forged_hash.to_hex()),
+    );
+    let receipts_bytes = receipts_value.to_canonical_bytes();
+    let forged_receipts =
+        nomos_sim::CausalReceiptSequence::from_canonical_bytes(&receipts_bytes).unwrap();
+    let receipt_digest = forged_receipts.receipts()[0].digest();
+    fs::write(&receipts_path, receipts_bytes).unwrap();
+
+    let log_path = forged.join("command-log.json");
+    let mut log_value = parse_canonical(&fs::read(&log_path).unwrap()).unwrap();
+    let CanonicalValue::Array(rows) = object_mut(&mut log_value)
+        .get_mut(&FieldName::declared("rows"))
+        .unwrap()
+    else {
+        panic!("command log must contain an array")
+    };
+    object_mut(&mut rows[0]).insert(
+        FieldName::declared("causal_receipt_digest"),
+        CanonicalValue::text(receipt_digest.to_hex()),
+    );
+    object_mut(&mut rows[0]).insert(
+        FieldName::declared("resulting_state_hash"),
+        CanonicalValue::text(forged_hash.to_hex()),
+    );
+    let log_bytes = log_value.to_canonical_bytes();
+    let forged_log = nomos_sim::CommandLog::from_canonical_bytes(&log_bytes).unwrap();
+    fs::write(&log_path, log_bytes).unwrap();
+
+    let hashes_path = forged.join("state-hashes.json");
+    let mut hashes_value = parse_canonical(&fs::read(&hashes_path).unwrap()).unwrap();
+    let CanonicalValue::Array(rows) = object_mut(&mut hashes_value)
+        .get_mut(&FieldName::declared("rows"))
+        .unwrap()
+    else {
+        panic!("state-hash sequence must contain an array")
+    };
+    object_mut(&mut rows[1]).insert(
+        FieldName::declared("state_hash"),
+        CanonicalValue::text(forged_hash.to_hex()),
+    );
+    let hashes_bytes = hashes_value.to_canonical_bytes();
+    let forged_hashes = nomos_sim::StateHashSequence::from_canonical_bytes(&hashes_bytes).unwrap();
+    fs::write(&hashes_path, hashes_bytes).unwrap();
+
+    let initial = nomos_sim::PersistedRuntimeState::from_canonical_bytes(
+        &fs::read(forged.join("initial-state.json")).unwrap(),
+        world.simulation(),
+    )
+    .unwrap();
+    let final_state = nomos_sim::PersistedRuntimeState::from_canonical_bytes(
+        &fs::read(&final_path).unwrap(),
+        world.simulation(),
+    )
+    .unwrap();
+    let result = nomos_sim::RunResult::completed(
+        world.package_digest(),
+        &initial,
+        &final_state,
+        &forged_log,
+        &forged_receipts,
+        &forged_hashes,
+    )
+    .unwrap();
+    fs::write(forged.join("result.json"), result.to_canonical_bytes()).unwrap();
+
+    assert_eq!(
+        open_run_bundle(&forged, &world)
+            .unwrap_err()
+            .code()
+            .as_str(),
+        "EK0816"
+    );
+    assert_ne!(
+        Sha256Digest::of_bytes(&fs::read(forged.join("result.json")).unwrap()),
+        Sha256Digest::of_bytes(&fs::read(cwd.join("valid.run/result.json")).unwrap())
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn run_open_refuses_root_and_entry_symlinks_and_special_files() {
     use std::os::unix::fs::symlink;
-    use std::os::unix::net::UnixListener;
 
     let cwd = fresh_workspace("entry-types");
     compile(&cwd, "gaol.nomos", "gaol.world");
@@ -562,19 +709,8 @@ fn run_open_refuses_root_and_entry_symlinks_and_special_files() {
         "EK0819"
     );
 
-    copy_run(&cwd.join("valid.run"), &cwd.join("special.run"));
-    fs::remove_file(cwd.join("special.run/state-hashes.json")).unwrap();
-    let short_socket = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../target")
-        .join(format!(
-            "nomos-sw-j-{}-{}.sock",
-            std::process::id(),
-            COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
-    let _socket = UnixListener::bind(&short_socket).unwrap();
-    fs::rename(short_socket, cwd.join("special.run/state-hashes.json")).unwrap();
     assert_eq!(
-        open_run_bundle(&cwd.join("special.run"), &world)
+        open_run_bundle(Path::new("/dev/null"), &world)
             .unwrap_err()
             .code()
             .as_str(),

--- a/crates/nomos-cli/tests/sw_j.rs
+++ b/crates/nomos-cli/tests/sw_j.rs
@@ -391,6 +391,106 @@ fn usage_environment_existing_output_and_cross_semantics_fail_closed() {
     assert_exit(&collision, 1);
     assert_eq!(directory_bytes(&cwd.join("one.world")), package_before);
 
+    let nested_run = run(
+        &cwd,
+        [
+            "run",
+            "one.world",
+            "--commands",
+            "gaol.commands",
+            "--out",
+            "one.world/nested.run",
+        ],
+    );
+    assert_exit(&nested_run, 1);
+    let nested_report = canonical_stdout(&nested_run);
+    let CanonicalValue::Array(diagnostics) = field(&nested_report, "diagnostics") else {
+        panic!("rejection report must contain diagnostics")
+    };
+    assert_eq!(
+        field(&diagnostics[0], "code"),
+        &CanonicalValue::text("EK0821")
+    );
+    assert_eq!(directory_bytes(&cwd.join("one.world")), package_before);
+    assert!(!cwd.join("one.world/nested.run").exists());
+
+    let nested_command = run(
+        &cwd,
+        [
+            "command",
+            "one.world",
+            "--state",
+            "initial.run/final-state.json",
+            "close north_gate",
+            "--out",
+            "one.world/nested-command.run",
+        ],
+    );
+    assert_exit(&nested_command, 1);
+    assert_eq!(directory_bytes(&cwd.join("one.world")), package_before);
+    assert!(!cwd.join("one.world/nested-command.run").exists());
+
+    let state_bundle_before = directory_bytes(&cwd.join("initial.run"));
+    let nested_in_state_bundle = run(
+        &cwd,
+        [
+            "command",
+            "one.world",
+            "--state",
+            "initial.run/final-state.json",
+            "close north_gate",
+            "--out",
+            "initial.run/nested-command.run",
+        ],
+    );
+    assert_exit(&nested_in_state_bundle, 1);
+    assert_eq!(
+        directory_bytes(&cwd.join("initial.run")),
+        state_bundle_before
+    );
+    assert!(!cwd.join("initial.run/nested-command.run").exists());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+
+        symlink("one.world", cwd.join("package-alias")).unwrap();
+        let aliased_nested = run(
+            &cwd,
+            [
+                "run",
+                "one.world",
+                "--commands",
+                "gaol.commands",
+                "--out",
+                "package-alias/aliased.run",
+            ],
+        );
+        assert_exit(&aliased_nested, 1);
+        assert_eq!(directory_bytes(&cwd.join("one.world")), package_before);
+        assert!(!cwd.join("one.world/aliased.run").exists());
+
+        symlink("initial.run", cwd.join("run-alias")).unwrap();
+        let aliased_state_bundle = run(
+            &cwd,
+            [
+                "command",
+                "one.world",
+                "--state",
+                "run-alias/final-state.json",
+                "close north_gate",
+                "--out",
+                "run-alias/aliased-command.run",
+            ],
+        );
+        assert_exit(&aliased_state_bundle, 1);
+        assert_eq!(
+            directory_bytes(&cwd.join("initial.run")),
+            state_bundle_before
+        );
+        assert!(!cwd.join("initial.run/aliased-command.run").exists());
+    }
+
     let changed = String::from_utf8(SOURCE.to_vec())
         .unwrap()
         .replace("credential/gaoler_key", "credential/other_key");

--- a/crates/nomos-core/src/diagnostic.rs
+++ b/crates/nomos-core/src/diagnostic.rs
@@ -495,6 +495,14 @@ pub mod codes {
     pub const RUNTIME_COMMAND_AMBIGUOUS: DiagnosticCode = DiagnosticCode::new("EK0815");
     /// Persisted logs, hashes, receipts, or result evidence disagree.
     pub const RUNTIME_EVIDENCE_INCONSISTENT: DiagnosticCode = DiagnosticCode::new("EK0816");
+    /// A requested run-bundle destination already exists.
+    pub const RUN_BUNDLE_OUTPUT_EXISTS: DiagnosticCode = DiagnosticCode::new("EK0817");
+    /// A run bundle does not contain exactly the six required root files.
+    pub const RUN_BUNDLE_ENTRY_SET_INVALID: DiagnosticCode = DiagnosticCode::new("EK0818");
+    /// A run-bundle root or entry has a forbidden filesystem type.
+    pub const RUN_BUNDLE_ENTRY_TYPE_INVALID: DiagnosticCode = DiagnosticCode::new("EK0819");
+    /// Reading, staging, publishing, or cleaning a run bundle failed.
+    pub const RUN_BUNDLE_IO: DiagnosticCode = DiagnosticCode::new("EK0820");
 
     /// A resolver-plan collection repeats one stable semantic identity.
     pub const RESOLVER_DUPLICATE_IDENTITY: DiagnosticCode = DiagnosticCode::new("EK0901");
@@ -589,6 +597,10 @@ pub mod codes {
         RUNTIME_COMMAND_SCRIPT_INVALID,
         RUNTIME_COMMAND_AMBIGUOUS,
         RUNTIME_EVIDENCE_INCONSISTENT,
+        RUN_BUNDLE_OUTPUT_EXISTS,
+        RUN_BUNDLE_ENTRY_SET_INVALID,
+        RUN_BUNDLE_ENTRY_TYPE_INVALID,
+        RUN_BUNDLE_IO,
         RESOLVER_DUPLICATE_IDENTITY,
         RESOLVER_CLAIM_ENTITY_MISMATCH,
         RESOLVER_ACTIVATION_NAMESPACE_MISSING,

--- a/crates/nomos-core/src/diagnostic.rs
+++ b/crates/nomos-core/src/diagnostic.rs
@@ -503,6 +503,8 @@ pub mod codes {
     pub const RUN_BUNDLE_ENTRY_TYPE_INVALID: DiagnosticCode = DiagnosticCode::new("EK0819");
     /// Reading, staging, publishing, or cleaning a run bundle failed.
     pub const RUN_BUNDLE_IO: DiagnosticCode = DiagnosticCode::new("EK0820");
+    /// A run-bundle output would overlap immutable input evidence.
+    pub const RUN_BUNDLE_OUTPUT_OVERLAPS_INPUT: DiagnosticCode = DiagnosticCode::new("EK0821");
 
     /// A resolver-plan collection repeats one stable semantic identity.
     pub const RESOLVER_DUPLICATE_IDENTITY: DiagnosticCode = DiagnosticCode::new("EK0901");
@@ -601,6 +603,7 @@ pub mod codes {
         RUN_BUNDLE_ENTRY_SET_INVALID,
         RUN_BUNDLE_ENTRY_TYPE_INVALID,
         RUN_BUNDLE_IO,
+        RUN_BUNDLE_OUTPUT_OVERLAPS_INPUT,
         RESOLVER_DUPLICATE_IDENTITY,
         RESOLVER_CLAIM_ENTITY_MISMATCH,
         RESOLVER_ACTIVATION_NAMESPACE_MISSING,

--- a/crates/nomos-sim/src/command_language.rs
+++ b/crates/nomos-sim/src/command_language.rs
@@ -51,6 +51,25 @@ impl CommandRequest {
         self.argument.as_ref()
     }
 
+    /// Parses the exact single-command spelling used by `nomos command`.
+    ///
+    /// The line has the same token, whitespace, identifier, and argument rules
+    /// as one command-script body line, but has no schema header or line ending.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0814` when the line is not the unique accepted spelling of
+    /// one command request.
+    pub fn from_line(line: &str) -> Result<Self, Diagnostic> {
+        let request = parse_request(line)?;
+        if request.to_line() != line {
+            return Err(invalid(
+                "command request does not exactly re-encode from its typed meaning",
+            ));
+        }
+        Ok(request)
+    }
+
     /// Canonical semantic value used by later command-log evidence.
     #[must_use]
     pub fn to_canonical(&self) -> CanonicalValue {

--- a/crates/nomos-sim/src/execution.rs
+++ b/crates/nomos-sim/src/execution.rs
@@ -1,0 +1,174 @@
+//! Deterministic execution into the complete typed evidence for one run.
+
+use nomos_core::{Diagnostic, RepairClass, Sha256Digest};
+use nomos_projection::SimulationPlan;
+
+use crate::{
+    CausalReceiptSequence, CommandLog, CommandLogRow, CommandRequest, PersistedRuntimeState,
+    RunResult, StateHashSequence, commit_transaction, resolve_command,
+};
+
+/// Complete typed artifacts and terminal diagnostic for one command sequence.
+///
+/// Runtime rejection is evidence rather than a partially returned error: all
+/// commands committed before the rejection remain bound by the log, receipts,
+/// hashes, final state, and rejected result. Errors returned by
+/// [`execute_requests`] instead mean that internally constructed evidence could
+/// not satisfy its own invariants.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RunExecution {
+    initial: PersistedRuntimeState,
+    final_state: PersistedRuntimeState,
+    log: CommandLog,
+    receipts: CausalReceiptSequence,
+    hashes: StateHashSequence,
+    result: RunResult,
+    rejection: Option<Diagnostic>,
+}
+
+impl RunExecution {
+    /// Persisted state from which the first request was attempted.
+    #[must_use]
+    pub const fn initial(&self) -> &PersistedRuntimeState {
+        &self.initial
+    }
+
+    /// Persisted state after the last successfully committed request.
+    #[must_use]
+    pub const fn final_state(&self) -> &PersistedRuntimeState {
+        &self.final_state
+    }
+
+    /// Successfully committed command rows.
+    #[must_use]
+    pub const fn command_log(&self) -> &CommandLog {
+        &self.log
+    }
+
+    /// One causal receipt per committed command.
+    #[must_use]
+    pub const fn causal_receipts(&self) -> &CausalReceiptSequence {
+        &self.receipts
+    }
+
+    /// Initial hash followed by one hash per committed command.
+    #[must_use]
+    pub const fn state_hashes(&self) -> &StateHashSequence {
+        &self.hashes
+    }
+
+    /// Content-binding terminal record.
+    #[must_use]
+    pub const fn result(&self) -> &RunResult {
+        &self.result
+    }
+
+    /// Stable diagnostic that stopped execution, if the run was rejected.
+    #[must_use]
+    pub const fn rejection(&self) -> Option<&Diagnostic> {
+        self.rejection.as_ref()
+    }
+}
+
+/// Resolves and commits requests in order, stopping at the first rejection.
+///
+/// The caller supplies an already verified package digest and a persisted state
+/// bound to the supplied plan; this crate remains independent of package and
+/// compiler implementations.
+///
+/// # Errors
+///
+/// Returns the first evidence-construction inconsistency. Command resolution
+/// and transaction failures are represented by a valid rejected
+/// [`RunExecution`].
+pub fn execute_requests(
+    plan: &SimulationPlan,
+    input_package_digest: Sha256Digest,
+    initial: PersistedRuntimeState,
+    requests: &[CommandRequest],
+) -> Result<RunExecution, Diagnostic> {
+    // Reopen the typed envelope against the caller's plan so an in-memory state
+    // previously bound to different semantics cannot cross this boundary.
+    let initial = PersistedRuntimeState::from_canonical_bytes(&initial.to_canonical_bytes(), plan)?;
+    let mut current = initial.state().clone();
+    let mut rows = Vec::new();
+    let mut receipts = Vec::new();
+    let mut rejection = if requests.is_empty() {
+        Some(
+            Diagnostic::new(
+                nomos_core::diagnostic::codes::RUNTIME_COMMAND_SCRIPT_INVALID,
+                "a runtime execution requires at least one command request",
+            )
+            .with_repair(RepairClass::FixSourceSyntax),
+        )
+    } else {
+        None
+    };
+
+    for (index, request) in requests.iter().enumerate() {
+        let command = match resolve_command(plan, request) {
+            Ok(command) => command,
+            Err(diagnostic) => {
+                rejection = Some(diagnostic);
+                break;
+            }
+        };
+        let input_state_hash = current.state_hash();
+        let committed = match commit_transaction(plan, &current, &command) {
+            Ok(committed) => committed,
+            Err(diagnostic) => {
+                rejection = Some(diagnostic);
+                break;
+            }
+        };
+        let ordinal = u64::try_from(index).map_err(|_| {
+            Diagnostic::new(
+                nomos_core::diagnostic::codes::RUNTIME_EVIDENCE_INCONSISTENT,
+                "committed command ordinal exceeds u64",
+            )
+        })?;
+        rows.push(CommandLogRow::new(
+            ordinal,
+            request.clone(),
+            command,
+            input_state_hash,
+            committed.receipt(),
+        )?);
+        receipts.push(committed.receipt().clone());
+        current = committed.into_snapshot();
+    }
+
+    let log = CommandLog::new(rows)?;
+    let receipt_sequence = CausalReceiptSequence::new(initial.state().tick(), &log, receipts)?;
+    let hashes = StateHashSequence::from_command_log(initial.state_hash(), &log)?;
+    let final_state = PersistedRuntimeState::new(plan, current)?;
+    let result = match rejection.as_ref() {
+        Some(diagnostic) => RunResult::rejected(
+            input_package_digest,
+            &initial,
+            &final_state,
+            &log,
+            &receipt_sequence,
+            &hashes,
+            diagnostic.code(),
+        )?,
+        None => RunResult::completed(
+            input_package_digest,
+            &initial,
+            &final_state,
+            &log,
+            &receipt_sequence,
+            &hashes,
+        )?,
+    };
+
+    Ok(RunExecution {
+        initial,
+        final_state,
+        log,
+        receipts: receipt_sequence,
+        hashes,
+        result,
+        rejection,
+    })
+}

--- a/crates/nomos-sim/src/execution.rs
+++ b/crates/nomos-sim/src/execution.rs
@@ -68,6 +68,94 @@ impl RunExecution {
     pub const fn rejection(&self) -> Option<&Diagnostic> {
         self.rejection.as_ref()
     }
+
+    /// Verifies that the terminal result agrees with the execution outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EK0816` when completed/rejected status, diagnostic identity,
+    /// or the complete committed evidence disagrees.
+    pub fn validate(&self, plan: &SimulationPlan) -> Result<(), Diagnostic> {
+        validate_committed_evidence(
+            plan,
+            &self.initial,
+            &self.final_state,
+            &self.log,
+            &self.receipts,
+            &self.hashes,
+        )?;
+        match (self.result.status(), self.rejection.as_ref()) {
+            (crate::RunStatus::Completed, None) => Ok(()),
+            (crate::RunStatus::Rejected, Some(diagnostic))
+                if self.result.rejection_diagnostic() == Some(diagnostic.code()) =>
+            {
+                Ok(())
+            }
+            _ => Err(crate::run_evidence::inconsistent(
+                "run result status disagrees with the terminal execution outcome",
+            )),
+        }
+    }
+}
+
+/// Re-executes every committed request and requires byte-identical evidence.
+///
+/// A rejected run deliberately omits its uncommitted request, so this checks
+/// only the committed prefix named by the command log.
+///
+/// # Errors
+///
+/// Returns `EK0816` when the log, receipts, hashes, or final state cannot be
+/// reproduced from the initial state and supplied simulation semantics.
+pub fn validate_committed_evidence(
+    plan: &SimulationPlan,
+    initial: &PersistedRuntimeState,
+    final_state: &PersistedRuntimeState,
+    log: &CommandLog,
+    receipts: &CausalReceiptSequence,
+    hashes: &StateHashSequence,
+) -> Result<(), Diagnostic> {
+    let initial = PersistedRuntimeState::from_canonical_bytes(&initial.to_canonical_bytes(), plan)?;
+    let mut current = initial.state().clone();
+    let mut expected_rows = Vec::with_capacity(log.rows().len());
+    let mut expected_receipts = Vec::with_capacity(log.rows().len());
+    for row in log.rows() {
+        let command = resolve_command(plan, row.request()).map_err(|_| {
+            crate::run_evidence::inconsistent(
+                "a committed command-log request no longer resolves under the supplied semantics",
+            )
+        })?;
+        let input_state_hash = current.state_hash();
+        let committed = commit_transaction(plan, &current, &command).map_err(|_| {
+            crate::run_evidence::inconsistent(
+                "a committed command-log request no longer commits under the supplied semantics",
+            )
+        })?;
+        expected_rows.push(CommandLogRow::new(
+            row.ordinal(),
+            row.request().clone(),
+            command,
+            input_state_hash,
+            committed.receipt(),
+        )?);
+        expected_receipts.push(committed.receipt().clone());
+        current = committed.into_snapshot();
+    }
+    let expected_log = CommandLog::new(expected_rows)?;
+    let expected_receipts =
+        CausalReceiptSequence::new(initial.state().tick(), &expected_log, expected_receipts)?;
+    let expected_hashes = StateHashSequence::from_command_log(initial.state_hash(), &expected_log)?;
+    let expected_final = PersistedRuntimeState::new(plan, current)?;
+    if &expected_log != log
+        || &expected_receipts != receipts
+        || &expected_hashes != hashes
+        || &expected_final != final_state
+    {
+        return Err(crate::run_evidence::inconsistent(
+            "committed run evidence does not reproduce from its initial state and simulation semantics",
+        ));
+    }
+    Ok(())
 }
 
 /// Resolves and commits requests in order, stopping at the first rejection.

--- a/crates/nomos-sim/src/lib.rs
+++ b/crates/nomos-sim/src/lib.rs
@@ -50,7 +50,7 @@ mod transaction;
 
 pub use command_language::{CommandRequest, CommandScript, resolve_command};
 pub use commit::{CommittedTransaction, commit_transaction, commit_transaction_with_budget};
-pub use execution::{RunExecution, execute_requests};
+pub use execution::{RunExecution, execute_requests, validate_committed_evidence};
 pub use receipt::{CausalReceipt, EffectiveFactRef, EffectiveFactValue, ProjectionDelta};
 pub use resolver::{resolve_light, resolve_movement};
 pub use run_evidence::{
@@ -112,7 +112,7 @@ pub fn causal_receipt_sequence_schema() -> SchemaId {
         .expect("the causal-receipt-sequence schema id is a valid literal")
 }
 
-/// Canonical schema for the future run bundle's content-binding result.
+/// Canonical schema for a run bundle's content-binding result.
 #[must_use]
 pub fn run_result_schema() -> SchemaId {
     SchemaId::new("nomos.run_result", 1).expect("the run-result schema id is a valid literal")

--- a/crates/nomos-sim/src/lib.rs
+++ b/crates/nomos-sim/src/lib.rs
@@ -40,6 +40,7 @@ use nomos_core::id::SchemaId;
 
 mod command_language;
 mod commit;
+mod execution;
 mod receipt;
 mod resolver;
 mod run_evidence;
@@ -49,6 +50,7 @@ mod transaction;
 
 pub use command_language::{CommandRequest, CommandScript, resolve_command};
 pub use commit::{CommittedTransaction, commit_transaction, commit_transaction_with_budget};
+pub use execution::{RunExecution, execute_requests};
 pub use receipt::{CausalReceipt, EffectiveFactRef, EffectiveFactValue, ProjectionDelta};
 pub use resolver::{resolve_light, resolve_movement};
 pub use run_evidence::{

--- a/crates/nomos-sim/src/run_evidence.rs
+++ b/crates/nomos-sim/src/run_evidence.rs
@@ -1,4 +1,4 @@
-//! Typed persisted evidence shared by future run and replay orchestration.
+//! Typed persisted evidence shared by run and future replay orchestration.
 
 use nomos_core::canonical::read::parse_canonical;
 use nomos_core::{CanonicalValue, Diagnostic, RepairClass, SchemaId, Sha256Digest, StateHash};

--- a/crates/nomos-sim/src/run_result.rs
+++ b/crates/nomos-sim/src/run_result.rs
@@ -1,4 +1,4 @@
-//! Content binding for the complete typed evidence of one future run bundle.
+//! Content binding for the complete typed evidence of one run bundle.
 
 use std::collections::BTreeSet;
 
@@ -87,7 +87,7 @@ impl RunArtifactDigest {
     }
 }
 
-/// Terminal status of a future run bundle.
+/// Terminal status of a run bundle.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum RunStatus {
     /// Every requested command committed.
@@ -107,7 +107,7 @@ impl RunStatus {
     }
 }
 
-/// Content-binding record written as a future run bundle's `result.json`.
+/// Content-binding record written as a run bundle's `result.json`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct RunResult {
     schema: SchemaId,
@@ -452,6 +452,18 @@ fn validate_typed_evidence(
 ) -> Result<(), Diagnostic> {
     hashes.validate_command_log(log)?;
     receipts.validate_command_log(initial.state().tick(), log)?;
+    let committed = u64::try_from(log.rows().len())
+        .map_err(|_| inconsistent("committed command count exceeds u64"))?;
+    let expected_final_tick = initial
+        .state()
+        .tick()
+        .checked_add(committed)
+        .ok_or_else(|| inconsistent("run final tick overflows u64"))?;
+    if final_state.state().tick() != expected_final_tick {
+        return Err(inconsistent(
+            "final-state tick does not continue from the initial state and committed-command count",
+        ));
+    }
     if initial.runtime_semantics_digest() != final_state.runtime_semantics_digest() {
         return Err(inconsistent(
             "initial and final states name different runtime semantics",

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -268,7 +268,14 @@ never accumulates history (git has that).
   committed commands and the stable terminal code; status remains a canonical
   content claim rather than authenticity, while publication validates it
   against the in-memory terminal outcome. The repaired tree passes the full
-  author proof. A fresh PR CI run and non-author exact-head audit/rerun remain
+  author proof and PR CI run `32557756337`. A second fresh non-author audit of
+  `3d2c88c` passed all four proof commands and found one remaining immutability
+  hole: an output nested below the input package could create a directory in the
+  package and invalidate it. The next repair rejects resolved output paths at or
+  below the package or a verified input-state run bundle, including
+  symlinked-ancestor aliases, before execution or publication, with subprocess
+  coverage for both runtime commands. The repaired tree passes the full author
+  proof. Fresh PR CI and a third non-author exact-head audit/rerun remain
   outstanding.
 
 ## What is next

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -252,14 +252,30 @@ never accumulates history (git has that).
   cover completed and rejected bundles, empty/partial rejection evidence,
   deterministic bytes, input immutability, cross-semantics refusal, existing
   output preservation, noncanonical and digest mutations, exact entry sets,
-  symlink/special-file refusal, and injected staging cleanup. The full author
-  proof, PR CI, and non-author exact-head audit/rerun remain outstanding.
+  symlink/special-file refusal, and injected staging cleanup. Head `f8eba93`
+  passed the author proof and PR CI run `32556961214`, but the first non-author
+  exact-head audit rejected it. One test attempted to create a Unix socket,
+  which the isolated review sandbox correctly refused; the audit also found a
+  missing final-tick cross-check and asked for stronger evidence that committed
+  artifacts reproduce from the supplied simulation semantics. The repair uses
+  the existing `/dev/null` character device for a read-only special-root check,
+  checks final tick from initial tick plus committed count, re-executes every
+  committed log row on open, and compares the complete regenerated log,
+  receipts, hashes, and final state. It also tests that `nomos run` begins from
+  the exact package-derived initial state and refreshes stale scope text. The
+  audit's proposed inference of a rejected request from `result.json` is not
+  representable under issue #58's explicit rule that rejected bundles bind only
+  committed commands and the stable terminal code; status remains a canonical
+  content claim rather than authenticity, while publication validates it
+  against the in-memory terminal outcome. The repaired tree passes the full
+  author proof. A fresh PR CI run and non-author exact-head audit/rerun remain
+  outstanding.
 
 ## What is next
 
-Finish issue #58: complete the mutation and CLI proof, run the full author
-proof, publish a draft PR, obtain green CI, and obtain the required fresh
-non-author exact-head audit/rerun. Later work includes replay, explanations, the
+Finish issue #58: publish the review repair, obtain fresh green PR CI, and
+obtain the required fresh non-author exact-head audit/rerun. Later work includes
+replay, explanations, the
 required stable v1-to-v2 movement migration, direct v2 runtime loading/refusal
 evidence, the Linux aarch64 and ten-run matrix, measured Gate K budgets, final
 schema-ownership review, and the formal cold-agent gates.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -274,15 +274,20 @@ never accumulates history (git has that).
   package and invalidate it. The next repair rejects resolved output paths at or
   below the package or a verified input-state run bundle, including
   symlinked-ancestor aliases, before execution or publication, with subprocess
-  coverage for both runtime commands. The repaired tree passes the full author
-  proof. Fresh PR CI and a third non-author exact-head audit/rerun remain
-  outstanding.
+  coverage for both runtime commands. Head `8ff16e5` passed the full author
+  proof and PR CI run `32558458548`. A third fresh non-author exact-head audit
+  passed all four proof commands and found no runtime-code issue, but rejected
+  two stale evidence-boundary sentences in `docs/movement.md` and
+  `docs/transitions.md` that still listed runtime CLI execution as open. Repair
+  commit `3f58532` makes both documents current through SW-J and passes the full
+  author proof. PR #59 is the authoritative live record for the required fresh
+  exact-head CI and non-author rerun before owner merge.
 
 ## What is next
 
-Finish issue #58: publish the review repair, obtain fresh green PR CI, and
-obtain the required fresh non-author exact-head audit/rerun. Later work includes
-replay, explanations, the
+Finish issue #58 only after PR #59 records green CI and a clean non-author
+exact-head rerun for the final repair, then perform the owner-authorized merge
+and branch cleanup. Later work includes replay, explanations, the
 required stable v1-to-v2 movement migration, direct v2 runtime loading/refusal
 evidence, the Linux aarch64 and ten-run matrix, measured Gate K budgets, final
 schema-ownership review, and the formal cold-agent gates.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,8 +1,7 @@
 # Handoff — state of the repository
 
-Updated 2026-08-22 for the issue #56 persisted-runtime evidence slice.
-The semantic opener and filesystem-authoring CLI are merged and green; SW-I is
-the active feature branch.
+Updated 2026-08-22 for the issue #58 filesystem-runtime slice.
+SW-I is merged and green; SW-J is the active feature branch.
 This file orients a fresh session; it is rewritten at each slice boundary and
 never accumulates history (git has that).
 
@@ -218,7 +217,7 @@ never accumulates history (git has that).
   complete author proof, PR CI run `32550761498`, and a clean non-author rerun
   with no findings. PR #53 merged as `54e5dd2`, issue #52 closed, and post-merge
   CI run `32551021136` passed.
-- **SW-I implementation is repaired and author-green (#56/#57):** strict typed decoders now
+- **SW-I is merged (#56/#57):** strict typed decoders now
   reconstruct `nomos.runtime_state@1` and every nested value in
   `nomos.causal_receipt@1`. `nomos.persisted_runtime_state@1` binds the unchanged
   inner state hash to exact simulation semantics; `nomos.command_script@1`
@@ -240,22 +239,30 @@ never accumulates history (git has that).
   a successful command/evidence chain beginning from the fixture's persisted
   tick-5 state, plus a wrong-zero-anchor rejection. The four pre-SW-I receipt
   digests and state hashes were compared against untouched checkpoint `94f60eb`
-  and remain frozen as regression goldens. Draft PR #57 remains open for a
-  complete final-head author proof, CI, and a fresh non-author audit/rerun;
-  exact-head disposition is recorded externally in that PR so updating this
-  handoff cannot invalidate it. No runtime CLI command or run-directory
-  publisher was added.
+  and remain frozen as regression goldens. Final head `e890e69` passed the full
+  author proof, PR CI run `32554756895`, and a clean GPT-5.6 Luna max non-author
+  exact-head audit/rerun. PR #57 merged as `3d4a19a`, issue #56 closed, and
+  post-merge CI run `32555728168` passed. SW-I added no runtime CLI command or
+  run-directory publisher.
+- **SW-J is active (#58):** branch `sw-j-runtime-cli-58` implements typed
+  ordered execution, atomic publication and strict opening of the exact
+  six-file run bundle, plus `nomos run` and `nomos command`. The checked-in
+  `fixtures/gaol.commands` drives five deterministic commits; the single-command
+  path resumes from its persisted tick-5 final state. Targeted tests currently
+  cover completed and rejected bundles, empty/partial rejection evidence,
+  deterministic bytes, input immutability, cross-semantics refusal, existing
+  output preservation, noncanonical and digest mutations, exact entry sets,
+  symlink/special-file refusal, and injected staging cleanup. The full author
+  proof, PR CI, and non-author exact-head audit/rerun remain outstanding.
 
 ## What is next
 
-Finish issue #56's evidence chain: publish this documentation head, obtain green
-PR CI, and obtain the required fresh non-author exact-head audit/rerun before
-marking PR #57 ready. Record that immutable disposition in PR #57. The following
-slice may publish verified run bundles and expose runtime `run`/`command`.
-Later work includes replay, explanations, the required stable v1-to-v2 movement
-migration, direct v2 runtime loading/refusal evidence, the Linux aarch64 and
-ten-run matrix, measured Gate K budgets, final schema-ownership review, and the
-formal cold-agent gates.
+Finish issue #58: complete the mutation and CLI proof, run the full author
+proof, publish a draft PR, obtain green CI, and obtain the required fresh
+non-author exact-head audit/rerun. Later work includes replay, explanations, the
+required stable v1-to-v2 movement migration, direct v2 runtime loading/refusal
+evidence, the Linux aarch64 and ten-run matrix, measured Gate K budgets, final
+schema-ownership review, and the formal cold-agent gates.
 
 The old `agy` Gemini route remains falsified evidence. Issue #49 qualifies Pi as
 the replacement transport without spending a formal attempt or changing the
@@ -271,8 +278,10 @@ cargo test --workspace --locked
 cargo xtask boundary
 cargo run --locked --bin nomos -- --help
 cargo run --locked --bin nomos -- validate fixtures/gaol.nomos
-cargo run --locked --bin nomos -- compile fixtures/gaol.nomos --out target/tmp/sw-h-proof/gaol.world
-cargo run --locked --bin nomos -- inspect target/tmp/sw-h-proof/gaol.world
+cargo run --locked --bin nomos -- compile fixtures/gaol.nomos --out target/tmp/sw-j-proof/gaol.world
+cargo run --locked --bin nomos -- inspect target/tmp/sw-j-proof/gaol.world
+cargo run --locked --bin nomos -- run target/tmp/sw-j-proof/gaol.world --commands fixtures/gaol.commands --out target/tmp/sw-j-proof/gaol.run
+cargo run --locked --bin nomos -- command target/tmp/sw-j-proof/gaol.world --state target/tmp/sw-j-proof/gaol.run/final-state.json "close north_gate" --out target/tmp/sw-j-proof/after-close.run
 docs/evaluation/test-agy-print-preflight.sh
 docs/evaluation/test-agy-formal-boundary-preflight.sh
 docs/evaluation/test-pi-cold-agent-preflight.sh
@@ -291,9 +300,9 @@ author proof, Luna max exact-head rerun, PR CI, and post-merge CI also passed al
 four commands; the focused release SW-G test passed. SW-F, SW-D, and
 issue #24 have the same author/non-author/CI chain as recorded above. Earlier
 SW-C, revision-4, and Rust-1.98 maintenance reruns also passed.
-Still unproven: Linux aarch64 release, ten runs per target, runtime and
-explanation commands, migration/replay, measured Gate K budgets, and formal
-cold-agent gates. The contract also requires a final explicit schema-ownership
+Still unproven: Linux aarch64 release, ten runs per target, explanation
+commands, migration/replay, measured Gate K budgets, and formal cold-agent
+gates. The contract also requires a final explicit schema-ownership
 source-review receipt after the Gate K schema set stabilizes; that final
 receipt does not exist yet.
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,6 +1,6 @@
 ---
 title: Gate K compiler
-status: Implementation reference through SW-G
+status: Compiler implementation reference; current through SW-J
 date: 2026-08-22
 applies_to: KERNEL.md sections 1, 2, 4, 9; acceptance 1-3 and 11
 ---
@@ -133,17 +133,17 @@ SW-C corrected the narrower SW-B naming before it became serialized behavior.
 - complete package members, build receipts, schema ownership, and initial state
   reproduce byte-for-byte across clean compilation.
 
-## Still unproved
+## Slice history and remaining work
 
-The CLI remains intentionally unimplemented. Acceptance item 3's observable
-`nomos inspect` command requires a complete package, including projections;
-SW-C proves its expansion/IR half but does not call the criterion satisfied.
-Issue #5 records that scope split.
+At SW-C, the CLI was intentionally unimplemented: acceptance item 3's
+observable `nomos inspect` command required the complete package added by later
+slices. Issue #5 records that historical scope split. SW-H now exposes
+`validate`, `compile`, and `inspect`; SW-J adds `run` and `command` over the
+verified package boundary.
 
 Typed provenance prepares the data needed by `explain-entity`, but the CLI
-surface itself remains unimplemented. SW-G writes complete packages through a
-library boundary, but it does not implement command-line verbs, run outputs,
-replay, migration, or explanations. `produced_schemas()` reports construction
-evidence, stable IR, all four projections, the registry, and compiler receipts.
-Construction versions remain preserved evidence; stable `nomos.world_ir@1` is
-now independently frozen for the later required v1-to-v2 migration.
+explanation surface remains unimplemented. Replay and migration also remain
+outstanding. `produced_schemas()` reports construction evidence, stable IR, all
+four projections, the registry, and compiler receipts. Construction versions
+remain preserved evidence; stable `nomos.world_ir@1` is independently frozen
+for the later required v1-to-v2 migration.

--- a/docs/movement.md
+++ b/docs/movement.md
@@ -1,7 +1,7 @@
 ---
 title: Gate K ground movement resolution
-status: Implementation reference for SW-E
-date: 2026-08-21
+status: Movement implementation reference; current through SW-J
+date: 2026-08-22
 applies_to: KERNEL.md sections 1, 2, 4; acceptance 5
 ---
 
@@ -71,7 +71,7 @@ claim. These results are computed from the projected activation expressions;
 
 SW-E's resolver remains ground-movement-only. SW-F now carries its before/after
 facts into committed typed receipts alongside light facts; the movement plan
-and navigation schema do not change. SW-G packages those artifacts and SW-H
-exposes their filesystem validation, compilation, and inspection. Replay,
-migration, runtime CLI execution, explanations, and the multi-target/formal
-cold-agent evidence remain open.
+and navigation schema do not change. SW-G packages those artifacts, SW-H
+exposes their filesystem validation, compilation, and inspection, and SW-J
+executes runtime commands into verified run bundles. Replay, migration,
+explanations, and the multi-target/formal cold-agent evidence remain open.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,6 +1,6 @@
 ---
 title: Gate K package evidence boundary
-status: Implementation reference through SW-G semantic-open repair
+status: Package implementation reference; current through SW-J
 date: 2026-08-22
 applies_to: KERNEL.md sections 5-7; acceptance 12
 ---
@@ -30,8 +30,9 @@ typed stable IR and regenerating every projection.
 `nomos-cli::write_compiled_world` and `compile_and_write_world` complete
 assembly and semantic validation before entering the generic writer, and
 `open_compiled_world` crosses that same typed semantic boundary after generic
-integrity checks. These are library orchestration APIs, not command-line verbs.
-Runtime causal receipts never enter an input package and live only in later run
+integrity checks. SW-H exposes this orchestration through `compile` and
+`inspect`; SW-J consumes the opened result through `run` and `command`. Runtime
+causal receipts never enter an input package and live only in separate run
 outputs.
 
 ## Stable artifacts and ownership
@@ -55,8 +56,9 @@ exactly on semantic open.
 This source review enumerates every canonical type newly entering a complete
 package. Repository search confirms no second crate defines any of these
 schemas; crate edges prevent projection/runtime code from naming IR types.
-This is an SW-G receipt, not the final Gate K ownership receipt: replay,
-migration, and run-output schema types have not stabilized yet.
+This began as an SW-G receipt, not the final Gate K ownership receipt. SW-I and
+SW-J subsequently stabilized the current run-output types; replay and migration
+schema ownership remain outstanding.
 
 Stable `nomos.world_ir@1` is not construction v3 with a new label. It preserves
 the construction schema as provenance, adds explicit compiler/catalog versions,
@@ -144,6 +146,7 @@ binds bytes but supplies neither access control nor provenance.
 SHA-256 proves byte identity, not authenticity. Compiler receipts bind exact
 source and artifact bytes inside the package, but they are not signatures.
 SW-H exposes this boundary through filesystem `validate`, `compile`, and
-`inspect` commands. It does not implement signing, guarantee power-loss
-durability, write run directories, execute runtime commands, replay, migrate,
-or satisfy whole-Gate-K acceptance.
+`inspect` commands, and SW-J consumes it without changing the input package to
+write run directories and execute runtime commands. The repository still does
+not implement signing, guarantee power-loss durability, replay, migrate, or
+satisfy whole-Gate-K acceptance.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,6 +1,6 @@
 ---
 title: Gate K runtime commit and persisted evidence
-status: Implementation reference through SW-I
+status: Implementation reference through SW-J
 date: 2026-08-22
 applies_to: KERNEL.md sections 2, 3, 5, 7, and 9; acceptance 5, 9, 10, and 12
 ---
@@ -9,9 +9,9 @@ applies_to: KERNEL.md sections 2, 3, 5, 7, and 9; acceptance 5, 9, 10, and 12
 
 SW-F closes the in-memory transaction boundary. SW-G subsequently assigns
 stable World IR and packages the simulation plan that supplies initial-state
-material. SW-I defines the strict persisted values needed by later filesystem
-execution without publishing run outputs or adding runtime CLI commands. The
-path is:
+material. SW-I defines the strict persisted values needed by filesystem
+execution. SW-J publishes those values as verified immutable run bundles and
+exposes the runtime CLI commands. The path is:
 
 ```text
 nomos-schema construction@3 light-union plan
@@ -20,6 +20,7 @@ nomos-schema construction@3 light-union plan
   -> nomos-sim resolve after settlement
   -> nomos.runtime_state@1 snapshot
   -> SHA-256 + nomos.causal_receipt@1
+  -> six-file atomic run bundle
 ```
 
 ## Compiler-owned light semantics
@@ -130,12 +131,40 @@ digest rows and derives every binding from their exact canonical bytes; later
 validation recomputes all five digests. Human diagnostic wording remains
 outside `RunResult`; its rejection identity is the stable diagnostic code.
 
+## Filesystem execution and run bundles
+
+`nomos_sim::execute_requests` resolves and commits requests in order without
+knowing about packages or the filesystem. It stops at the first rejection and
+returns one `RunExecution` whose initial/final state, committed log, causal
+receipts, state hashes, result binding, and optional terminal diagnostic agree.
+The CLI supplies only the digest and typed simulation plan from an already
+verified `OpenedCompiledWorld`.
+
+`nomos run` reads the exact schema-headed command script and begins from the
+package-derived initial state. `nomos command` strictly decodes a persisted
+state against the package simulation semantics and executes one exact request
+line. Runtime rejection is published evidence: only successful commits enter
+the log, the final state is the last committed snapshot, and `result.json`
+records the stable rejection code. CLI input, environment, or publication
+failure returns no partial output.
+
+The publisher writes exactly `initial-state.json`, `final-state.json`,
+`command-log.json`, `causal-receipts.json`, `state-hashes.json`, and
+`result.json` in a fresh sibling staging directory. It strictly reopens all six
+typed artifacts against the input package, recomputes all bindings, then uses
+one rename. Existing destinations are preserved. Roots and entries must be the
+expected directory and regular files; symlinks, special files, missing/extra
+entries, noncanonical bytes, digest changes, cross-package evidence, and
+cross-semantics state reuse fail closed. As with compiled packages, callers own
+a quiescent supported local-filesystem tree; this is integrity, not hostile
+filesystem race safety or authenticity.
+
 ## Evidence boundary
 
 SW-F proves in-memory snapshot immutability and commit evidence; SW-G proves the
 package contains deterministic material for the same initial snapshot; SW-H
 exposes filesystem validation, compilation, and inspection; SW-I proves the
-strict typed values and their cross-object integrity rules. No slice yet writes
-run directories, executes runtime commands through the CLI, replays, performs
-the required World IR migration, runs the multi-target ten-run matrix, or
-performs formal cold-agent gates.
+strict typed values and their cross-object integrity rules; SW-J publishes and
+reopens those exact values through `run` and `command`. No slice yet replays,
+explains causal evidence, performs the required World IR migration, runs the
+multi-target ten-run matrix, or performs formal cold-agent gates.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -104,7 +104,7 @@ text semantics accepted by issue #56. Resolution searches only external
 commands on machines owned by the requested entity and produces one explicit
 typed namespace command; it never reads source or guesses among namespaces.
 
-Four independently versioned canonical evidence types prepare the later run
+Four independently versioned canonical evidence types underpin the run
 publisher:
 
 - `nomos.command_log@1` records zero-based contiguous committed rows. Each row
@@ -129,7 +129,11 @@ artifact-set, count, endpoint, command/receipt, receipt-digest, and tick-chain
 agreement. `RunResult` accepts all five typed artifacts rather than caller-made
 digest rows and derives every binding from their exact canonical bytes; later
 validation recomputes all five digests. Human diagnostic wording remains
-outside `RunResult`; its rejection identity is the stable diagnostic code.
+outside `RunResult`; its rejection identity is the stable diagnostic code. A
+rejected bundle intentionally binds only the committed prefix and the terminal
+code, as issue #58 requires; it does not persist the rejected request. Status is
+therefore a canonical content claim, not an authenticity claim. Publication
+also checks it against the in-memory terminal outcome before writing.
 
 ## Filesystem execution and run bundles
 
@@ -155,9 +159,14 @@ typed artifacts against the input package, recomputes all bindings, then uses
 one rename. Existing destinations are preserved. Roots and entries must be the
 expected directory and regular files; symlinks, special files, missing/extra
 entries, noncanonical bytes, digest changes, cross-package evidence, and
-cross-semantics state reuse fail closed. As with compiled packages, callers own
-a quiescent supported local-filesystem tree; this is integrity, not hostile
-filesystem race safety or authenticity.
+cross-semantics state reuse fail closed. Opening re-executes every committed log
+row from the persisted initial state and requires byte-identical receipts,
+hashes, and final state, including exact tick continuity. As with compiled
+packages, callers own a quiescent supported local-filesystem tree; this is
+integrity, not hostile filesystem race safety or authenticity. The generic
+opener accepts both package-initial `run` bundles and nonzero-tick `command`
+bundles; the `run` command itself derives and tests its initial state against the
+opened package.
 
 ## Evidence boundary
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -156,8 +156,12 @@ The publisher writes exactly `initial-state.json`, `final-state.json`,
 `command-log.json`, `causal-receipts.json`, `state-hashes.json`, and
 `result.json` in a fresh sibling staging directory. It strictly reopens all six
 typed artifacts against the input package, recomputes all bindings, then uses
-one rename. Existing destinations are preserved. Roots and entries must be the
-expected directory and regular files; symlinks, special files, missing/extra
+one rename. Existing destinations are preserved. Before execution, the CLI
+resolves existing path ancestors and rejects an output at or below the immutable
+input package, including paths that enter it through a symlinked ancestor. When
+`nomos command` consumes a state from a verified run bundle, that input bundle
+receives the same protection. Roots and entries must be the expected directory
+and regular files; symlinks, special files, missing/extra
 entries, noncanonical bytes, digest changes, cross-package evidence, and
 cross-semantics state reuse fail closed. Opening re-executes every committed log
 row from the persisted initial state and requires byte-identical receipts,

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -1,7 +1,7 @@
 ---
 title: Gate K transitions and transaction preparation
-status: Implementation reference through SW-F
-date: 2026-08-21
+status: Transition implementation reference; current through SW-J
+date: 2026-08-22
 applies_to: KERNEL.md sections 1, 2, 4; acceptance 4-6
 ---
 
@@ -103,6 +103,6 @@ SW-E's ground `MovementDisposition` facts remain as described in
 [`movement.md`](movement.md). SW-F proves light removal,
 persistence/diagnostics deltas, committed in-memory state, hashes, and typed
 causal receipts as described in [`runtime.md`](runtime.md). SW-G packages those
-artifacts and SW-H exposes filesystem validation, compilation, and inspection.
-Runtime CLI execution, replay, migration, the ten-run target matrix, and
-whole-Gate-K cold-agent acceptance remain open.
+artifacts, SW-H exposes filesystem validation, compilation, and inspection, and
+SW-J executes runtime commands into verified run bundles. Replay, migration,
+the ten-run target matrix, and whole-Gate-K cold-agent acceptance remain open.

--- a/fixtures/gaol.commands
+++ b/fixtures/gaol.commands
@@ -1,0 +1,6 @@
+schema nomos.command_script@1
+unlock north_gate with credential/gaoler_key
+open north_gate
+unseal north_gate
+ignite north_gate
+extinguish brazier_02


### PR DESCRIPTION
## Summary

- execute resolved command requests in order into one typed `RunExecution`, preserving only committed evidence and stopping at the first rejection
- atomically publish and strictly reopen the exact six-file run bundle against one verified compiled package
- expose exact `nomos run` and `nomos command` grammars, including completed and evidence-bearing rejected results
- bind standalone input state to package simulation semantics and bind every run to the exact package digest
- re-execute every committed log row during open and require byte-identical regenerated log, receipts, hashes, final state, and tick continuity
- reject output paths nested under immutable input packages or verified input-state run bundles, including symlinked-ancestor aliases
- add `fixtures/gaol.commands` and an end-to-end subprocess/mutation suite covering deterministic completed runs, nonzero-tick continuation, partial rejection, immutable inputs, all exit classes, output collision/overlap, package/semantics mismatch, fully rehashed semantic forgery, artifact tampering, forbidden entries, and staging cleanup
- retain the slice boundary: no replay, migration, explanations, dependency, package-format, or contract change

Closes #58.

## Final evidence

Exact head: `ba2061d587de07e1a43004324165b25e7b4af061`

Author proof passed on Rust/Cargo 1.98.0:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --workspace --locked
cargo xtask boundary
```

Exact-head CI run `32559105492` passed.

A fresh GPT-5.6 Luna max non-author audit of the exact final head reported no findings and PASS. It independently reran all four proof commands on Linux x86_64 with Rust/Cargo 1.98.0 and left the detached worktree clean.

## Review disposition

Earlier exact-head audits exposed and drove repairs for final-tick continuity, semantic reproduction of committed evidence, isolated special-file testing, immutable-input overlap through nested and symlink-aliased paths, and stale runtime-boundary documentation. The final head includes each repair and its regression coverage.

Rejected bundles intentionally bind only the committed prefix and stable terminal code, exactly as issue #58 specifies. The rejected request is not persisted; status is a canonical content claim validated against the in-memory terminal outcome during publication, not an authenticity claim.
