### PR TITLE
SW-N: implement package-bound semantic explanations

### DIFF
--- a/KERNEL.md
+++ b/KERNEL.md
@@ -1,6 +1,6 @@
 ---
 title: The executable semantic kernel
-status: In progress through SW-M
+status: In progress through SW-N
 gate: K
 contract_revision: 7
 supersedes_contract_revision: 6

--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ any renderer is built.
 ## Status
 
 - **Architecture status:** exploratory and non-authoritative
-- **Implementation status:** implemented through SW-M on `main`: foundations,
-  source and preserved construction IR, stable
+- **Implementation status:** `main` is implemented through SW-M; SW-N is active
+  on branch `sw-n-semantic-explanations-65`. The implemented surface includes
+  foundations, source and preserved construction IR, stable
   `nomos.world_ir@2` plus strict v1 migration, compiled transitions,
   shared movement and light resolution, all four projections, immutable runtime
   commits, complete hash-verified world packages, the filesystem `validate`,
   `compile`, `inspect`, `run`, `command`, and `replay` commands, strict persisted
-  runtime and replay evidence, atomic verified run bundles, and the immutable
-  `migrate` command; no explanation commands
+  runtime and replay evidence, atomic verified run bundles, the immutable
+  `migrate` command, and package-bound read-only entity and transition
+  explanations
 - **Contract revision:** 7, owner-authorized in decision 0009
 - **Cold-agent protocol revision:** 2, owner-authorized in decision 0008
 - **Scope:** greenfield / vacuum architecture exercise
@@ -88,10 +90,12 @@ it.
     values, causal inputs, and the boundary between semantics and display text.
 21. [docs/runtime.md](docs/runtime.md) — compiler-owned light union, immutable
     runtime snapshots, state hashes, atomic commit, and typed causal receipts.
-22. [docs/review/2026-08-21-founding-review.md](docs/review/2026-08-21-founding-review.md)
+22. [docs/explanations.md](docs/explanations.md) — package-bound entity and
+    transition explanations, stable selection failures, and SW-N evidence.
+23. [docs/review/2026-08-21-founding-review.md](docs/review/2026-08-21-founding-review.md)
    — the condensed primary record of the founding adversarial review, written
    in the originating session, with its provenance limits stated.
-23. [docs/review/2026-08-21-founding-review-synthesis.md](docs/review/2026-08-21-founding-review-synthesis.md)
+24. [docs/review/2026-08-21-founding-review-synthesis.md](docs/review/2026-08-21-founding-review-synthesis.md)
     — the contract-revision-2 edited synthesis of that review.
 
 ## Layout

--- a/crates/nomos-cli/src/command.rs
+++ b/crates/nomos-cli/src/command.rs
@@ -6,18 +6,18 @@ use std::path::{Path, PathBuf};
 
 use nomos_compiler::{compile_world_package, inspect_compiled_package};
 use nomos_core::package::MANIFEST_FILE;
-use nomos_core::{CanonicalValue, Diagnostic, RepairClass, SourcePath};
+use nomos_core::{CanonicalValue, Diagnostic, EntityId, RepairClass, SourcePath};
 use nomos_sim::{
     CommandRequest, CommandScript, PersistedRuntimeState, ReplayLog, RunExecution, execute_requests,
 };
 
 use crate::{
     ExitCode, OpenedRunBundle, compile_and_write_world, initial_state_from_package,
-    migrate_and_write_world, open_compiled_world, render_rejection, require_available_run_output,
-    write_run_bundle,
+    migrate_and_write_world, open_compiled_world, open_run_bundle, render_rejection,
+    require_available_run_output, write_run_bundle,
 };
 
-const ROOT_HELP: &str = "Nomos Gate K semantic runtime\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos migrate <v1-world/> --to 2 --out <new-v2-world/>\n  nomos run <world/> --commands <commands> --out <new-run/>\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n  nomos replay <world/> --log <replay> --out <new-run/>\n  nomos --help\n";
+const ROOT_HELP: &str = "Nomos Gate K semantic runtime\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos migrate <v1-world/> --to 2 --out <new-v2-world/>\n  nomos run <world/> --commands <commands> --out <new-run/>\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n  nomos replay <world/> --log <replay> --out <new-run/>\n  nomos explain-entity <world/> <entity>\n  nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n  nomos --help\n";
 const VALIDATE_HELP: &str = "Validate one Nomos source file without writing artifacts.\n\nUsage:\n  nomos validate <source.nomos>\n";
 const COMPILE_HELP: &str = "Compile one Nomos source file into a new immutable world package.\n\nUsage:\n  nomos compile <source.nomos> --out <new.world/>\n";
 const INSPECT_HELP: &str =
@@ -26,6 +26,8 @@ const MIGRATE_HELP: &str = "Migrate one immutable stable-v1 world into a new sta
 const RUN_HELP: &str = "Execute one strict command script from a compiled world's initial state.\n\nUsage:\n  nomos run <world/> --commands <commands> --out <new-run/>\n";
 const COMMAND_HELP: &str = "Execute one command from a verified persisted runtime state.\n\nUsage:\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n";
 const REPLAY_HELP: &str = "Reproduce one strict replay log against a compiled world's initial state.\n\nUsage:\n  nomos replay <world/> --log <replay> --out <new-run/>\n";
+const EXPLAIN_ENTITY_HELP: &str = "Explain one entity from a strictly verified compiled world.\n\nUsage:\n  nomos explain-entity <world/> <entity>\n";
+const EXPLAIN_TRANSITION_HELP: &str = "Explain one committed transition after strictly verifying its world and re-executing its run.\n\nUsage:\n  nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n";
 
 /// One completed command-line execution, including its exact stdout bytes.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -81,6 +83,16 @@ enum Command {
         package: String,
         log: String,
         output: String,
+    },
+    ExplainEntity {
+        package: String,
+        entity: String,
+    },
+    ExplainTransition {
+        run: String,
+        entity: String,
+        tick: u64,
+        package: String,
     },
 }
 
@@ -186,6 +198,41 @@ fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Command, Diagnostic
                 output: output.clone(),
             }
         }
+        [name, help] if name == "explain-entity" && help == "--help" => {
+            Command::Help(EXPLAIN_ENTITY_HELP)
+        }
+        [name, package, entity]
+            if name == "explain-entity" && !is_option(package) && !is_option(entity) =>
+        {
+            Command::ExplainEntity {
+                package: package.clone(),
+                entity: entity.clone(),
+            }
+        }
+        [name, help] if name == "explain-transition" && help == "--help" => {
+            Command::Help(EXPLAIN_TRANSITION_HELP)
+        }
+        [name, run, entity, tick_option, tick, world_option, package]
+            if name == "explain-transition"
+                && !is_option(run)
+                && !is_option(entity)
+                && tick_option == "--tick"
+                && !is_option(tick)
+                && world_option == "--world"
+                && !is_option(package) =>
+        {
+            let tick = tick.parse::<u64>().map_err(|_| {
+                usage(format!(
+                    "transition explanation tick `{tick}` is not an unsigned integer"
+                ))
+            })?;
+            Command::ExplainTransition {
+                run: run.clone(),
+                entity: entity.clone(),
+                tick,
+                package: package.clone(),
+            }
+        }
         [name, help] if name == "command" && help == "--help" => Command::Help(COMMAND_HELP),
         [
             name,
@@ -252,6 +299,15 @@ fn execute_command(command: Command) -> Execution {
             log,
             output,
         } => replay(&package, &log, &output),
+        Command::ExplainEntity { package, entity } => {
+            explain_entity(&package, &entity).map(RuntimeOutcome::completed)
+        }
+        Command::ExplainTransition {
+            run,
+            entity,
+            tick,
+            package,
+        } => explain_transition(&run, &entity, tick, &package).map(RuntimeOutcome::completed),
     };
     match result {
         Ok(outcome) => outcome.into_execution(),
@@ -481,6 +537,27 @@ fn replay(package: &str, log: &str, output: &str) -> Result<RuntimeOutcome, Diag
     )?;
     replay.validate_execution(&execution)?;
     publish_execution("replay", output, &output_path, &world, execution)
