### PR TITLE
Replace the playable gaol SVG with WebGL

### DIFF
--- a/experiments/executable-gaol/AUTHORING.md
+++ b/experiments/executable-gaol/AUTHORING.md
@@ -22,7 +22,7 @@ declared `visual/beveled_masonry` style and axis-aligned rectangular masses no
 higher than 4 cells. The primary gate must be reachable from the player anchor,
 water should create a legible route choice, and the brazier must light a useful
 landmark. Change composition and traversal, not the bounded look. Do not edit
-`render-core.mjs` for an area.
+either renderer implementation for an area.
 
 Run `experiments/executable-gaol/gaol verify` to compile every area, compare its
 committed rendering plan, check the shared visual grammar, and capture the

--- a/experiments/executable-gaol/README.md
+++ b/experiments/executable-gaol/README.md
@@ -1,9 +1,9 @@
 # Executable gaol experiment
 
-This is the deliberately quarantined answer to issues #101, #103, and #105:
-three independently authored areas, one bounded look, one renderer, and visible
-semantic state. It is not Gate K or Gate 1 evidence and it does not change the
-accepted workspace.
+This is the deliberately quarantined answer to issues #101, #103, #105, #107,
+and #110: three independently authored areas, one bounded look, one WebGL
+renderer, a connected run, and visible semantic state. It is not Gate K or
+Gate 1 evidence and it does not change the accepted workspace.
 
 **Play online:** <https://conarylabs.github.io/nomos/>
 
@@ -13,11 +13,12 @@ Run:
 experiments/executable-gaol/gaol capture
 ```
 
-That command compiles all three area sources, executes fifteen real Nomos
-command scripts, derives three `nomos.experiment.rendering_plan@1` artifacts only from
-subsystem projections and runtime state, checks their exact shared visual
-grammar, emits deterministic SVG frames, and rasterizes a cross-area PNG contact
-sheet with `rsvg-convert` when available.
+That diagnostic command compiles all three area sources, executes fifteen real
+Nomos command scripts, derives three `nomos.experiment.rendering_plan@1`
+artifacts only from subsystem projections and runtime state, checks their exact
+shared visual grammar, emits deterministic SVG frames, and rasterizes a
+cross-area PNG contact sheet with `rsvg-convert` when available. SVG is retained
+as exact semantic/capture evidence; it is no longer the playable presentation.
 
 To use the interactive state and forensic-overlay controls:
 
@@ -25,9 +26,11 @@ To use the interactive state and forensic-overlay controls:
 experiments/executable-gaol/gaol serve
 ```
 
-Open the printed local URL. The renderer receives only `areas.json` and the three
-selected rendering plans; it does not parse `.nomos`, World IR, or compiler
-receipts. North Gaol, Cistern Walk, and Ember Vault use the same camera, bounded
+Open the printed local URL. The WebGL renderer receives only `areas.json`, the
+three selected rendering plans, and presentation-only actor deltas; it does not
+parse `.nomos`, World IR, or compiler receipts. Its pinned Three.js backend
+supplies meshes, depth, shadows, fog, real point lights, and animated shader
+water. North Gaol, Cistern Walk, and Ember Vault use the same camera, bounded
 palette, materials, assemblies, actor silhouettes, beveled masonry vocabulary,
 effect language, and renderer. Their doors, water, light, actors, wall height,
 masonry masses, and composition come from separate area content.
@@ -65,9 +68,10 @@ The GitHub Pages workflow publishes that directory. No dev-machine port,
 repository checkout, `.nomos` source, World IR, or credential enters the public
 artifact.
 
-Known limits: this is stylized deterministic SVG rather than a GPU renderer;
-actor positions, masonry-mass collision, and the gaoler pursuit rule are
-presentation-only because Gate K has no dynamic actor or architecture state;
-audio, combat, networking, and persistence beyond the existing Gate K state are
+Known limits: this is a procedural WebGL visual proof rather than production
+art; its pixels are not deterministic across GPU/driver combinations. Actor
+positions, masonry-mass collision, and the gaoler pursuit rule are
+presentation-only because Gate K has no dynamic actor or architecture state.
+Audio, combat, networking, and persistence beyond the existing Gate K state are
 absent. Its job is to test whether independently authored rooms can remain
 visually coherent and playable through the same semantic bridge.

