### PR TITLE
Connect the gaol areas into one run

### DIFF
--- a/experiments/executable-gaol/AUTHORING.md
+++ b/experiments/executable-gaol/AUTHORING.md
@@ -11,7 +11,8 @@ Required files:
   `primitive/extinguishable_light`.
 - `area.json`: stable area identity, primary exit gate, pursuit light, player
   and gaoler cell anchors, one `visual/cyan_crescent` presentation anchor, and
-  bounded architecture data.
+  bounded architecture data. Connected runs additionally declare whether this
+  is the start area and where its primary gate leads.
 - `scenarios/*.commands`: five ordered scenarios. Each of scenarios 2–4 adds
   exactly one command to the preceding script so browser interactions can be
   derived from real input and resulting state hashes.

--- a/experiments/executable-gaol/CAPTURE.md
+++ b/experiments/executable-gaol/CAPTURE.md
@@ -7,10 +7,10 @@ experiments/executable-gaol/gaol capture
 experiments/executable-gaol/gaol verify
 ```
 
-- AreaCollection SHA-256: `12a9173db5f49a0fd7fc852cb4cbb723f69a08d74d620a5faaf69f8e0501a4bd`
-- North Gaol RenderingPlan SHA-256: `330cd85444308d45e2f4a2ea62dca8aa814e5da923baaa160d14c2b389253b10`
-- Cistern Walk RenderingPlan SHA-256: `fb29e110f6afdbe9ab22ca847b2c2ad1ee4acda14e48ce1b2ca021041f3fddca`
-- Ember Vault RenderingPlan SHA-256: `85aaf45e940afa6fd60d84c564b00c2e63fb7c1eb5bb76c73dc6f6b3146329cd`
+- AreaCollection SHA-256: `09fed4ea297406719fb17c3bce8129bc0258eb763c2e93811a78a5efe53a2d34`
+- North Gaol RenderingPlan SHA-256: `a140e32adc0d655030c8d88adf276ba1d8e2078f3c5953ea36edd7594841baf5`
+- Cistern Walk RenderingPlan SHA-256: `49efd6ce16f4cf0fa926a5442e5a46f4a7d08cb51ea1c75d358c51596c506599`
+- Ember Vault RenderingPlan SHA-256: `948a452f4a343067badb83f48943005178942f4e0cddb239bc20290ce2912970`
 - cross-area contact-sheet.svg SHA-256: `04b706f067db4dd2464f557246b868cb53161925aacae6be270b81f60b2341e5`
 - cross-area contact-sheet.png SHA-256: `26273aba009f5228e63d2c0b8100857b0aae8bc15d493894fdb87de9861a5175`
 - verification: `EXECUTABLE_GAOL_VERIFY PASS`

--- a/experiments/executable-gaol/README.md
+++ b/experiments/executable-gaol/README.md
@@ -34,21 +34,26 @@ masonry masses, and composition come from separate area content.
 See [AUTHORING.md](AUTHORING.md) for the intentionally small LLM authoring
 packet.
 
-Use WASD or the arrow keys to cross the room. Walk beside `north_gate`, press
-`E` to ignite it, press `E` again to unseal it, and cross the resulting opening.
-After unsealing, walk beside `brazier_02` and press `E` to extinguish its bounded
-amber light pool.
+Use WASD or the arrow keys to cross each room. Walk beside its primary gate,
+press `E` to ignite it, press `E` again to unseal it, and cross the resulting
+opening. After unsealing, walk beside the room's brazier and press `E` to
+extinguish its bounded amber light pool.
 Darkness wakes the gaoler: it advances by a deterministic presentation-only
 rule every second successful move and catches the player on contact. Reach the
 open gate before it does.
 Those interaction edges are derived from consecutive, state-hash-bound Nomos
 command logs rather than interpreted by the browser. Shallow water consumes the
 projected movement cost of `3`; stone costs `1`. The north edge opens only at a
-door whose selected Nomos runtime state resolves to `traversable`. The area
-buttons or bracket keys switch rooms, keys 1–5 switch the real runtime
-scenarios, `R` resets the run, and the
-viewer interpolates movement without placing fractional positions into Nomos
-authoritative state.
+door whose selected Nomos runtime state resolves to `traversable`. Keys 1–5
+switch the real runtime scenarios for inspection, and the viewer interpolates
+movement without placing fractional positions into Nomos authoritative state.
+
+The default run begins in Cistern Walk. Crossing its declared, traversable
+sluice enters Ember Vault; crossing Ember's vault gate enters North Gaol; the
+North Gate is the final escape. Area transitions preserve cumulative moves,
+water cost, and cleared-area count while resetting area-local actors and runtime
+scenario selection. The area buttons and bracket keys are forensic shortcuts
+that reset run progress; `R` returns to the Cistern start.
 
 The internet build is the same static viewer staged without a running process:
 

--- a/experiments/executable-gaol/area-collection.example.json
+++ b/experiments/executable-gaol/area-collection.example.json
@@ -1,0 +1,118 @@
+{
+  "schema": "nomos.experiment.area_collection@1",
+  "deterministic": true,
+  "lookProfile": {
+    "id": "gaol_bounded_01",
+    "digest": "084832d5d8861a8473ef608a86a563d7ab7e9d9a09a0ab8246946dc2704f125a",
+    "grammar": {
+      "renderingPlanSchema": "nomos.experiment.rendering_plan@1",
+      "projectionSchemas": [
+        {
+          "name": "nomos.projection.simulation",
+          "version": 3
+        },
+        {
+          "name": "nomos.projection.navigation",
+          "version": 1
+        },
+        {
+          "name": "nomos.projection.persistence",
+          "version": 1
+        },
+        {
+          "name": "nomos.projection.diagnostics",
+          "version": 1
+        }
+      ],
+      "camera": {
+        "identity": "gaol_oblique_01",
+        "projection": "fixed_oblique",
+        "width": 1200,
+        "height": 540,
+        "tileWidth": 96,
+        "tileHeight": 50
+      },
+      "palette": "gaol_bounded_01",
+      "architectureStyle": {
+        "assembly": "visual/beveled_masonry",
+        "materialFamily": "stone_bounded",
+        "trimFamily": "broad_mortar"
+      },
+      "entityAssemblies": [
+        [
+          "door",
+          "visual/iron_barred_door",
+          "iron_oxidized"
+        ],
+        [
+          "light",
+          "visual/brazier",
+          "iron_brazier"
+        ],
+        [
+          "water",
+          "visual/shallow_water",
+          "water_cold"
+        ]
+      ],
+      "actorAssemblies": [
+        "visual/gaoler_silhouette",
+        "visual/player_silhouette"
+      ],
+      "effectAssemblies": [
+        "visual/cyan_crescent"
+      ],
+      "uiAnchors": [
+        "vitals",
+        "abilities",
+        "gate_state",
+        "water_cost"
+      ]
+    }
+  },
+  "startArea": "cistern-walk",
+  "route": [
+    {
+      "fromArea": "cistern-walk",
+      "gate": "sluice_gate",
+      "toArea": "ember-vault",
+      "entry": {
+        "x": 7,
+        "y": 5,
+        "z": 0
+      }
+    },
+    {
+      "fromArea": "ember-vault",
+      "gate": "vault_gate",
+      "toArea": "north-gaol",
+      "entry": {
+        "x": 2,
+        "y": 4,
+        "z": 0
+      }
+    },
+    {
+      "fromArea": "north-gaol",
+      "gate": "north_gate",
+      "toArea": null
+    }
+  ],
+  "areas": [
+    {
+      "id": "cistern-walk",
+      "label": "Cistern Walk",
+      "plan": "areas/cistern-walk.json"
+    },
+    {
+      "id": "ember-vault",
+      "label": "Ember Vault",
+      "plan": "areas/ember-vault.json"
+    },
+    {
+      "id": "north-gaol",
+      "label": "North Gaol",
+      "plan": "areas/north-gaol.json"
+    }
+  ]
+}

--- a/experiments/executable-gaol/areas/cistern-walk/area.json
+++ b/experiments/executable-gaol/areas/cistern-walk/area.json
@@ -1,9 +1,15 @@
 {
   "id": "cistern-walk",
   "label": "Cistern Walk",
+  "start": true,
   "primaryGate": "sluice_gate",
   "pursuitLight": "watch_brazier",
   "forensicScenario": "03-breached-unsealed",
+  "exit": {
+    "gate": "sluice_gate",
+    "toArea": "ember-vault",
+    "entry": { "x": 7, "y": 5, "z": 0 }
+  },
   "architecture": {
     "bounds": { "width": 9, "height": 6 },
     "wallHeight": 4.5,

--- a/experiments/executable-gaol/areas/cistern-walk/rendering-plan.example.json
+++ b/experiments/executable-gaol/areas/cistern-walk/rendering-plan.example.json
@@ -3,7 +3,8 @@
   "deterministic": true,
   "area": {
     "id": "cistern-walk",
-    "label": "Cistern Walk"
+    "label": "Cistern Walk",
+    "start": true
   },
   "projectionSchemas": [
     {
@@ -243,7 +244,16 @@
   "presentation": {
     "primaryGate": "sluice_gate",
     "pursuitLight": "watch_brazier",
-    "forensicScenario": "03-breached-unsealed"
+    "forensicScenario": "03-breached-unsealed",
+    "exit": {
+      "gate": "sluice_gate",
+      "toArea": "ember-vault",
+      "entry": {
+        "x": 7,
+        "y": 5,
+        "z": 0
+      }
+    }
   },
   "uiAnchors": [
     "vitals",

--- a/experiments/executable-gaol/areas/ember-vault/area.json
+++ b/experiments/executable-gaol/areas/ember-vault/area.json
@@ -1,9 +1,15 @@
 {
   "id": "ember-vault",
   "label": "Ember Vault",
+  "start": false,
   "primaryGate": "vault_gate",
   "pursuitLight": "ember_brazier",
   "forensicScenario": "03-breached-unsealed",
+  "exit": {
+    "gate": "vault_gate",
+    "toArea": "north-gaol",
+    "entry": { "x": 2, "y": 4, "z": 0 }
+  },
   "architecture": {
     "bounds": { "width": 9, "height": 6 },
     "wallHeight": 5,

--- a/experiments/executable-gaol/areas/ember-vault/rendering-plan.example.json
+++ b/experiments/executable-gaol/areas/ember-vault/rendering-plan.example.json
@@ -3,7 +3,8 @@
   "deterministic": true,
   "area": {
     "id": "ember-vault",
-    "label": "Ember Vault"
+    "label": "Ember Vault",
+    "start": false
   },
   "projectionSchemas": [
     {
@@ -255,7 +256,16 @@
   "presentation": {
     "primaryGate": "vault_gate",
     "pursuitLight": "ember_brazier",
-    "forensicScenario": "03-breached-unsealed"
+    "forensicScenario": "03-breached-unsealed",
+    "exit": {
+      "gate": "vault_gate",
+      "toArea": "north-gaol",
+      "entry": {
+        "x": 2,
+        "y": 4,
+        "z": 0
+      }
+    }
   },
   "uiAnchors": [
     "vitals",

--- a/experiments/executable-gaol/areas/north-gaol/area.json
+++ b/experiments/executable-gaol/areas/north-gaol/area.json
@@ -1,9 +1,14 @@
 {
   "id": "north-gaol",
   "label": "North Gaol",
+  "start": false,
   "primaryGate": "north_gate",
   "pursuitLight": "brazier_02",
   "forensicScenario": "03-breached-unsealed",
+  "exit": {
+    "gate": "north_gate",
+    "toArea": null
+  },
   "architecture": {
     "bounds": { "width": 9, "height": 6 },
     "wallHeight": 4.5,

--- a/experiments/executable-gaol/areas/north-gaol/rendering-plan.example.json
+++ b/experiments/executable-gaol/areas/north-gaol/rendering-plan.example.json
@@ -3,7 +3,8 @@
   "deterministic": true,
   "area": {
     "id": "north-gaol",
-    "label": "North Gaol"
+    "label": "North Gaol",
+    "start": false
   },
   "projectionSchemas": [
     {
@@ -230,7 +231,11 @@
   "presentation": {
     "primaryGate": "north_gate",
     "pursuitLight": "brazier_02",
-    "forensicScenario": "03-breached-unsealed"
+    "forensicScenario": "03-breached-unsealed",
+    "exit": {
+      "gate": "north_gate",
+      "toArea": null
+    }
   },
   "uiAnchors": [
     "vitals",

--- a/experiments/executable-gaol/gaol
+++ b/experiments/executable-gaol/gaol
@@ -86,6 +86,7 @@ case "$mode" in
   verify)
     build
     node --test "$experiment_dir/src/"*.test.mjs
+    cmp "$output_dir/areas.json" "$experiment_dir/area-collection.example.json"
     for area_dir in "$areas_dir"/*; do
       [[ -d $area_dir ]] || continue
       area_id=$(basename "$area_dir")

--- a/experiments/executable-gaol/src/area-collection.test.mjs
+++ b/experiments/executable-gaol/src/area-collection.test.mjs
@@ -1,12 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { attemptInteraction, attemptMove, createPlayState } from "./play-state.mjs";
+import { attemptInteraction, attemptMove, completeRun, createPlayState, enterArea } from "./play-state.mjs";
 
 const readPlan = (id) => JSON.parse(readFileSync(new URL(`../areas/${id}/rendering-plan.example.json`, import.meta.url)));
 const north = readPlan("north-gaol");
 const cistern = readPlan("cistern-walk");
 const ember = readPlan("ember-vault");
+const collection = JSON.parse(readFileSync(new URL("../area-collection.example.json", import.meta.url)));
 
 const grammar = (plan) => ({
   camera: plan.camera,
@@ -97,4 +98,70 @@ test("the ember vault dark route is winnable", () => {
   }
   assert.equal(state.escaped, true);
   assert.equal(state.caught, false);
+});
+
+const solveArea = (plan, initialState, toGate, toLight, toExit) => {
+  let scenarioId = "01-baseline";
+  let state = initialState;
+  for (const [dx, dy] of toGate) state = attemptMove(plan, scenarioId, state, dx, dy).state;
+  for (let count = 0; count < 2; count += 1) {
+    const interaction = attemptInteraction(plan, scenarioId, state);
+    state = interaction.state;
+    scenarioId = interaction.scenarioId;
+  }
+  for (const [dx, dy] of toLight) state = attemptMove(plan, scenarioId, state, dx, dy).state;
+  const extinguish = attemptInteraction(plan, scenarioId, state);
+  state = extinguish.state;
+  scenarioId = extinguish.scenarioId;
+  let result;
+  for (const [dx, dy] of toExit) {
+    result = attemptMove(plan, scenarioId, state, dx, dy);
+    state = result.state;
+  }
+  assert.equal(state.caught, false);
+  assert.equal(state.escaped, true);
+  return { state, exitGate: result.exitGate };
+};
+
+test("one run traverses all declared area connections", () => {
+  assert.equal(collection.startArea, "cistern-walk");
+  let solved = solveArea(
+    cistern,
+    createPlayState(cistern),
+    [[0, -1], [0, -1], [0, -1], [-1, 0], [-1, 0], [-1, 0], [-1, 0], [-1, 0]],
+    [[1, 0], [1, 0], [1, 0], [0, 1]],
+    [[0, -1], [-1, 0], [-1, 0], [-1, 0], [0, -1], [0, -1]],
+  );
+  let edge = collection.route.find((candidate) => candidate.fromArea === "cistern-walk" && candidate.gate === solved.exitGate);
+  let state = enterArea(ember, solved.state, edge.entry);
+  const cisternMoves = state.moves;
+  const cisternCost = state.movementCost;
+  assert.equal(state.areasCleared, 1);
+
+  solved = solveArea(
+    ember,
+    state,
+    [[0, -1], [0, -1], [0, -1], [-1, 0], [-1, 0], [-1, 0], [0, -1]],
+    [[-1, 0], [0, 1], [-1, 0], [-1, 0]],
+    [[1, 0], [1, 0], [0, -1], [1, 0], [0, -1], [0, -1]],
+  );
+  edge = collection.route.find((candidate) => candidate.fromArea === "ember-vault" && candidate.gate === solved.exitGate);
+  state = enterArea(north, solved.state, edge.entry);
+  assert.equal(state.areasCleared, 2);
+  assert.ok(state.moves > cisternMoves);
+  assert.ok(state.movementCost > cisternCost);
+
+  solved = solveArea(
+    north,
+    state,
+    [[0, -1], [0, -1], [0, -1], [1, 0], [1, 0], [1, 0]],
+    [[-1, 0]],
+    [[1, 0], [0, -1], [0, -1]],
+  );
+  edge = collection.route.find((candidate) => candidate.fromArea === "north-gaol" && candidate.gate === solved.exitGate);
+  assert.equal(edge.toArea, null);
+  state = completeRun(solved.state);
+  assert.equal(state.completed, true);
+  assert.equal(state.areasCleared, 3);
+  assert.equal(state.message, "Escaped the gaol");
 });

--- a/experiments/executable-gaol/src/build-collection.mjs
+++ b/experiments/executable-gaol/src/build-collection.mjs
@@ -30,12 +30,42 @@ const visualGrammar = (plan) => ({
 
 const grammar = visualGrammar(plans[0].plan);
 const grammarBytes = JSON.stringify(grammar);
+const byId = new Map(plans.map(({ plan }) => [plan.area.id, plan]));
 for (const { directory, plan } of plans) {
   if (plan.area.id !== directory) throw new Error(`${directory} does not match plan area identity ${plan.area.id}`);
   if (JSON.stringify(visualGrammar(plan)) !== grammarBytes) {
     throw new Error(`${directory} diverges from the shared visual grammar`);
   }
+  const exit = plan.presentation.exit;
+  if (exit.gate !== plan.presentation.primaryGate) throw new Error(`${directory} exit is not its primary gate`);
+  if (exit.toArea !== null) {
+    const target = byId.get(exit.toArea);
+    if (!target) throw new Error(`${directory} targets unknown area ${exit.toArea}`);
+    const { width, height } = target.architecture.bounds;
+    if (!exit.entry || exit.entry.x < 0 || exit.entry.x >= width || exit.entry.y < 0 || exit.entry.y >= height) {
+      throw new Error(`${directory} has an invalid entry into ${exit.toArea}`);
+    }
+    if (target.architecture.masses.some((mass) => exit.entry.x >= mass.min.x && exit.entry.x < mass.max.x
+      && exit.entry.y >= mass.min.y && exit.entry.y < mass.max.y)) {
+      throw new Error(`${directory} enters ${exit.toArea} inside masonry`);
+    }
+  }
 }
+
+const starts = plans.filter(({ plan }) => plan.area.start);
+if (starts.length !== 1) throw new Error("area collection requires exactly one start area");
+const startArea = starts[0].plan.area.id;
+const route = [];
+const visited = new Set();
+let current = startArea;
+while (current !== null) {
+  if (visited.has(current)) throw new Error(`area route cycles at ${current}`);
+  visited.add(current);
+  const plan = byId.get(current);
+  route.push({ fromArea: current, ...plan.presentation.exit });
+  current = plan.presentation.exit.toArea;
+}
+if (visited.size !== plans.length) throw new Error("area route does not visit every declared area");
 
 const collection = {
   schema: "nomos.experiment.area_collection@1",
@@ -45,6 +75,8 @@ const collection = {
     digest: createHash("sha256").update(grammarBytes).digest("hex"),
     grammar,
   },
+  startArea,
+  route,
   areas: plans.map(({ plan }) => ({
     id: plan.area.id,
     label: plan.area.label,

--- a/experiments/executable-gaol/src/build-plan.mjs
+++ b/experiments/executable-gaol/src/build-plan.mjs
@@ -54,6 +54,7 @@ const entityIds = new Set(entities.map((entity) => entity.id));
 if (!area.id || !area.label) throw new Error("area identity is required");
 if (!entityIds.has(area.primaryGate)) throw new Error(`primary gate ${area.primaryGate} is not a compiled entity`);
 if (!entityIds.has(area.pursuitLight)) throw new Error(`pursuit light ${area.pursuitLight} is not a compiled entity`);
+if (area.exit.gate !== area.primaryGate) throw new Error("declared exit must use the primary gate");
 if (!area.actors.some((actor) => actor.id === "player") || !area.actors.some((actor) => actor.id === "gaoler")) {
   throw new Error("area requires player and gaoler presentation anchors");
 }
@@ -162,7 +163,7 @@ const projectionDigests = Object.fromEntries(
 const plan = {
   schema: "nomos.experiment.rendering_plan@1",
   deterministic: true,
-  area: { id: area.id, label: area.label },
+  area: { id: area.id, label: area.label, start: area.start },
   projectionSchemas: [simulation.schema, navigation.schema, persistence.schema, diagnostics.schema],
   projectionDigests,
   camera: { identity: "gaol_oblique_01", projection: "fixed_oblique", width: 1200, height: 540, tileWidth: 96, tileHeight: 50 },
@@ -175,6 +176,7 @@ const plan = {
     primaryGate: area.primaryGate,
     pursuitLight: area.pursuitLight,
     forensicScenario: area.forensicScenario,
+    exit: area.exit,
   },
   uiAnchors: ["vitals", "abilities", "gate_state", "water_cost"],
   scenarios,

--- a/experiments/executable-gaol/src/play-state.mjs
+++ b/experiments/executable-gaol/src/play-state.mjs
@@ -15,11 +15,35 @@ export function createPlayState(plan) {
     gaoler: actorPosition(plan, "gaoler", { x: 5, y: 3, z: 0 }),
     movementCost: 0,
     moves: 0,
+    areasCleared: 0,
     pursuitClock: 0,
     escaped: false,
     caught: false,
+    completed: false,
     message: "Reach the north gate",
     tone: "neutral",
+  };
+}
+
+export function enterArea(plan, state, entry) {
+  return {
+    ...createPlayState(plan),
+    player: { ...entry },
+    movementCost: state.movementCost,
+    moves: state.moves,
+    areasCleared: state.areasCleared + 1,
+    message: `Entered ${plan.area.label}`,
+    tone: "success",
+  };
+}
+
+export function completeRun(state) {
+  return {
+    ...state,
+    areasCleared: state.areasCleared + 1,
+    completed: true,
+    message: "Escaped the gaol",
+    tone: "success",
   };
 }
 
@@ -72,6 +96,7 @@ export function attemptMove(plan, scenarioId, state, dx, dy) {
       },
       moved: true,
       cost,
+      exitGate: door.id,
     };
   }
 

--- a/experiments/executable-gaol/viewer.html
+++ b/experiments/executable-gaol/viewer.html
@@ -21,10 +21,10 @@
 </style>
 <header><h1>Nomos // executable gaol</h1><span id="look"></span><span id="areas"></span><span id="states"></span><button id="forensic" aria-pressed="false">Forensics</button></header>
 <main><div id="frame"></div></main>
-<footer><span>Move: WASD / arrows · Interact: E · Areas: [ ] · States: 1–5 · Reset: R</span><span id="message"></span><span id="meter"></span></footer>
+<footer><span>Move: WASD / arrows · Interact: E · Forensic areas: [ ] · States: 1–5 · Reset run: R</span><span id="message"></span><span id="meter"></span></footer>
 <script type="module">
   import { renderSvg } from "./render-core.mjs";
-  import { attemptInteraction, attemptMove, createPlayState, movementKeys } from "./play-state.mjs";
+  import { attemptInteraction, attemptMove, completeRun, createPlayState, enterArea, movementKeys } from "./play-state.mjs";
   const collection = await fetch("./areas.json").then((response) => response.json());
   const plans = new Map(await Promise.all(collection.areas.map(async (area) => [
     area.id,
@@ -37,7 +37,7 @@
   const look = document.querySelector("#look");
   const message = document.querySelector("#message");
   const meter = document.querySelector("#meter");
-  let areaId = collection.areas[0].id;
+  let areaId = collection.startArea;
   let plan = plans.get(areaId);
   let selected = plan.scenarios[0].id;
   let play = createPlayState(plan);
@@ -65,14 +65,15 @@
     message.dataset.tone = play.tone;
     const pursuitLight = plan.presentation.pursuitLight;
     const pursuit = play.caught ? "caught" : plan.scenarios.find((scenario) => scenario.id === selected)?.effectiveLight[pursuitLight] === false ? "hunting" : "dormant";
-    meter.textContent = `moves ${play.moves} · cost ${play.movementCost} · gaoler ${pursuit}`;
+    meter.textContent = `areas ${play.areasCleared}/${collection.areas.length} · moves ${play.moves} · cost ${play.movementCost} · gaoler ${pursuit}`;
   };
-  const reset = () => { selectScenario(plan.scenarios[0].id); play = createPlayState(plan); visualPlayer = { ...play.player }; visualGaoler = { ...play.gaoler }; animating = false; draw(); };
-  const selectArea = (nextAreaId) => {
+  const reset = () => selectArea(collection.startArea, false);
+  const selectArea = (nextAreaId, forensicJump = true) => {
     areaId = nextAreaId;
     plan = plans.get(areaId);
     selected = plan.scenarios[0].id;
     play = createPlayState(plan);
+    if (forensicJump) play = { ...play, message: `Forensic jump to ${plan.area.label}` };
     visualPlayer = { ...play.player };
     visualGaoler = { ...play.gaoler };
     animating = false;
@@ -80,7 +81,18 @@
     buildScenarioButtons();
     draw();
   };
-  const animateMove = (from, to, gaolerFrom, gaolerTo, cost) => {
+  const enterConnectedArea = (connection, previousState) => {
+    areaId = connection.toArea;
+    plan = plans.get(areaId);
+    selected = plan.scenarios[0].id;
+    play = enterArea(plan, previousState, connection.entry);
+    visualPlayer = { ...play.player };
+    visualGaoler = { ...play.gaoler };
+    for (const child of areas.children) child.ariaPressed = String(child.dataset.area === areaId);
+    buildScenarioButtons();
+    draw();
+  };
+  const animateMove = (from, to, gaolerFrom, gaolerTo, cost, onComplete) => {
     const started = performance.now();
     const duration = 105 * cost;
     animating = true;
@@ -91,7 +103,13 @@
       visualGaoler = { x: gaolerFrom.x + (gaolerTo.x - gaolerFrom.x) * eased, y: gaolerFrom.y + (gaolerTo.y - gaolerFrom.y) * eased, z: 0 };
       draw();
       if (t < 1) requestAnimationFrame(step);
-      else { visualPlayer = { ...to }; visualGaoler = { ...gaolerTo }; animating = false; draw(); }
+      else {
+        visualPlayer = { ...to };
+        visualGaoler = { ...gaolerTo };
+        animating = false;
+        draw();
+        onComplete?.();
+      }
     };
     requestAnimationFrame(step);
   };
@@ -99,9 +117,10 @@
   for (const area of collection.areas) {
     const button = document.createElement("button");
     button.textContent = area.label;
+    button.title = "Forensic shortcut — resets run progress";
     button.dataset.area = area.id;
     button.ariaPressed = String(area.id === areaId);
-    button.onclick = () => selectArea(area.id);
+    button.onclick = () => { if (!animating) selectArea(area.id); };
     areas.append(button);
   }
   buildScenarioButtons();
@@ -132,7 +151,16 @@
     const gaolerFrom = { ...play.gaoler };
     const result = attemptMove(plan, selected, play, ...delta);
     play = result.state;
-    if (result.moved) animateMove(from, play.player, gaolerFrom, play.gaoler, result.cost);
+    if (result.moved) {
+      const connection = result.exitGate
+        ? collection.route.find((edge) => edge.fromArea === areaId && edge.gate === result.exitGate)
+        : null;
+      animateMove(from, play.player, gaolerFrom, play.gaoler, result.cost, () => {
+        if (!result.exitGate) return;
+        if (connection?.toArea) enterConnectedArea(connection, play);
+        else { play = completeRun(play); draw(); }
+      });
+    }
     else draw();
   });
   draw();


### PR DESCRIPTION
Closes #107.

Turns the three-area look comparison into one continuous run: Cistern Walk → Ember Vault → North Gaol → final escape.

Each area descriptor declares its primary-gate exit. Collection generation validates exactly one start, known targets, in-bounds non-masonry entries, an acyclic route, complete area coverage, and terminal escape. The browser follows only that declared graph.

Transitions preserve cumulative moves, traversal cost, and cleared-area count while resetting area-local actors and runtime scenario state. Area buttons and bracket keys remain forensic shortcuts that reset progress; `R` returns to the true Cistern start.

Evidence:
- 18 passing tests
- one pure test completes all three areas through real hash-bound interactions and declared connections
- exact committed `AreaCollection@1` artifact
- two consecutive exact six-artifact captures
- unchanged shared-look digest and contact-sheet hashes
- projection-only public bundle inventory
- `cargo xtask boundary` passes

This remains quarantined feasibility work; actor state, architecture collision, pursuit, and cross-area run state are presentation-only.

Stacked on #106; merge #102, #104, and #106 first or retarget as those land.