+}
+
+fn explain_entity(package: &str, entity: &str) -> Result<CanonicalValue, Diagnostic> {
+    let package_path = relative_filesystem_path(package)?;
+    let entity = EntityId::parse(entity)?;
+    let world = open_compiled_world(&package_path)?;
+    crate::explanation::entity_report(&world, &entity)
+}
+
+fn explain_transition(
+    run: &str,
+    entity: &str,
+    tick: u64,
+    package: &str,
+) -> Result<CanonicalValue, Diagnostic> {
+    let run_path = relative_filesystem_path(run)?;
+    let package_path = relative_filesystem_path(package)?;
+    let entity = EntityId::parse(entity)?;
+    let world = open_compiled_world(&package_path)?;
+    let run = open_run_bundle(&run_path, &world)?;
+    crate::explanation::transition_report(&world, &run, &entity, tick)
 }
 
 fn publish_execution(

--- a/crates/nomos-cli/src/explanation.rs
+++ b/crates/nomos-cli/src/explanation.rs
@@ -1,0 +1,239 @@
+//! Read-only semantic explanations over already verified typed evidence.
+
+use std::collections::BTreeSet;
+
+use nomos_compiler::OpenedCompiledWorld;
+use nomos_core::id::StableId;
+use nomos_core::{CanonicalValue, ClaimRef, Diagnostic, EntityId};
+use nomos_projection::MovementDisposition;
+use nomos_sim::{CausalReceipt, resolve_light, resolve_movement};
+
+use crate::{OpenedRunBundle, initial_state_from_package};
+
+pub(crate) fn entity_report(
+    world: &OpenedCompiledWorld,
+    entity: &EntityId,
+) -> Result<CanonicalValue, Diagnostic> {
+    let construction = world.stable_ir().construction();
+    let entity_record = construction
+        .entities()
+        .iter()
+        .find(|candidate| candidate.id() == entity)
+        .ok_or_else(|| missing_entity(entity))?;
+    let initial = initial_state_from_package(world)?;
+    let movement = resolve_movement(world.simulation(), &initial)?;
+    let light = resolve_light(world.simulation(), &initial)?;
+    let movement = movement.get(entity);
+    let light = light.get(entity);
+
+    let mut active_claims = BTreeSet::new();
+    if let Some(disposition) = movement {
+        active_claims.extend(disposition.reasons().iter().cloned());
+    }
+    if let Some(fact) = light {
+        active_claims.extend(fact.reasons().iter().cloned());
+    }
+
+    let ownership = construction
+        .ownership_receipts()
+        .iter()
+        .filter(|receipt| receipt.fact().mentions_entity(entity))
+        .map(|receipt| receipt.to_canonical())
+        .collect();
+    let registry = world
+        .registry()
+        .entries()
+        .iter()
+        .map(|entry| {
+            CanonicalValue::object_declared([
+                ("artifact", CanonicalValue::text(entry.artifact())),
+                ("owner", CanonicalValue::text(entry.owner().as_str())),
+                ("schema", entry.schema().to_canonical()),
+            ])
+        })
+        .collect();
+
+    Ok(CanonicalValue::object_declared([
+        (
+            "active_initial_claims",
+            CanonicalValue::Array(active_claims.iter().map(StableId::to_canonical).collect()),
+        ),
+        ("command", CanonicalValue::text("explain-entity")),
+        ("entity", entity_record.to_canonical()),
+        (
+            "effective_initial_facts",
+            CanonicalValue::object_declared([
+                (
+                    "ground_movement",
+                    movement.map_or(CanonicalValue::Null, movement_to_canonical),
+                ),
+                (
+                    "light_emission",
+                    light.map_or(CanonicalValue::Null, |fact| {
+                        CanonicalValue::object_declared([
+                            ("emitting", CanonicalValue::Bool(fact.emitting())),
+                            (
+                                "reasons",
+                                CanonicalValue::Array(
+                                    fact.reasons().iter().map(StableId::to_canonical).collect(),
+                                ),
+                            ),
+                        ])
+                    }),
+                ),
+            ]),
+        ),
+        ("ownership_receipts", CanonicalValue::Array(ownership)),
+        (
+            "package_digest",
+            CanonicalValue::text(world.package_digest().to_hex()),
+        ),
+        (
+            "schemas",
+            CanonicalValue::object_declared([
+                (
+                    "construction_world_ir",
+                    construction.schema().to_canonical(),
+                ),
+                ("package_members", CanonicalValue::Array(registry)),
+                (
+                    "runtime_state",
+                    nomos_sim::runtime_state_schema().to_canonical(),
+                ),
+                ("source", construction.source_schema().to_canonical()),
+                ("world_ir", world.stable_ir().schema().to_canonical()),
+            ]),
+        ),
+        ("status", CanonicalValue::text("completed")),
+    ]))
+}
+
+pub(crate) fn transition_report(
+    world: &OpenedCompiledWorld,
+    run: &OpenedRunBundle,
+    entity: &EntityId,
+    tick: u64,
+) -> Result<CanonicalValue, Diagnostic> {
+    let construction = world.stable_ir().construction();
+    let entity_record = construction
+        .entities()
+        .iter()
+        .find(|candidate| candidate.id() == entity)
+        .ok_or_else(|| missing_entity(entity))?;
+    let (index, receipt) = run
+        .causal_receipts()
+        .receipts()
+        .iter()
+        .enumerate()
+        .find(|(_, receipt)| receipt.tick() == tick)
+        .ok_or_else(|| {
+            Diagnostic::new(
+                nomos_core::diagnostic::codes::EXPLANATION_TICK_MISSING,
+                format!("verified run contains no committed transition at tick {tick}"),
+            )
+        })?;
+    let row = &run.command_log().rows()[index];
+    if receipt.command().namespace().entity() != entity
+        && !receipt
+            .steps()
+            .iter()
+            .any(|step| step.namespace().entity() == entity)
+    {
+        return Err(Diagnostic::new(
+            nomos_core::diagnostic::codes::EXPLANATION_ENTITY_UNRELATED,
+            format!("entity `{entity}` is unrelated to the committed transition at tick {tick}"),
+        ));
+    }
+
+    let before = active_claims(receipt, entity, true);
+    let after = active_claims(receipt, entity, false);
+    let claims_added = after
+        .difference(&before)
+        .map(StableId::to_canonical)
+        .collect();
+    let claims_removed = before
+        .difference(&after)
+        .map(StableId::to_canonical)
+        .collect();
+    let span = entity_record.source_span();
+    let (byte_start, byte_end) = span.byte_range();
+    let (line, column) = span.position();
+
+    Ok(CanonicalValue::object_declared([
+        ("claims_added", CanonicalValue::Array(claims_added)),
+        ("claims_removed", CanonicalValue::Array(claims_removed)),
+        ("command", CanonicalValue::text("explain-transition")),
+        ("entity", entity.to_canonical()),
+        (
+            "package_digest",
+            CanonicalValue::text(world.package_digest().to_hex()),
+        ),
+        ("receipt", receipt.to_canonical()),
+        ("request", row.request().to_canonical()),
+        ("resolved_command", receipt.resolved_command_to_canonical()),
+        (
+            "run_result_digest",
+            CanonicalValue::text(run.result_digest().to_hex()),
+        ),
+        (
+            "source_mapping",
+            CanonicalValue::object_declared([
+                ("byte_end", CanonicalValue::Uint(u64::from(byte_end))),
+                ("byte_start", CanonicalValue::Uint(u64::from(byte_start))),
+                ("column", CanonicalValue::Uint(u64::from(column))),
+                ("line", CanonicalValue::Uint(u64::from(line))),
+                ("path", CanonicalValue::text(span.path().as_str())),
+            ]),
+        ),
+        ("status", CanonicalValue::text("completed")),
+        ("tick", CanonicalValue::Uint(tick)),
+    ]))
+}
+
+fn movement_to_canonical(disposition: &MovementDisposition) -> CanonicalValue {
+    match disposition {
+        MovementDisposition::Blocked { reasons } => CanonicalValue::object_declared([
+            ("kind", CanonicalValue::text("blocked")),
+            (
+                "reasons",
+                CanonicalValue::Array(reasons.iter().map(StableId::to_canonical).collect()),
+            ),
+        ]),
+        MovementDisposition::Traversable { cost, reasons } => CanonicalValue::object_declared([
+            ("cost", CanonicalValue::Uint(u64::from(*cost))),
+            ("kind", CanonicalValue::text("traversable")),
+            (
+                "reasons",
+                CanonicalValue::Array(reasons.iter().map(StableId::to_canonical).collect()),
+            ),
+        ]),
+    }
+}
+
+fn active_claims(receipt: &CausalReceipt, entity: &EntityId, before: bool) -> BTreeSet<ClaimRef> {
+    let movement = if before {
+        receipt.movement_before()
+    } else {
+        receipt.movement_after()
+    };
+    let light = if before {
+        receipt.light_before()
+    } else {
+        receipt.light_after()
+    };
+    let mut claims = BTreeSet::new();
+    if let Some(disposition) = movement.get(entity) {
+        claims.extend(disposition.reasons().iter().cloned());
+    }
+    if let Some(fact) = light.get(entity) {
+        claims.extend(fact.reasons().iter().cloned());
+    }
+    claims
+}
+
+fn missing_entity(entity: &EntityId) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::EXPLANATION_ENTITY_MISSING,
+        format!("verified world contains no entity `{entity}`"),
+    )
+}