--- a/experiments/executable-gaol/gaol
+++ b/experiments/executable-gaol/gaol
@@ -58,6 +58,7 @@ stage_site() {
   mkdir -p "$site_dir/areas"
   install -m 644 "$experiment_dir/viewer.html" "$site_dir/index.html"
   install -m 644 "$experiment_dir/src/render-core.mjs" "$site_dir/render-core.mjs"
+  install -m 644 "$experiment_dir/src/webgl-renderer.mjs" "$site_dir/webgl-renderer.mjs"
   install -m 644 "$experiment_dir/src/play-state.mjs" "$site_dir/play-state.mjs"
   install -m 644 "$output_dir/areas.json" "$site_dir/areas.json"
   local area_dir

--- a/experiments/executable-gaol/src/webgl-renderer.mjs
+++ b/experiments/executable-gaol/src/webgl-renderer.mjs
@@ -1,0 +1,400 @@
+import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.min.js";
+
+const colors = {
+  void: 0x090e13,
+  fog: 0x111b24,
+  stone0: 0x202b34,
+  stone1: 0x2d3a43,
+  stone2: 0x3d4b52,
+  mortar: 0x111920,
+  iron: 0x111a20,
+  rust: 0x70412f,
+  water: 0x244857,
+  cyan: 0x83eeea,
+  amber: 0xffa544,
+  player: 0x347b7d,
+  gaoler: 0x8c5638,
+};
+
+const shadow = (object, cast = true, receive = true) => {
+  object.castShadow = cast;
+  object.receiveShadow = receive;
+  return object;
+};
+
+const material = (color, roughness = 0.78, metalness = 0.04) => new THREE.MeshStandardMaterial({
+  color, roughness, metalness,
+});
+
+const disposeTree = (root) => root.traverse((object) => {
+  object.geometry?.dispose();
+  if (Array.isArray(object.material)) object.material.forEach((entry) => entry.dispose());
+  else object.material?.dispose();
+});
+
+const stateOf = (scenario, entity, machine, fallback) =>
+  scenario.machineStates[`${entity}.${machine}`] ?? fallback;
+
+const cellPosition = (plan, cell, elevation = 0) => new THREE.Vector3(
+  cell.x + 0.5 - plan.architecture.bounds.width / 2,
+  elevation,
+  cell.y + 0.5 - plan.architecture.bounds.height / 2,
+);
+
+const addBox = (parent, size, position, boxMaterial, options = {}) => {
+  const mesh = shadow(new THREE.Mesh(new THREE.BoxGeometry(...size), boxMaterial));
+  mesh.position.set(...position);
+  if (options.rotationY) mesh.rotation.y = options.rotationY;
+  parent.add(mesh);
+  return mesh;
+};
+
+const addStoneSegment = (parent, x, z, height, axis, stoneMaterials) => {
+  const courses = Math.ceil(height / 0.46);
+  for (let course = 0; course < courses; course += 1) {
+    const courseHeight = Math.min(0.42, height - course * 0.46);
+    if (courseHeight <= 0) continue;
+    const offset = course % 2 ? 0.13 : -0.13;
+    const size = axis === "x" ? [0.94, courseHeight, 0.34] : [0.34, courseHeight, 0.94];
+    const position = axis === "x"
+      ? [x + offset, course * 0.46 + courseHeight / 2, z]
+      : [x, course * 0.46 + courseHeight / 2, z + offset];
+    addBox(parent, size, position, stoneMaterials[(course + Math.round(x + z)) & 1]);
+  }
+  const capSize = axis === "x" ? [1.02, 0.12, 0.44] : [0.44, 0.12, 1.02];
+  addBox(parent, capSize, [x, height + 0.06, z], stoneMaterials[2]);
+};
+
+const waterMaterial = () => new THREE.ShaderMaterial({
+  uniforms: {
+    uTime: { value: 0 },
+    uDeep: { value: new THREE.Color(0x173744) },
+    uLight: { value: new THREE.Color(0x4d8290) },
+  },
+  vertexShader: `
+    uniform float uTime;
+    varying float vWave;
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      vec3 p = position;
+      float a = sin((p.x + uTime * .55) * 4.2) * .025;
+      float b = cos((p.y - uTime * .38) * 5.7) * .018;
+      p.z += a + b;
+      vWave = a + b;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(p, 1.0);
+    }
+  `,
+  fragmentShader: `
+    uniform vec3 uDeep;
+    uniform vec3 uLight;
+    uniform float uTime;
+    varying float vWave;
+    varying vec2 vUv;
+    void main() {
+      float line = smoothstep(.46, .5, abs(sin((vUv.x * 9.0 + vUv.y * 4.0 + uTime * .2) * 3.14159)));
+      vec3 color = mix(uDeep, uLight, clamp(vWave * 9.0 + .42 + line * .08, 0.0, 1.0));
+      gl_FragColor = vec4(color, .86);
+    }
+  `,
+  transparent: true,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+});
+
+const buildFloor = (root, plan, resources) => {
+  const { width, height } = plan.architecture.bounds;
+  for (let y = 0; y < height; y += 1) for (let x = 0; x < width; x += 1) {
+    const floor = addBox(root, [0.96, 0.12, 0.96], [x + 0.5 - width / 2, -0.08, y + 0.5 - height / 2], resources.stone[(x + y) & 1], { cast: false });
+    floor.castShadow = false;
+  }
+};
+
+const buildWalls = (root, plan, resources) => {
+  const { width, height } = plan.architecture.bounds;
+  const wallHeight = plan.architecture.wallHeight * 0.72;
+  const northDoors = new Set(plan.entities
+    .filter((entity) => entity.kind === "door" && entity.anchor.cell.y === 0)
+    .map((entity) => entity.anchor.cell.x));
+  for (let x = 0; x < width; x += 1) {
+    if (!northDoors.has(x)) addStoneSegment(root, x + 0.5 - width / 2, -height / 2 - 0.18, wallHeight, "x", resources.stone);
+    addStoneSegment(root, x + 0.5 - width / 2, height / 2 + 0.18, 0.32, "x", resources.stone);
+  }
+  for (let y = 0; y < height; y += 1) {
+    addStoneSegment(root, -width / 2 - 0.18, y + 0.5 - height / 2, wallHeight, "z", resources.stone);
+    addStoneSegment(root, width / 2 + 0.18, y + 0.5 - height / 2, 0.32, "z", resources.stone);
+  }
+};
+
+const buildMasses = (root, plan, resources) => {
+  for (const mass of plan.architecture.masses) {
+    const width = mass.max.x - mass.min.x;
+    const depth = mass.max.y - mass.min.y;
+    const height = mass.height * 0.72;
+    const x = (mass.min.x + mass.max.x) / 2 - plan.architecture.bounds.width / 2;
+    const z = (mass.min.y + mass.max.y) / 2 - plan.architecture.bounds.height / 2;
+    addBox(root, [width - 0.08, height, depth - 0.08], [x, height / 2, z], resources.stone[1]);
+    addBox(root, [width + 0.03, 0.12, depth + 0.03], [x, height + 0.06, z], resources.stone[2]);
+  }
+};
+
+const buildWater = (root, plan, resources, animatedMaterials) => {
+  for (const entity of plan.entities.filter((entry) => entry.kind === "water")) {
+    const width = entity.anchor.max.x - entity.anchor.min.x + 1;
+    const depth = entity.anchor.max.y - entity.anchor.min.y + 1;
+    const x = (entity.anchor.min.x + entity.anchor.max.x + 1) / 2 - plan.architecture.bounds.width / 2;
+    const z = (entity.anchor.min.y + entity.anchor.max.y + 1) / 2 - plan.architecture.bounds.height / 2;
+    addBox(root, [width - 0.09, 0.14, depth - 0.09], [x, 0.015, z], resources.waterBed, { cast: false });
+    const shader = waterMaterial();
+    animatedMaterials.push(shader);
+    const surface = new THREE.Mesh(new THREE.PlaneGeometry(width - 0.1, depth - 0.1, width * 6, depth * 6), shader);
+    surface.rotation.x = -Math.PI / 2;
+    surface.position.set(x, 0.105, z);
+    surface.receiveShadow = true;
+    root.add(surface);
+  }
+};
+
+const buildDoor = (root, plan, scenario, entity, resources, glowLights) => {
+  const group = new THREE.Group();
+  group.position.copy(cellPosition(plan, entity.anchor.cell));
+  group.position.z -= 0.38;
+  const access = stateOf(scenario, entity.id, "access", "locked");
+  const integrity = stateOf(scenario, entity.id, "integrity", "intact");
+  const ward = stateOf(scenario, entity.id, "ward", "sealed");
+
+  addBox(group, [0.25, 2.45, 0.48], [-0.58, 1.22, 0], resources.stone[2]);
+  addBox(group, [0.25, 2.45, 0.48], [0.58, 1.22, 0], resources.stone[2]);
+  addBox(group, [1.42, 0.3, 0.5], [0, 2.38, 0], resources.stone[2]);
+  addBox(group, [1.68, 0.13, 0.58], [0, 2.6, 0], resources.stone[1]);
+
+  if (integrity === "destroyed") {
+    for (const [x, y, angle] of [[-0.34, .65, -.16], [.02, .42, .21], [.35, .78, -.25]]) {
+      const bar = addBox(group, [0.075, 1.18, 0.08], [x, y, 0], resources.iron);
+      bar.rotation.z = angle;
+    }
+  } else {
+    const slide = access === "open" ? 0.62 : 0;
+    for (let x = -0.42; x <= 0.43; x += 0.21) addBox(group, [0.065, 1.92, 0.07], [x + slide, 1.12, 0], resources.iron);
+    addBox(group, [1.02, 0.09, 0.09], [slide, 1.12, 0], resources.rust);
+  }
+
+  if (ward === "sealed") {
+    const wardMaterial = new THREE.MeshBasicMaterial({ color: colors.cyan, transparent: true, opacity: 0.72, blending: THREE.AdditiveBlending });
+    const ring = new THREE.Mesh(new THREE.TorusGeometry(0.42, 0.025, 10, 48), wardMaterial);
+    ring.position.set(0, 1.22, 0.1);
+    group.add(ring);
+    const diamond = new THREE.LineLoop(
+      new THREE.BufferGeometry().setFromPoints([
+        new THREE.Vector3(0, 1.78, 0.11), new THREE.Vector3(.42, 1.22, .11),
+        new THREE.Vector3(0, .66, .11), new THREE.Vector3(-.42, 1.22, .11),
+      ]),
+      new THREE.LineBasicMaterial({ color: colors.cyan, transparent: true, opacity: .8 }),
+    );
+    group.add(diamond);
+    const wardLight = new THREE.PointLight(colors.cyan, 3.4, 3.2, 2);
+    wardLight.position.set(0, 1.22, 0.45);
+    group.add(wardLight);
+    glowLights.push({ light: wardLight, phase: entity.anchor.cell.x * 0.7, base: 3.4, amplitude: 0.25 });
+  }
+  root.add(group);
+};
+
+const buildBrazier = (root, plan, scenario, entity, resources, glowLights) => {
+  const group = new THREE.Group();
+  group.position.copy(cellPosition(plan, entity.anchor.cell));
+  const lit = scenario.effectiveLight[entity.id] === true;
+  const pedestal = shadow(new THREE.Mesh(new THREE.CylinderGeometry(.16, .23, .48, 8), resources.iron));
+  pedestal.position.y = .24;
+  group.add(pedestal);
+  const bowl = shadow(new THREE.Mesh(new THREE.CylinderGeometry(.34, .18, .18, 8), resources.rust));
+  bowl.position.y = .55;
+  group.add(bowl);
+  if (lit) {
+    const flameMaterial = new THREE.MeshBasicMaterial({ color: colors.amber, transparent: true, opacity: .92, blending: THREE.AdditiveBlending });
+    const flame = new THREE.Mesh(new THREE.ConeGeometry(.17, .55, 7), flameMaterial);
+    flame.position.y = .92;
+    flame.scale.z = .72;
+    group.add(flame);
+    const light = new THREE.PointLight(colors.amber, 8.5, 5.6, 2);
+    light.position.y = 1.12;
+    light.castShadow = true;
+    light.shadow.mapSize.set(512, 512);
+    group.add(light);
+    glowLights.push({ light, flame, phase: entity.anchor.cell.x + entity.anchor.cell.y, base: 8.5, amplitude: 1.1 });
+  }
+  root.add(group);
+};
+
+const buildEffectAnchors = (root, plan, scenario) => {
+  for (const effect of plan.effects.filter((entry) => entry.assembly === "visual/cyan_crescent")) {
+    const gate = plan.entities.find((entity) => entity.id === effect.anchorEntity);
+    if (!gate || stateOf(scenario, gate.id, "ward", "sealed") !== "sealed") continue;
+    const p = cellPosition(plan, { x: effect.presentationAnchor.x, y: effect.presentationAnchor.y });
+    const material = new THREE.MeshBasicMaterial({ color: colors.cyan, transparent: true, opacity: .34, blending: THREE.AdditiveBlending });
+    const crescent = new THREE.Mesh(new THREE.TorusGeometry(.38, .055, 8, 32, Math.PI * 1.25), material);
+    crescent.rotation.x = -Math.PI / 2;
+    crescent.rotation.z = -.45;
+    crescent.position.set(p.x, .09, p.z);
+    root.add(crescent);
+  }
+};
+
+const actorMesh = (id, resources) => {
+  const group = new THREE.Group();
+  const isPlayer = id === "player";
+  const bodyMaterial = isPlayer ? resources.player : resources.gaoler;
+  const cloak = shadow(new THREE.Mesh(new THREE.ConeGeometry(isPlayer ? .25 : .32, isPlayer ? .78 : .9, 7), bodyMaterial));
+  cloak.position.y = isPlayer ? .43 : .48;
+  group.add(cloak);
+  const head = shadow(new THREE.Mesh(new THREE.IcosahedronGeometry(isPlayer ? .15 : .17, 1), resources.skin));
+  head.position.y = isPlayer ? .92 : 1.04;
+  group.add(head);
+  if (isPlayer) {
+    const blade = addBox(group, [.055, .65, .055], [.28, .58, 0], resources.cyanMetal);
+    blade.rotation.z = -.55;
+  } else {
+    const shoulder = addBox(group, [.72, .11, .2], [0, .78, 0], resources.rust);
+    shoulder.rotation.z = .04;
+  }
+  return group;
+};
+
+const buildActors = (root, plan, actorPositions, resources, actorMeshes) => {
+  for (const actor of plan.actors) {
+    const mesh = actorMesh(actor.id, resources);
+    const anchor = actorPositions?.[actor.id] ?? actor.anchor.cell;
+    mesh.position.copy(cellPosition(plan, anchor, anchor.z ?? 0));
+    actorMeshes.set(actor.id, mesh);
+    root.add(mesh);
+  }
+};
+
+const makeResources = () => ({
+  stone: [material(colors.stone0), material(colors.stone1), material(colors.stone2, .7)],
+  iron: material(colors.iron, .42, .7),
+  rust: material(colors.rust, .68, .42),
+  waterBed: material(colors.water, .3, .18),
+  player: material(colors.player, .62),
+  gaoler: material(colors.gaoler, .74),
+  skin: material(0x96735b, .85),
+  cyanMetal: material(colors.cyan, .25, .6),
+});
+
+export function createGaolRenderer(container) {
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: "high-performance" });
+  renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+  renderer.setClearColor(colors.void);
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.28;
+  container.replaceChildren(renderer.domElement);
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(colors.void);
+  scene.fog = new THREE.FogExp2(colors.fog, 0.045);
+  const camera = new THREE.OrthographicCamera(-7, 7, 3.15, -3.15, 0.1, 80);
+  const hemi = new THREE.HemisphereLight(0x8aa8b8, 0x131c24, 2.05);
+  scene.add(hemi);
+  const moon = new THREE.DirectionalLight(0xabc8d7, 4.2);
+  moon.position.set(-7, 11, 7);
+  moon.castShadow = true;
+  moon.shadow.mapSize.set(2048, 2048);
+  moon.shadow.camera.left = -8;
+  moon.shadow.camera.right = 8;
+  moon.shadow.camera.top = 8;
+  moon.shadow.camera.bottom = -8;
+  scene.add(moon);
+
+  let worldRoot = new THREE.Group();
+  scene.add(worldRoot);
+  let actorMeshes = new Map();
+  let animatedMaterials = [];
+  let glowLights = [];
+  let planIdentity;
+  let scenarioIdentity;
+  let forensicState = false;
+  let grid;
+
+  const fit = () => {
+    const width = Math.max(container.clientWidth, 1);
+    const height = Math.max(container.clientHeight, 1);
+    renderer.setSize(width, height, false);
+    const aspect = width / height;
+    const halfHeight = 3.7;
+    camera.left = -halfHeight * aspect;
+    camera.right = halfHeight * aspect;
+    camera.top = halfHeight;
+    camera.bottom = -halfHeight;
+    camera.updateProjectionMatrix();
+  };
+  new ResizeObserver(fit).observe(container);
+  fit();
+
+  const rebuild = (plan, scenarioId, actorPositions) => {
+    scene.remove(worldRoot);
+    disposeTree(worldRoot);
+    worldRoot = new THREE.Group();
+    scene.add(worldRoot);
+    actorMeshes = new Map();
+    animatedMaterials = [];
+    glowLights = [];
+    const resources = makeResources();
+    const scenario = plan.scenarios.find((candidate) => candidate.id === scenarioId) ?? plan.scenarios[0];
+    buildFloor(worldRoot, plan, resources);
+    buildWalls(worldRoot, plan, resources);
+    buildMasses(worldRoot, plan, resources);
+    buildWater(worldRoot, plan, resources, animatedMaterials);
+    for (const entity of plan.entities) {
+      if (entity.kind === "door") buildDoor(worldRoot, plan, scenario, entity, resources, glowLights);
+      if (entity.kind === "light") buildBrazier(worldRoot, plan, scenario, entity, resources, glowLights);
+    }
+    buildEffectAnchors(worldRoot, plan, scenario);
+    buildActors(worldRoot, plan, actorPositions, resources, actorMeshes);
+    const { width, height } = plan.architecture.bounds;
+    const target = new THREE.Vector3(0, .5, 0);
+    camera.position.set(width * .86, Math.max(width, height) * .92, height * 1.08);
+    camera.lookAt(target);
+    planIdentity = plan.area.id;
+    scenarioIdentity = scenario.id;
+  };
+
+  const updateActors = (plan, actorPositions) => {
+    for (const actor of plan.actors) {
+      const anchor = actorPositions?.[actor.id] ?? actor.anchor.cell;
+      actorMeshes.get(actor.id)?.position.copy(cellPosition(plan, anchor, anchor.z ?? 0));
+    }
+  };
+
+  const present = (plan, scenarioId, forensic = false, presentation = {}) => {
+    if (planIdentity !== plan.area.id || scenarioIdentity !== scenarioId) rebuild(plan, scenarioId, presentation.actorPositions);
+    else updateActors(plan, presentation.actorPositions);
+    if (forensicState !== forensic) {
+      forensicState = forensic;
+      if (grid) worldRoot.remove(grid);
+      grid = forensic ? new THREE.GridHelper(Math.max(plan.architecture.bounds.width, plan.architecture.bounds.height), Math.max(plan.architecture.bounds.width, plan.architecture.bounds.height), colors.cyan, 0x30434a) : null;
+      if (grid) {
+        grid.position.y = .13;
+        worldRoot.add(grid);
+      }
+    }
+  };
+
+  const clock = new THREE.Clock();
+  const animate = () => {
+    const elapsed = clock.getElapsedTime();
+    for (const shader of animatedMaterials) shader.uniforms.uTime.value = elapsed;
+    for (const glow of glowLights) {
+      const flicker = Math.sin(elapsed * 8.7 + glow.phase) * .5 + Math.sin(elapsed * 13.1 + glow.phase * .7) * .5;
+      glow.light.intensity = glow.base + flicker * glow.amplitude;
+      if (glow.flame) glow.flame.scale.y = 1 + flicker * .06;
+    }
+    renderer.render(scene, camera);
+    requestAnimationFrame(animate);
+  };
+  animate();
+
+  return { present, renderer, scene, camera };
+}

--- a/experiments/executable-gaol/src/webgl-viewer.test.mjs
+++ b/experiments/executable-gaol/src/webgl-viewer.test.mjs
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const viewer = readFileSync(new URL("../viewer.html", import.meta.url), "utf8");
+const renderer = readFileSync(new URL("./webgl-renderer.mjs", import.meta.url), "utf8");
+
+test("the playable viewer presents WebGL rather than SVG", () => {
+  assert.match(viewer, /createGaolRenderer/);
+  assert.match(viewer, /gpu\.present/);
+  assert.doesNotMatch(viewer, /renderSvg|innerHTML\s*=\s*render/);
+});
+
+test("the WebGL backend is exact-version pinned and projection-only", () => {
+  assert.match(renderer, /three@0\.185\.1\/build\/three\.module\.min\.js/);
+  for (const forbidden of [".nomos", "world-ir", "world_ir", "simulation.json", "navigation.json"]) {
+    assert.equal(renderer.includes(forbidden), false, `renderer contains forbidden input ${forbidden}`);
+  }
+});
+
+test("no declared area receives renderer special treatment", () => {
+  for (const area of ["cistern-walk", "ember-vault", "north-gaol"]) {
+    assert.equal(renderer.includes(area), false, `renderer special-cases ${area}`);
+  }
+});
+
+test("the GPU grammar includes the required graphical systems", () => {
+  for (const primitive of [
+    "WebGLRenderer",
+    "MeshStandardMaterial",
+    "DirectionalLight",
+    "PointLight",
+    "ShaderMaterial",
+    "FogExp2",
+    "shadowMap.enabled",
+  ]) assert.equal(renderer.includes(primitive), true, `${primitive} is absent`);
+});