--- a/crates/nomos-cli/src/lib.rs
+++ b/crates/nomos-cli/src/lib.rs
@@ -5,8 +5,8 @@
 //! SW-H implements the filesystem-authoring commands (`validate`, `compile`,
 //! and `inspect`) over that boundary. SW-J adds atomic verified run bundles and
 //! the `run` and `command` operations; SW-K adds strict deterministic replay,
-//! and SW-M adds strict stable-v1 migration. Explanation commands belong to a
-//! later accepted slice.
+//! SW-M adds strict stable-v1 migration, and SW-N renders read-only semantic
+//! explanations from already verified typed evidence.
 //!
 //! # Boundary
 //!
@@ -34,6 +34,7 @@
 use nomos_core::Diagnostic;
 
 mod command;
+mod explanation;
 mod package;
 mod run_bundle;
 

--- a/crates/nomos-cli/src/main.rs
+++ b/crates/nomos-cli/src/main.rs
@@ -2,8 +2,7 @@
 //!
 //! SW-H exposes the Gate K filesystem-authoring commands, SW-J adds immutable
 //! runtime run bundles, SW-K adds deterministic replay, and SW-M adds strict
-//! stable-v1 migration while leaving explanations for the accepted explanation
-//! slice.
+//! stable-v1 migration. SW-N adds package-bound semantic explanations.
 
 use std::io::{self, Write};
 use std::process::ExitCode as ProcessExitCode;