--- a/experiments/executable-gaol/viewer.html
+++ b/experiments/executable-gaol/viewer.html
@@ -14,16 +14,25 @@
   button { color:#d7ddd9; background:#202d35; border:1px solid #4c6068; border-radius:5px; padding:7px 11px; cursor:pointer }
   button[aria-pressed="true"] { color:#10161d; background:#8ee6e3; border-color:#bfffff }
   main { display:grid; place-items:center; padding:18px }
-  #frame { width:min(100%,1200px); box-shadow:0 28px 80px #0009; border:1px solid #3c4a51; line-height:0 }
-  #frame svg { width:100%; height:auto }
-  footer { display:flex; justify-content:center; gap:24px; padding:11px 18px 15px; color:#8e9b9c; background:#0a1016dd; border-top:1px solid #26343b }
+  #frame { width:min(100%,1200px); aspect-ratio:20/9; box-shadow:0 28px 80px #0009; border:1px solid #3c4a51; line-height:0; background:#090e13 }
+  #frame canvas { width:100%; height:100%; display:block }
+  footer { display:flex; flex-wrap:wrap; justify-content:center; gap:8px 24px; padding:11px 18px 15px; color:#8e9b9c; background:#0a1016dd; border-top:1px solid #26343b }
   #message[data-tone="blocked"], #message[data-tone="danger"] { color:#d47158 } #message[data-tone="success"] { color:#8ee6e3 } #message[data-tone="water"] { color:#70909a }
+  @media (max-width:700px) {
+    header { padding:10px; gap:8px }
+    h1 { flex-basis:100% }
+    #areas { order:2; width:100%; padding:0 0 7px; border:0; border-bottom:1px solid #33424a }
+    #states { order:3; flex-wrap:wrap }
+    #forensic { order:4 }
+    main { padding:10px }
+    footer { justify-content:flex-start; font-size:12px }
+  }
 </style>
 <header><h1>Nomos // executable gaol</h1><span id="look"></span><span id="areas"></span><span id="states"></span><button id="forensic" aria-pressed="false">Forensics</button></header>
 <main><div id="frame"></div></main>
 <footer><span>Move: WASD / arrows · Interact: E · Forensic areas: [ ] · States: 1–5 · Reset run: R</span><span id="message"></span><span id="meter"></span></footer>
 <script type="module">
-  import { renderSvg } from "./render-core.mjs";
+  import { createGaolRenderer } from "./webgl-renderer.mjs";
   import { attemptInteraction, attemptMove, completeRun, createPlayState, enterArea, movementKeys } from "./play-state.mjs";
   const collection = await fetch("./areas.json").then((response) => response.json());
   const plans = new Map(await Promise.all(collection.areas.map(async (area) => [
@@ -37,6 +46,7 @@
   const look = document.querySelector("#look");
   const message = document.querySelector("#message");
   const meter = document.querySelector("#meter");
+  const gpu = createGaolRenderer(frame);
   let areaId = collection.startArea;
   let plan = plans.get(areaId);
   let selected = plan.scenarios[0].id;
@@ -60,7 +70,7 @@
     }
   };
   const draw = () => {
-    frame.innerHTML = renderSvg(plan, selected, forensic.ariaPressed === "true", { actorPositions: { player: visualPlayer, gaoler: visualGaoler } });
+    gpu.present(plan, selected, forensic.ariaPressed === "true", { actorPositions: { player: visualPlayer, gaoler: visualGaoler } });
     message.textContent = play.message;
     message.dataset.tone = play.tone;
     const pursuitLight = plan.presentation.pursuitLight;


### PR DESCRIPTION
## Outcome

Replaces the public playable SVG presentation with a plan-driven WebGL diorama while retaining SVG only for deterministic diagnostic/contact-sheet capture. The same renderer builds Cistern Walk, Ember Vault, and North Gaol from their existing rendering plans; it contains no area-ID branches and cannot read `.nomos` or World IR.

The pinned Three.js 0.185.1 backend supplies real meshes, depth, PBR-ish bounded materials, shadows, fog, cyan ward emission, brazier point lights, and animated shader water. Existing movement, verified interactions, scenario controls, pursuit, area traversal, and forensic grid remain intact.

Closes #110.

## Evidence

- `experiments/executable-gaol/gaol verify` — pass, 22 tests
- `experiments/executable-gaol/gaol site` — pass
- headless Chromium desktop capture — all three areas visually inspected
- headless Chromium narrow capture — inspected
- browser smoke: `WEBGL_BROWSER_SMOKE PASS areas=3 movement=2 console_errors=0`
- `cargo xtask boundary` — clean
- `git diff --check` — clean
- staged site file inventory contains no `.nomos`, World IR, or compiler-receipt files

## Limits

- GPU pixels are intentionally not byte-deterministic; exact rendering plans and SVG diagnostics remain deterministic.
- Three.js is exact-version pinned from jsDelivr and therefore the playable page requires network access to that module.
- Dynamic actors, masonry collision, and pursuit are still presentation-only, matching the prior experiment boundary.
- This is quarantined experimental work and cannot satisfy Gate K or Gate 1.

## Stack

Draft, based on `experiment/issue-107-executable-gaol` / PR #108. Owner retains merge and disposition.