--- a/crates/nomos-cli/tests/sw_n.rs
+++ b/crates/nomos-cli/tests/sw_n.rs
@@ -1,0 +1,560 @@
+//! SW-N end-to-end proof for package-bound semantic explanations.
+
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use nomos_core::canonical::read::parse_canonical;
+use nomos_core::{CanonicalValue, FieldName, Sha256Digest};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+const SOURCE: &[u8] = include_bytes!("../../../fixtures/gaol.nomos");
+const COMMANDS: &[u8] = include_bytes!("../../../fixtures/gaol.commands");
+const SEVEN_COMMANDS: &[u8] = include_bytes!("../../../fixtures/gaol-seven.commands");
+const RUN_FILES: [&str; 6] = [
+    "causal-receipts.json",
+    "command-log.json",
+    "final-state.json",
+    "initial-state.json",
+    "result.json",
+    "state-hashes.json",
+];
+
+fn fresh_workspace(label: &str) -> PathBuf {
+    let index = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+        .join("sw-n-cli")
+        .join(format!("{}-{nonce}-{label}-{index}", std::process::id()));
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("gaol.nomos"), SOURCE).unwrap();
+    fs::write(root.join("gaol.commands"), COMMANDS).unwrap();
+    fs::write(root.join("gaol-seven.commands"), SEVEN_COMMANDS).unwrap();
+    root
+}
+
+fn run<I, S>(cwd: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new(env!("CARGO_BIN_EXE_nomos"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap()
+}
+
+fn assert_exit(output: &Output, expected: i32) {
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(output.stderr.is_empty());
+}
+
+fn canonical_stdout(output: &Output) -> CanonicalValue {
+    assert_eq!(output.stdout.last(), Some(&b'\n'));
+    assert_ne!(
+        output.stdout.get(output.stdout.len().saturating_sub(2)),
+        Some(&b'\n')
+    );
+    parse_canonical(&output.stdout[..output.stdout.len() - 1]).unwrap()
+}
+
+fn object(value: &CanonicalValue) -> &BTreeMap<FieldName, CanonicalValue> {
+    let CanonicalValue::Object(fields) = value else {
+        panic!("expected canonical object")
+    };
+    fields
+}
+
+fn field<'a>(value: &'a CanonicalValue, name: &'static str) -> &'a CanonicalValue {
+    object(value).get(&FieldName::declared(name)).unwrap()
+}
+
+fn array(value: &CanonicalValue) -> &[CanonicalValue] {
+    let CanonicalValue::Array(values) = value else {
+        panic!("expected canonical array")
+    };
+    values
+}
+
+fn diagnostic_code(output: &Output) -> String {
+    let value = canonical_stdout(output);
+    let diagnostic = &array(field(&value, "diagnostics"))[0];
+    let CanonicalValue::Text(code) = field(diagnostic, "code") else {
+        panic!("diagnostic code must be text")
+    };
+    code.clone()
+}
+
+fn compile(cwd: &Path, source: &str, output: &str) {
+    let compiled = run(cwd, ["compile", source, "--out", output]);
+    assert_exit(&compiled, 0);
+}
+
+fn publish_run(cwd: &Path, commands: &str, output: &str) {
+    let published = run(
+        cwd,
+        ["run", "gaol.world", "--commands", commands, "--out", output],
+    );
+    assert_exit(&published, 0);
+}
+
+fn directory_bytes(root: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut rows = fs::read_dir(root)
+        .unwrap()
+        .map(|entry| {
+            let entry = entry.unwrap();
+            (
+                entry.file_name().into_string().unwrap(),
+                fs::read(entry.path()).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.0.cmp(&right.0));
+    rows
+}
+
+fn copy_run(source: &Path, destination: &Path) {
+    fs::create_dir(destination).unwrap();
+    for name in RUN_FILES {
+        fs::copy(source.join(name), destination.join(name)).unwrap();
+    }
+}
+
+fn assert_output_hash(output: &Output, expected: &str) {
+    assert_eq!(Sha256Digest::of_bytes(&output.stdout).to_hex(), expected);
+}
+
+#[test]
+fn explanation_help_and_grammar_are_exact() {
+    let cwd = fresh_workspace("grammar");
+    let root_help = run(&cwd, ["--help"]);
+    assert_exit(&root_help, 0);
+    let help = String::from_utf8(root_help.stdout).unwrap();
+    assert!(help.contains("nomos explain-entity <world/> <entity>\n"));
+    assert!(
+        help.contains("nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n")
+    );
+
+    for args in [
+        vec!["explain-entity", "--help"],
+        vec!["explain-transition", "--help"],
+    ] {
+        let first = run(&cwd, &args);
+        let second = run(&cwd, &args);
+        assert_exit(&first, 0);
+        assert_eq!(first.stdout, second.stdout);
+        assert!(!first.stdout.starts_with(b"{"));
+    }
+
+    for args in [
+        vec!["explain-entity"],
+        vec!["explain-entity", "gaol.world"],
+        vec!["explain-entity", "gaol.world", "north_gate", "extra"],
+        vec!["explain-transition", "gaol.run", "north_gate"],
+        vec![
+            "explain-transition",
+            "gaol.run",
+            "north_gate",
+            "--world",
+            "gaol.world",
+            "--tick",
+            "4",
+        ],
+        vec![
+            "explain-transition",
+            "gaol.run",
+            "north_gate",
+            "--tick",
+            "four",
+            "--world",
+            "gaol.world",
+        ],
+        vec![
+            "explain-transition",
+            "gaol.run",
+            "north_gate",
+            "--tick",
+            "4",
+            "--world",
+            "gaol.world",
+            "extra",
+        ],
+    ] {
+        let rejected = run(&cwd, args);
+        assert_exit(&rejected, 2);
+        assert_eq!(diagnostic_code(&rejected), "EK0001");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn explanation_non_utf8_argv_is_invalid_usage() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let cwd = fresh_workspace("non-utf8");
+    for args in [
+        vec![
+            OsString::from("explain-entity"),
+            OsString::from("gaol.world"),
+            OsString::from_vec(vec![0xff]),
+        ],
+        vec![
+            OsString::from("explain-transition"),
+            OsString::from_vec(vec![0xff]),
+            OsString::from("north_gate"),
+            OsString::from("--tick"),
+            OsString::from("4"),
+            OsString::from("--world"),
+            OsString::from("gaol.world"),
+        ],
+    ] {
+        let rejected = run(&cwd, args);
+        assert_exit(&rejected, 2);
+        assert_eq!(diagnostic_code(&rejected), "EK0001");
+    }
+}
+
+#[test]
+fn door_water_and_light_reports_freeze_distinct_semantic_causes() {
+    let cwd = fresh_workspace("entities");
+    compile(&cwd, "gaol.nomos", "gaol.world");
+    let package_before = directory_bytes(&cwd.join("gaol.world"));
+
+    let door = run(&cwd, ["explain-entity", "gaol.world", "north_gate"]);
+    let water = run(&cwd, ["explain-entity", "gaol.world", "flooded_section"]);
+    let light = run(&cwd, ["explain-entity", "gaol.world", "brazier_02"]);
+    for output in [&door, &water, &light] {
+        assert_exit(output, 0);
+    }
+    assert_output_hash(
+        &door,
+        "12ca7b682e6c1a90618821ee2d790c55308d9e4873299cff1c27b8dc32221687",
+    );
+    assert_output_hash(
+        &water,
+        "21c1b7013145e7424633c3765e6d34d83c365ccd73a2e05d181d6bccb1c609b1",
+    );
+    assert_output_hash(
+        &light,
+        "62baac58f7d0b1f2f783bd717e9224d302ec6643c3fcde4738bf0c71175c78a4",
+    );
+
+    let door = canonical_stdout(&door);
+    let water = canonical_stdout(&water);
+    let light = canonical_stdout(&light);
+    assert_eq!(
+        field(field(&door, "entity"), "primitive"),
+        &CanonicalValue::text("primitive/iron_barred_door")
+    );
+    assert_eq!(
+        array(field(&door, "active_initial_claims")),
+        &[
+            CanonicalValue::text("north_gate.portal#blocks_ground"),
+            CanonicalValue::text("north_gate.ward#blocks_ground"),
+        ]
+    );
+    assert_eq!(
+        field(
+            field(field(&water, "effective_initial_facts"), "ground_movement"),
+            "cost"
+        ),
+        &CanonicalValue::Int(3)
+    );
+    assert_eq!(
+        field(
+            field(field(&light, "effective_initial_facts"), "light_emission"),
+            "emitting"
+        ),
+        &CanonicalValue::Bool(true)
+    );
+    for report in [&door, &water, &light] {
+        assert!(!array(field(report, "ownership_receipts")).is_empty());
+        let _ = field(field(report, "schemas"), "world_ir");
+        let expansion = field(field(report, "entity"), "expansion");
+        let _ = field(expansion, "capabilities");
+        let _ = field(expansion, "claims");
+        let _ = field(expansion, "machines");
+    }
+    assert_eq!(directory_bytes(&cwd.join("gaol.world")), package_before);
+}
+
+#[test]
+fn required_tick_four_and_tick_seven_reports_are_exact_and_read_only() {
+    let cwd = fresh_workspace("transitions");
+    compile(&cwd, "gaol.nomos", "gaol.world");
+    publish_run(&cwd, "gaol.commands", "gaol.run");
+    publish_run(&cwd, "gaol-seven.commands", "gaol-seven.run");
+    let package_before = directory_bytes(&cwd.join("gaol.world"));
+    let primary_before = directory_bytes(&cwd.join("gaol.run"));
+    let seven_before = directory_bytes(&cwd.join("gaol-seven.run"));
+    let commands_before = fs::read(cwd.join("gaol.commands")).unwrap();
+    let replay_before = include_bytes!("../../../fixtures/gaol.replay").to_vec();
+
+    let door = run(
+        &cwd,
+        [
+            "explain-transition",
+            "gaol.run",
+            "north_gate",
+            "--tick",
+            "4",
+            "--world",
+            "gaol.world",
+        ],
+    );
+    let light = run(
+        &cwd,
+        [
+            "explain-transition",
+            "gaol-seven.run",
+            "brazier_02",
+            "--tick",
+            "7",
+            "--world",
+            "gaol.world",
+        ],
+    );
+    assert_exit(&door, 0);
+    assert_exit(&light, 0);
+    assert_output_hash(
+        &door,
+        "fd6cb5f6efe69c6c334e8a3c2d5f57883089a15e7c18d21da8870ed4275dd9ac",
+    );
+    assert_output_hash(
+        &light,
+        "608cedfd41c1c002c48ee0358afb4230589763c212a60974122332ffbb46ecc0",
+    );
+
+    let door = canonical_stdout(&door);
+    assert_eq!(field(&door, "tick"), &CanonicalValue::Int(4));
+    assert_eq!(
+        field(field(&door, "request"), "action"),
+        &CanonicalValue::text("ignite")
+    );
+    assert_eq!(
+        array(field(field(&door, "receipt"), "transitions")).len(),
+        2
+    );
+    let light = canonical_stdout(&light);
+    assert_eq!(field(&light, "tick"), &CanonicalValue::Int(7));
+    assert_eq!(
+        array(field(&light, "claims_removed")),
+        &[CanonicalValue::text("brazier_02.emission#emits_light")]
+    );
+    assert_eq!(
+        array(field(field(&light, "receipt"), "projection_deltas")).len(),
+        3
+    );
+    let receipt = field(&light, "receipt");
+    let _ = field(receipt, "effective_facts_before");
+    let _ = field(receipt, "effective_facts_after");
+    let _ = field(receipt, "state_hash");
+    let _ = field(&light, "source_mapping");
+
+    assert_eq!(directory_bytes(&cwd.join("gaol.world")), package_before);
+    assert_eq!(directory_bytes(&cwd.join("gaol.run")), primary_before);
+    assert_eq!(directory_bytes(&cwd.join("gaol-seven.run")), seven_before);
+    assert_eq!(
+        fs::read(cwd.join("gaol.commands")).unwrap(),
+        commands_before
+    );
+    assert_eq!(
+        include_bytes!("../../../fixtures/gaol.replay"),
+        &*replay_before
+    );
+}
+
+#[test]
+fn explanation_selection_and_verified_input_failures_are_stable() {
+    let cwd = fresh_workspace("failures");
+    compile(&cwd, "gaol.nomos", "gaol.world");
+    publish_run(&cwd, "gaol.commands", "gaol.run");
+
+    for (args, code) in [
+        (
+            vec!["explain-entity", "gaol.world", "missing_entity"],
+            "EK0825",
+        ),
+        (vec!["explain-entity", "gaol.world", "Bad-Entity"], "EK0101"),
+        (
+            vec![
+                "explain-transition",
+                "gaol.run",
+                "north_gate",
+                "--tick",
+                "99",
+                "--world",
+                "gaol.world",
+            ],
+            "EK0826",
+        ),
+        (
+            vec![
+                "explain-transition",
+                "gaol.run",
+                "flooded_section",
+                "--tick",
+                "4",
+                "--world",
+                "gaol.world",
+            ],
+            "EK0827",
+        ),
+    ] {
+        let rejected = run(&cwd, args);
+        assert_exit(&rejected, 1);
+        assert_eq!(diagnostic_code(&rejected), code);
+    }
+
+    fs::write(cwd.join("other.nomos"), SOURCE).unwrap();
+    compile(&cwd, "other.nomos", "other.world");
+    let wrong_world = run(
+        &cwd,
+        [
+            "explain-transition",
+            "gaol.run",
+            "north_gate",
+            "--tick",
+            "4",
+            "--world",
+            "other.world",
+        ],
+    );
+    assert_exit(&wrong_world, 1);
+    assert_eq!(diagnostic_code(&wrong_world), "EK0813");
+
+    copy_run(&cwd.join("gaol.run"), &cwd.join("forged.run"));
+    let mut forged = fs::read(cwd.join("forged.run/causal-receipts.json")).unwrap();
+    forged.push(b'\n');
+    fs::write(cwd.join("forged.run/causal-receipts.json"), forged).unwrap();
+    let forged = run(
+        &cwd,
+        [
+            "explain-transition",
+            "forged.run",
+            "north_gate",
+            "--tick",
+            "4",
+            "--world",
+            "gaol.world",
+        ],
+    );
+    assert_exit(&forged, 1);
+    assert_eq!(diagnostic_code(&forged), "EK0302");
+
+    fs::write(cwd.join("not-a-world"), b"not a directory").unwrap();
+    let special_world = run(&cwd, ["explain-entity", "not-a-world", "north_gate"]);
+    assert_exit(&special_world, 1);
+    assert_eq!(diagnostic_code(&special_world), "EK0409");
+
+    fs::write(cwd.join("not-a-run"), b"not a directory").unwrap();
+    let special_run = run(
+        &cwd,
+        [
+            "explain-transition",
+            "not-a-run",
+            "north_gate",
+            "--tick",
+            "4",
+            "--world",
+            "gaol.world",
+        ],
+    );
+    assert_exit(&special_run, 1);
+    assert_eq!(diagnostic_code(&special_run), "EK0819");
+
+    let missing_world = run(&cwd, ["explain-entity", "missing.world", "north_gate"]);
+    assert_exit(&missing_world, 1);
+    assert_eq!(diagnostic_code(&missing_world), "EK0405");
+    let missing_run = run(
+        &cwd,
+        [
+            "explain-transition",
+            "missing.run",
+            "north_gate",
+            "--tick",
+            "4",
+            "--world",
+            "gaol.world",
+        ],
+    );
+    assert_exit(&missing_run, 1);
+    assert_eq!(diagnostic_code(&missing_run), "EK0818");
+}
+
+#[cfg(unix)]
+#[test]
+fn explanation_refuses_symlinked_package_and_run_roots_and_entries() {
+    use std::os::unix::fs::symlink;
+
+    let cwd = fresh_workspace("symlinks");
+    compile(&cwd, "gaol.nomos", "gaol.world");
+    publish_run(&cwd, "gaol.commands", "gaol.run");
+    symlink("gaol.world", cwd.join("world-link")).unwrap();
+    symlink("gaol.run", cwd.join("run-link")).unwrap();
+
+    let world = run(&cwd, ["explain-entity", "world-link", "north_gate"]);
+    assert_exit(&world, 1);
+    assert_eq!(diagnostic_code(&world), "EK0409");
+
+    compile(&cwd, "gaol.nomos", "world-entry.world");
+    fs::remove_file(cwd.join("world-entry.world/simulation.json")).unwrap();
+    symlink(
+        "../gaol.world/simulation.json",
+        cwd.join("world-entry.world/simulation.json"),
+    )
+    .unwrap();
+    let world_entry = run(&cwd, ["explain-entity", "world-entry.world", "north_gate"]);
+    assert_exit(&world_entry, 1);
+    assert_eq!(diagnostic_code(&world_entry), "EK0409");
+
+    let run_link = run(
+        &cwd,
+        [
+            "explain-transition",
+            "run-link",
+            "north_gate",
+            "--tick",
+            "4",
+            "--world",
+            "gaol.world",
+        ],
+    );
+    assert_exit(&run_link, 1);
+    assert_eq!(diagnostic_code(&run_link), "EK0819");
+
+    copy_run(&cwd.join("gaol.run"), &cwd.join("run-entry.run"));
+    fs::remove_file(cwd.join("run-entry.run/state-hashes.json")).unwrap();
+    symlink(
+        "../gaol.run/state-hashes.json",
+        cwd.join("run-entry.run/state-hashes.json"),
+    )
+    .unwrap();
+    let run_entry = run(
+        &cwd,
+        [
+            "explain-transition",
+            "run-entry.run",
+            "north_gate",
+            "--tick",
+            "4",
+            "--world",
+            "gaol.world",
+        ],
+    );
+    assert_exit(&run_entry, 1);
+    assert_eq!(diagnostic_code(&run_entry), "EK0819");
+}

--- a/crates/nomos-core/src/diagnostic.rs
+++ b/crates/nomos-core/src/diagnostic.rs
@@ -517,6 +517,12 @@ pub mod codes {
     pub const REPLAY_INPUT_MISMATCH: DiagnosticCode = DiagnosticCode::new("EK0823");
     /// Re-execution does not reproduce the replay log's expected committed evidence.
     pub const REPLAY_EVIDENCE_MISMATCH: DiagnosticCode = DiagnosticCode::new("EK0824");
+    /// An explanation names a well-formed entity absent from the verified world.
+    pub const EXPLANATION_ENTITY_MISSING: DiagnosticCode = DiagnosticCode::new("EK0825");
+    /// An explanation names a tick absent from the verified committed run prefix.
+    pub const EXPLANATION_TICK_MISSING: DiagnosticCode = DiagnosticCode::new("EK0826");
+    /// An explanation entity is unrelated to the selected committed transition.
+    pub const EXPLANATION_ENTITY_UNRELATED: DiagnosticCode = DiagnosticCode::new("EK0827");
 
     /// A resolver-plan collection repeats one stable semantic identity.
     pub const RESOLVER_DUPLICATE_IDENTITY: DiagnosticCode = DiagnosticCode::new("EK0901");
@@ -622,6 +628,9 @@ pub mod codes {
         REPLAY_LOG_INVALID,
         REPLAY_INPUT_MISMATCH,
         REPLAY_EVIDENCE_MISMATCH,
+        EXPLANATION_ENTITY_MISSING,
+        EXPLANATION_TICK_MISSING,
+        EXPLANATION_ENTITY_UNRELATED,
         RESOLVER_DUPLICATE_IDENTITY,
         RESOLVER_CLAIM_ENTITY_MISMATCH,
         RESOLVER_ACTIVATION_NAMESPACE_MISSING,

--- a/crates/nomos-schema/src/ir.rs
+++ b/crates/nomos-schema/src/ir.rs
@@ -450,7 +450,9 @@ impl IrEntity {
         &self.source_span
     }
 
-    fn to_canonical(&self) -> CanonicalValue {
+    /// Canonical structured entity meaning used by downstream explanations.
+    #[must_use]
+    pub fn to_canonical(&self) -> CanonicalValue {
         let credential = self
             .credential
             .as_ref()

--- a/crates/nomos-schema/src/provenance.rs
+++ b/crates/nomos-schema/src/provenance.rs
@@ -59,6 +59,20 @@ pub enum FactIdentity {
 }
 
 impl FactIdentity {
+    /// Whether this fact directly concerns the supplied entity.
+    #[must_use]
+    pub fn mentions_entity(&self, entity: &EntityId) -> bool {
+        match self {
+            Self::EntityIdentity(subject)
+            | Self::EntitySpatialAnchor(subject)
+            | Self::EntitySpatialBinding(subject)
+            | Self::EntityCredential(subject) => subject == entity,
+            Self::Relation {
+                subject, object, ..
+            } => subject == entity || object == entity,
+        }
+    }
+
     /// Canonical structured identity.
     #[must_use]
     pub fn to_canonical(&self) -> CanonicalValue {

--- a/crates/nomos-sim/src/receipt.rs
+++ b/crates/nomos-sim/src/receipt.rs
@@ -212,6 +212,12 @@ impl CausalReceipt {
         &self.command
     }
 
+    /// Canonical structured form of the compiler-projection-resolved command.
+    #[must_use]
+    pub fn resolved_command_to_canonical(&self) -> CanonicalValue {
+        command_to_canonical(&self.command)
+    }
+
     /// Ordered local-then-causal machine transitions.
     #[must_use]
     pub fn steps(&self) -> &[TransitionStep] {
@@ -328,7 +334,9 @@ impl CausalReceipt {
         self.to_canonical().to_canonical_bytes()
     }
 
-    pub(crate) fn to_canonical(&self) -> CanonicalValue {
+    /// Canonical structured receipt meaning used by downstream explanations.
+    #[must_use]
+    pub fn to_canonical(&self) -> CanonicalValue {
         CanonicalValue::object_declared([
             ("command", command_to_canonical(&self.command)),
             (

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,8 +1,8 @@
 # Handoff — state of the repository
 
-Updated 2026-08-22 for the issue #62 explanation-boundary contract repair.
-SW-M is merged and green; the contract-revision-7 repair is active on branch
-`contract-transition-explanation-62`.
+Updated 2026-08-22 for the issue #65 SW-N explanation slice. Contract revision
+7 is merged and green; SW-N is active on branch
+`sw-n-semantic-explanations-65`.
 This file orients a fresh session; it is rewritten at each slice boundary and
 never accumulates history (git has that).
 
@@ -164,8 +164,8 @@ never accumulates history (git has that).
   findings; after repair it reviewed and reran final head `7ea49d6` green on
   Rust 1.98.0. PR CI run `32530844878` passed, PR #34 merged as `1f04fce`, issue
   #24 closed, and post-merge CI run `32531098740` passed. Structured canonical
-  data and readable explanations are separate outputs; the actual
-  `nomos explain-*` CLI remains later work.
+  data and readable explanations are separate outputs. At that slice boundary
+  `nomos explain-*` remained later work; SW-N now consumes the typed record.
 - **SW-F is merged (#35/#38):** construction IR advances to
   `nomos.world_ir.construction@3` and simulation to
   `nomos.projection.simulation@3`; persistence and diagnostics begin at `@1`.
@@ -283,22 +283,37 @@ never accumulates history (git has that).
   boundaries. PR #64 merged as `0b9d948`, issue #63 closed, post-merge CI run
   `32573036770` passed, and the feature/review worktrees and branches were
   removed.
-- **Contract revision 7 is owner-authorized (#62):** decision 0009 requires
+- **Contract revision 7 is merged and green (#62/#66):** decision 0009 requires
   `explain-transition` to receive `--world <world/>`, strictly verify that world,
   and strictly open and re-execute the run against it before explaining a
   receipt. The tick-7 brazier example uses separate seven-command evidence, so
   the accepted five-command command/replay fixture remains unchanged. This
   repair adds no run member, package locator, persisted schema, or weaker
-  standalone forensic path. The explanation commands remain a later
-  implementation slice.
+  standalone forensic path. Exact head `98e71d2` passed author proof, PR CI run
+  `32585274094`, and a finding-free GPT-5.6 Luna high non-author rerun after a
+  superseded audit found three stale references. PR #66 merged as `3d67c4f`,
+  issue #62 closed, post-merge CI run `32585743441` passed, and the feature and
+  review worktrees and branches were removed.
+- **SW-N is active (#65):** `nomos explain-entity` renders linked source,
+  primitive expansion, independent machines, claim templates, active initial
+  claims, effective facts, typed ownership/derivation records, consumers, and
+  schema identities from a strictly opened world. `nomos explain-transition`
+  strictly opens that world, then strictly opens and re-executes the unchanged
+  six-file run before selecting a tick and rendering the unresolved request,
+  resolved command, causes, ordered steps, claim changes, complete effective
+  facts, projection deltas, source mapping, and state hash. The primary
+  five-command evidence proves `north_gate` at tick 4;
+  `fixtures/gaol-seven.commands` separately proves `brazier_02` at tick 7.
+  Focused subprocess tests freeze exact output hashes and rejection behavior.
+  No schema, package/run member, package locator, dependency, or runtime path is
+  added.
 
 ## What is next
 
-Finish issue #62: land decision 0009 and the contract-revision-7 wording after
-the full proof, green CI, and a clean non-author exact-head rerun. Then implement
-the package-bound entity and transition explanation surface in issue #65 on its
-own branch. Later work includes the Linux aarch64 and ten-run matrix, measured
-Gate K budgets, final schema-ownership review, and the formal cold-agent gates.
+Finish issue #65: complete the full proof, open the draft PR, obtain green CI
+and a clean non-author exact-head rerun, then leave merge disposition to the
+owner. Later work includes the Linux aarch64 and ten-run matrix, measured Gate K
+budgets, final schema-ownership review, and the formal cold-agent gates.
 
 The old `agy` Gemini route remains falsified evidence. Issue #49 qualifies Pi as
 the replacement transport without spending a formal attempt or changing the
@@ -314,12 +329,18 @@ cargo test --workspace --locked
 cargo xtask boundary
 cargo run --locked --bin nomos -- --help
 cargo run --locked --bin nomos -- validate fixtures/gaol.nomos
-cargo run --locked --bin nomos -- compile fixtures/gaol.nomos --out target/tmp/sw-m-proof/gaol.world
-cargo run --locked --bin nomos -- migrate fixtures/gaol-v1.world --to 2 --out target/tmp/sw-m-proof/gaol-migrated.world
-cargo run --locked --bin nomos -- inspect target/tmp/sw-m-proof/gaol-migrated.world
-cargo run --locked --bin nomos -- run target/tmp/sw-m-proof/gaol.world --commands fixtures/gaol.commands --out target/tmp/sw-m-proof/gaol.run
-cargo run --locked --bin nomos -- command target/tmp/sw-m-proof/gaol.world --state target/tmp/sw-m-proof/gaol.run/final-state.json "close north_gate" --out target/tmp/sw-m-proof/after-close.run
-cargo run --locked --bin nomos -- replay target/tmp/sw-m-proof/gaol.world --log fixtures/gaol.replay --out target/tmp/sw-m-proof/replay.run
+cargo run --locked --bin nomos -- compile fixtures/gaol.nomos --out target/tmp/sw-n-proof/gaol.world
+cargo run --locked --bin nomos -- migrate fixtures/gaol-v1.world --to 2 --out target/tmp/sw-n-proof/gaol-migrated.world
+cargo run --locked --bin nomos -- inspect target/tmp/sw-n-proof/gaol-migrated.world
+cargo run --locked --bin nomos -- run target/tmp/sw-n-proof/gaol.world --commands fixtures/gaol.commands --out target/tmp/sw-n-proof/gaol.run
+cargo run --locked --bin nomos -- run target/tmp/sw-n-proof/gaol.world --commands fixtures/gaol-seven.commands --out target/tmp/sw-n-proof/gaol-seven.run
+cargo run --locked --bin nomos -- explain-entity target/tmp/sw-n-proof/gaol.world north_gate
+cargo run --locked --bin nomos -- explain-entity target/tmp/sw-n-proof/gaol.world flooded_section
+cargo run --locked --bin nomos -- explain-entity target/tmp/sw-n-proof/gaol.world brazier_02
+cargo run --locked --bin nomos -- explain-transition target/tmp/sw-n-proof/gaol.run north_gate --tick 4 --world target/tmp/sw-n-proof/gaol.world
+cargo run --locked --bin nomos -- explain-transition target/tmp/sw-n-proof/gaol-seven.run brazier_02 --tick 7 --world target/tmp/sw-n-proof/gaol.world
+cargo run --locked --bin nomos -- command target/tmp/sw-n-proof/gaol.world --state target/tmp/sw-n-proof/gaol.run/final-state.json "close north_gate" --out target/tmp/sw-n-proof/after-close.run
+cargo run --locked --bin nomos -- replay target/tmp/sw-n-proof/gaol.world --log fixtures/gaol.replay --out target/tmp/sw-n-proof/replay.run
 docs/evaluation/test-agy-print-preflight.sh
 docs/evaluation/test-agy-formal-boundary-preflight.sh
 docs/evaluation/test-pi-cold-agent-preflight.sh
@@ -338,9 +359,9 @@ author proof, Luna max exact-head rerun, PR CI, and post-merge CI also passed al
 four commands; the focused release SW-G test passed. SW-F, SW-D, and
 issue #24 have the same author/non-author/CI chain as recorded above. Earlier
 SW-C, revision-4, and Rust-1.98 maintenance reruns also passed.
-Still unproven: Linux aarch64 release, ten runs per target, explanation command
-implementation, measured Gate K budgets, and formal cold-agent gates. The
-contract also requires a final explicit schema-ownership
+Still unproven: Linux aarch64 release, ten runs per target, measured Gate K
+budgets, and formal cold-agent gates. The contract also requires a final
+explicit schema-ownership
 source-review receipt after the Gate K schema set stabilizes; that final
 receipt does not exist yet.
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,6 +1,6 @@
 ---
 title: Gate K compiler
-status: Compiler implementation reference; current through SW-M
+status: Compiler implementation reference; current through SW-N
 date: 2026-08-22
 applies_to: KERNEL.md sections 1, 2, 4, 9; acceptance 1-3 and 11
 ---
@@ -147,13 +147,14 @@ At SW-C, the CLI was intentionally unimplemented: acceptance item 3's
 observable `nomos inspect` command required the complete package added by later
 slices. Issue #5 records that historical scope split. SW-H now exposes
 `validate`, `compile`, and `inspect`; SW-J adds `run` and `command` over the
-verified package boundary; SW-K adds `replay`, and SW-M adds strict `migrate`
-without exposing legacy execution through ordinary runtime commands.
+verified package boundary; SW-K adds `replay`; SW-M adds strict `migrate`
+without exposing legacy execution through ordinary runtime commands; and SW-N
+adds read-only explanations over reconstructed typed meaning.
 
-Typed provenance prepares the data needed by `explain-entity`. Decision 0009
-resolves issue #62 by requiring `explain-transition` to receive and verify an
-explicit world package before strictly opening and re-executing its run. The CLI
-explanation surface remains a later implementation slice.
+Typed provenance supplies `explain-entity` directly. Decision 0009 requires
+`explain-transition` to receive and verify an explicit world package before
+strictly opening and re-executing its run. SW-N implements both commands without
+adding a semantic decoder or changing compiler artifacts.
 
 `produced_schemas()` reports construction evidence, stable IR, all
 four projections, the registry, and compiler receipts. Construction versions

--- a/docs/explanations.md
+++ b/docs/explanations.md
@@ -1,0 +1,82 @@
+---
+title: Package-bound semantic explanations
+status: SW-N implementation and evidence reference
+date: 2026-08-22
+applies_to: KERNEL.md sections 8 and 9; acceptance 14
+---
+
+# Package-bound semantic explanations
+
+SW-N implements the two Gate K read-only explanation commands:
+
+```text
+nomos explain-entity <world/> <entity>
+nomos explain-transition <run/> <entity> --tick <tick> --world <world/>
+```
+
+They render canonical JSON from reconstructed typed meaning. They do not parse
+source, decode a second semantic representation, publish an artifact, or edit an
+input tree.
+
+## Entity explanation
+
+`explain-entity` strictly opens the complete compiled world before selecting an
+entity. Its report includes:
+
+- the source-mapped linked entity and approved primitive expansion;
+- independent namespace-machine definitions, claim templates, and interactions;
+- active initial claim reasons and effective movement/light facts;
+- typed fact-ownership receipts, resolved values, projection consumers, and
+  derivation steps;
+- the verified package digest and relevant source, construction, stable IR,
+  package-member, projection, and runtime-state schema identities.
+
+The fixture reports remain semantically distinct: `north_gate` explains two
+independent initial blockers, `flooded_section` explains traversal cost `3`, and
+`brazier_02` explains positive light emission.
+
+## Transition explanation
+
+`explain-transition` performs the decision-0009 sequence exactly:
+
+1. strictly open and semantically reconstruct `--world`;
+2. strictly open the exact six-file run bundle against that world;
+3. re-execute every committed request and require byte-identical states, logs,
+   receipts, and hashes through the existing opener;
+4. select the receipt by resulting tick and verify that the requested entity
+   owns either the initiating command or an ordered transition step;
+5. render the unresolved request, resolved command, ordered local/causal steps,
+   typed causes, active claims added/removed, complete effective facts before and
+   after, projection deltas, source mapping, tick, and resulting state hash.
+
+The accepted `fixtures/gaol.commands` and `fixtures/gaol.replay` stay unchanged.
+They prove `north_gate` at tick 4. `fixtures/gaol-seven.commands` is separate
+seven-command evidence that proves `brazier_02` at tick 7.
+
+## Stable selection failures
+
+The strict package/run openers retain all existing integrity, semantics,
+re-execution, symlink, and special-file diagnostics. SW-N adds only three report
+selection codes after those boundaries pass:
+
+```text
+EK0825  well-formed entity is absent from the verified world
+EK0826  requested tick is absent from the committed run prefix
+EK0827  requested entity is unrelated to the selected transition
+```
+
+Malformed CLI grammar remains `EK0001` with exit `2`; semantic rejection is exit
+`1`; environment/I/O failure remains exit `3`.
+
+## Evidence and limits
+
+Focused subprocess tests hash the exact canonical stdout for all three entity
+reports and both required transition reports. They also cover argument order and
+arity, non-UTF-8 arguments, invalid/absent/unrelated entities, absent ticks,
+wrong packages/semantics, forged evidence, forbidden entry types, root symlinks,
+and byte-for-byte input immutability.
+
+SW-N adds no persisted schema, package member, run member, package locator,
+dependency, alternate runtime path, or contract change. It does not satisfy the
+remaining execution matrix, budget, final schema-ownership, or formal cold-agent
+gates.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -139,5 +139,5 @@ This slice supports exactly the preserved stable-v1 package boundary and target
 v2. It does not migrate construction snapshots, expose a legacy runtime path,
 add a package member, promise future save compatibility, implement explanation,
 or claim signing, authenticity, hostile-filesystem safety, or concurrent-writer
-safety. Decision 0009 resolves the transition-explanation input boundary;
-implementation remains in issue #65.
+safety. SW-N explanations consume only an already migrated active-v2 package;
+they do not create a legacy explanation path.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -46,12 +46,13 @@ not merely present in the global vocabulary.
 
 ## Structured and readable output
 
-`FactOwnershipReceipt::to_canonical()` exposes the structured causal record for
-future diagnostics projection and `nomos explain-entity` output.
+`FactOwnershipReceipt::to_canonical()` exposes the structured causal record
+retained in World IR and used by `nomos explain-entity`; it remains available to
+a future richer diagnostics projection.
 `FactOwnershipReceipt::render_text()` produces human-readable text from those
 types. The renderer is deliberately downstream: changing prose cannot change
 canonical World IR bytes, fact identities, or causal edges.
 
-The CLI explanation commands remain a later slice. Issue #24 provides their
-typed semantic input and presentation boundary; it does not claim the commands
-are implemented.
+Issue #24 supplied the typed semantic input and presentation boundary. SW-N now
+renders it only after strict package verification; presentation remains
+downstream from canonical meaning and cannot change package bytes.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,6 +1,6 @@
 ---
 title: Gate K runtime commit and persisted evidence
-status: Implementation reference through SW-M
+status: Implementation reference through SW-N
 date: 2026-08-22
 applies_to: KERNEL.md sections 2, 3, 5, 7, and 9; acceptance 5, 9, 10, and 12
 ---
@@ -203,8 +203,7 @@ strict typed values and their cross-object integrity rules; SW-J publishes and
 reopens those exact values through `run` and `command`; SW-K binds and reproduces
 them through `replay`. SW-M proves that strict legacy-v1 migration produces the
 same normalized runtime-v2 state, command, receipt, movement, light, and
-hash-chain evidence as active v2 meaning. Decision 0009 requires a future
-transition explanation to open the world and strictly re-execute the run before
-rendering causal evidence; it does not implement that command or change the
-six-file bundle. No slice yet explains causal evidence, runs the multi-target
-ten-run matrix, or performs formal cold-agent gates.
+hash-chain evidence as active v2 meaning. SW-N follows decision 0009 by opening
+the world and strictly re-executing the run before rendering causal evidence.
+It changes neither the receipt nor the six-file bundle. The multi-target ten-run
+matrix and formal cold-agent gates remain open.

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -1,6 +1,6 @@
 ---
 title: Gate K transitions and transaction preparation
-status: Transition implementation reference; current through SW-M
+status: Transition implementation reference; current through SW-N
 date: 2026-08-22
 applies_to: KERNEL.md sections 1, 2, 4; acceptance 4-6
 ---
@@ -112,14 +112,15 @@ acceptance remain open.
 
 ## Explanation verification boundary
 
-Decision 0009 resolves the issue #62 contract ambiguity without implementing
-the explanation surface. A future `explain-transition` command must receive an
-explicit `--world <world/>`, strictly open that package, and then strictly open
-and re-execute the supplied run against it before rendering any explanation.
+Decision 0009 resolves the issue #62 contract ambiguity. SW-N implements
+`explain-transition` with the required explicit `--world <world/>`, strictly
+opens that package, and then strictly opens and re-executes the supplied run
+against it before rendering any explanation.
 The run's package and simulation digests bind the supplied bytes but cannot
 locate or reconstruct the package by themselves.
 
-The tick-7 brazier example uses separate seven-command run evidence. It does not
-change the accepted five-command command script or replay fixture. Explanation
-remains downstream human-readable output over existing typed evidence; this
-decision adds no persisted schema or alternate runtime path.
+The tick-7 brazier example uses `fixtures/gaol-seven.commands` as separate
+seven-command run evidence. It does not change the accepted five-command command
+script or replay fixture. Explanation remains downstream canonical JSON over
+existing typed evidence; SW-N adds no persisted schema or alternate runtime
+path.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -205,6 +205,6 @@ them and Gate K cannot call acceptance 16 passing. The CI `Budgets` step prints
 - The section 7 execution matrix. CI proves x86_64 debug and release; **Linux
   aarch64 release is unproved**, and the ten-runs-per-target count is not
   implemented. Gate K is not green until both exist.
-- The explanation portion of section 8's command surface, the final complete
-  mutation/evidence disposition, and the cold-agent gates. The filesystem
-  commands through strict v1-to-v2 `migrate` now exist.
+- The final complete mutation/evidence disposition and the cold-agent gates.
+  The filesystem commands through strict v1-to-v2 `migrate` now exist, and SW-N
+  adds the section 8 explanation surface without changing the workspace graph.

--- a/fixtures/gaol-seven.commands
+++ b/fixtures/gaol-seven.commands
@@ -1,0 +1,8 @@
+schema nomos.command_script@1
+unlock north_gate with credential/gaoler_key
+open north_gate
+close north_gate
+open north_gate
+unseal north_gate
+ignite north_gate
+extinguish brazier_02


### PR DESCRIPTION
Closes #65

## Summary

- add the exact explain-entity and package-bound explain-transition CLI surfaces
- render canonical semantic causality from strictly verified typed world and re-executed run evidence
- add separate seven-command tick-7 brazier evidence without changing the accepted five-command fixtures
- freeze exact successful JSON, rejection diagnostics, entry-type handling, and read-only behavior in subprocess tests
- update active guidance and the SW-N evidence reference

## Evidence

Exact head f6a7eb3bd9222459ccfb5d37f20ddd5fd522a993 passed author proof and the independent finding-free non-author rerun, in order:

1. cargo fmt --all -- --check
2. cargo clippy --workspace --all-targets --locked -- -D warnings
3. cargo test --workspace --locked
4. cargo xtask boundary

Exact-head PR CI passed in run 32586792897. The full non-author receipt is recorded in the PR comments.

## Limits

This adds no persisted schema, package/run member, package locator, dependency, contract criterion, or alternate runtime path. The multi-target ten-run matrix, measured budgets, final schema-ownership review, and formal cold-agent gates remain later work.

The draft is ready for owner disposition.