### PR TITLE
Add content-driven gaol objectives and completion

### DIFF
--- a/experiments/executable-gaol/AUTHORING.md
+++ b/experiments/executable-gaol/AUTHORING.md
@@ -9,10 +9,11 @@ Required files:
 - `world.nomos`: exactly two `primitive/iron_barred_door` entities on the north
   face, one `primitive/shallow_water_region`, and one
   `primitive/extinguishable_light`.
-- `area.json`: stable area identity, primary exit gate, pursuit light, player
-  and gaoler cell anchors, one `visual/cyan_crescent` presentation anchor, and
-  bounded architecture data. Connected runs additionally declare whether this
-  is the start area and where its primary gate leads.
+- `area.json`: stable area identity, one `exit_via` objective targeting the
+  primary gate, pursuit light, player and gaoler cell anchors, one
+  `visual/cyan_crescent` presentation anchor, and bounded architecture data.
+  Connected runs additionally declare whether this is the start area and where
+  its primary gate leads.
 - `scenarios/*.commands`: five ordered scenarios. Each of scenarios 2–4 adds
   exactly one command to the preceding script so browser interactions can be
   derived from real input and resulting state hashes.

--- a/experiments/executable-gaol/CAPTURE.md
+++ b/experiments/executable-gaol/CAPTURE.md
@@ -8,13 +8,15 @@ experiments/executable-gaol/gaol verify
 ```
 
 - AreaCollection SHA-256: `09fed4ea297406719fb17c3bce8129bc0258eb763c2e93811a78a5efe53a2d34`
-- North Gaol RenderingPlan SHA-256: `a140e32adc0d655030c8d88adf276ba1d8e2078f3c5953ea36edd7594841baf5`
-- Cistern Walk RenderingPlan SHA-256: `49efd6ce16f4cf0fa926a5442e5a46f4a7d08cb51ea1c75d358c51596c506599`
-- Ember Vault RenderingPlan SHA-256: `948a452f4a343067badb83f48943005178942f4e0cddb239bc20290ce2912970`
+- North Gaol RenderingPlan SHA-256: `82d39f0a1b41ac60fe7e7a1ed142f8409a17c58a05d8063dc0302c69fe1bbd16`
+- Cistern Walk RenderingPlan SHA-256: `2f7b5a0e7efd53f933d7175eee529c73c7e3f43c756c43afd746be5daba1ba82`
+- Ember Vault RenderingPlan SHA-256: `e87288b9d183b4216974c51e6a0f5d965be7bf39a7e9229eb9b1c040d0a6f192`
 - cross-area contact-sheet.svg SHA-256: `04b706f067db4dd2464f557246b868cb53161925aacae6be270b81f60b2341e5`
 - cross-area contact-sheet.png SHA-256: `26273aba009f5228e63d2c0b8100857b0aae8bc15d493894fdb87de9861a5175`
 - verification: `EXECUTABLE_GAOL_VERIFY PASS`
 
-Two consecutive clean captures produced all six exact hashes. The committed
-PNG and example plans are review conveniences; the command regenerates them
-from the content, subsystem projections, and real runtime states.
+Two consecutive clean captures produced all six exact hashes. The plan hashes
+changed when the bounded `exit_via` objective became part of each plan; the
+collection and contact-sheet bytes remained exact. The committed PNG and
+example plans are review conveniences; the command regenerates them from the
+content, subsystem projections, and real runtime states.

--- a/experiments/executable-gaol/README.md
+++ b/experiments/executable-gaol/README.md
@@ -51,6 +51,12 @@ door whose selected Nomos runtime state resolves to `traversable`. Keys 1–5
 switch the real runtime scenarios for inspection, and the viewer interpolates
 movement without placing fractional positions into Nomos authoritative state.
 
+Each area declares one bounded `exit_via` objective referencing its compiled
+primary gate. The viewer derives the visible objective, nearby `E` prompt, and
+open-passage guidance from that plan data and the verified interaction edges;
+it contains no room-specific prompt text. Area arrivals identify route progress,
+and the final escape reports cumulative areas, moves, and traversal cost.
+
 The default run begins in Cistern Walk. Crossing its declared, traversable
 sluice enters Ember Vault; crossing Ember's vault gate enters North Gaol; the
 North Gate is the final escape. Area transitions preserve cumulative moves,

--- a/experiments/executable-gaol/areas/cistern-walk/area.json
+++ b/experiments/executable-gaol/areas/cistern-walk/area.json
@@ -3,6 +3,7 @@
   "label": "Cistern Walk",
   "start": true,
   "primaryGate": "sluice_gate",
+  "objective": { "kind": "exit_via", "target": "sluice_gate" },
   "pursuitLight": "watch_brazier",
   "forensicScenario": "03-breached-unsealed",
   "exit": {

--- a/experiments/executable-gaol/areas/cistern-walk/rendering-plan.example.json
+++ b/experiments/executable-gaol/areas/cistern-walk/rendering-plan.example.json
@@ -243,6 +243,10 @@
   ],
   "presentation": {
     "primaryGate": "sluice_gate",
+    "objective": {
+      "kind": "exit_via",
+      "target": "sluice_gate"
+    },
     "pursuitLight": "watch_brazier",
     "forensicScenario": "03-breached-unsealed",
     "exit": {

--- a/experiments/executable-gaol/areas/ember-vault/area.json
+++ b/experiments/executable-gaol/areas/ember-vault/area.json
@@ -3,6 +3,7 @@
   "label": "Ember Vault",
   "start": false,
   "primaryGate": "vault_gate",
+  "objective": { "kind": "exit_via", "target": "vault_gate" },
   "pursuitLight": "ember_brazier",
   "forensicScenario": "03-breached-unsealed",
   "exit": {

--- a/experiments/executable-gaol/areas/ember-vault/rendering-plan.example.json
+++ b/experiments/executable-gaol/areas/ember-vault/rendering-plan.example.json
@@ -255,6 +255,10 @@
   ],
   "presentation": {
     "primaryGate": "vault_gate",
+    "objective": {
+      "kind": "exit_via",
+      "target": "vault_gate"
+    },
     "pursuitLight": "ember_brazier",
     "forensicScenario": "03-breached-unsealed",
     "exit": {

--- a/experiments/executable-gaol/areas/north-gaol/area.json
+++ b/experiments/executable-gaol/areas/north-gaol/area.json
@@ -3,6 +3,7 @@
   "label": "North Gaol",
   "start": false,
   "primaryGate": "north_gate",
+  "objective": { "kind": "exit_via", "target": "north_gate" },
   "pursuitLight": "brazier_02",
   "forensicScenario": "03-breached-unsealed",
   "exit": {

--- a/experiments/executable-gaol/areas/north-gaol/rendering-plan.example.json
+++ b/experiments/executable-gaol/areas/north-gaol/rendering-plan.example.json
@@ -230,6 +230,10 @@
   ],
   "presentation": {
     "primaryGate": "north_gate",
+    "objective": {
+      "kind": "exit_via",
+      "target": "north_gate"
+    },
     "pursuitLight": "brazier_02",
     "forensicScenario": "03-breached-unsealed",
     "exit": {

--- a/experiments/executable-gaol/src/area-collection.test.mjs
+++ b/experiments/executable-gaol/src/area-collection.test.mjs
@@ -25,6 +25,15 @@ test("independent areas retain one exact visual grammar", () => {
   assert.deepEqual(grammar(ember), grammar(north));
 });
 
+test("every area exposes one exact compiled-door objective", () => {
+  for (const plan of [cistern, ember, north]) {
+    assert.deepEqual(Object.keys(plan.presentation.objective).sort(), ["kind", "target"]);
+    assert.equal(plan.presentation.objective.kind, "exit_via");
+    assert.equal(plan.presentation.objective.target, plan.presentation.primaryGate);
+    assert.equal(plan.entities.find((entity) => entity.id === plan.presentation.objective.target)?.kind, "door");
+  }
+});
+
 test("the second area is a distinct composition", () => {
   const anchors = (plan) => plan.entities.map((entity) => entity.anchor);
   assert.notDeepEqual(anchors(cistern), anchors(north));

--- a/experiments/executable-gaol/src/build-plan.mjs
+++ b/experiments/executable-gaol/src/build-plan.mjs
@@ -51,8 +51,16 @@ const entities = simulation.entities.map((entity) => {
 });
 
 const entityIds = new Set(entities.map((entity) => entity.id));
+const entityById = new Map(entities.map((entity) => [entity.id, entity]));
 if (!area.id || !area.label) throw new Error("area identity is required");
 if (!entityIds.has(area.primaryGate)) throw new Error(`primary gate ${area.primaryGate} is not a compiled entity`);
+if (JSON.stringify(Object.keys(area.objective ?? {}).sort()) !== JSON.stringify(["kind", "target"])) {
+  throw new Error("area objective must contain exactly kind and target");
+}
+if (area.objective?.kind !== "exit_via") throw new Error("area objective must use the bounded exit_via kind");
+if (!entityIds.has(area.objective.target)) throw new Error(`objective target ${area.objective.target} is not a compiled entity`);
+if (entityById.get(area.objective.target).kind !== "door") throw new Error("exit_via objective must target a compiled door");
+if (area.objective.target !== area.primaryGate) throw new Error("exit_via objective must target the primary gate");
 if (!entityIds.has(area.pursuitLight)) throw new Error(`pursuit light ${area.pursuitLight} is not a compiled entity`);
 if (area.exit.gate !== area.primaryGate) throw new Error("declared exit must use the primary gate");
 if (!area.actors.some((actor) => actor.id === "player") || !area.actors.some((actor) => actor.id === "gaoler")) {
@@ -174,6 +182,7 @@ const plan = {
   effects: area.effects,
   presentation: {
     primaryGate: area.primaryGate,
+    objective: area.objective,
     pursuitLight: area.pursuitLight,
     forensicScenario: area.forensicScenario,
     exit: area.exit,

--- a/experiments/executable-gaol/src/play-state.mjs
+++ b/experiments/executable-gaol/src/play-state.mjs
@@ -9,6 +9,10 @@ const actorPosition = (plan, id, fallback) => ({
   ...(plan?.actors.find((actor) => actor.id === id)?.anchor?.cell ?? fallback),
 });
 
+export const displayName = (id) => id.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+const objectiveTarget = (plan) => plan.presentation.objective.target;
+
 export function createPlayState(plan) {
   return {
     player: actorPosition(plan, "player", { x: 2, y: 4, z: 0 }),
@@ -20,7 +24,7 @@ export function createPlayState(plan) {
     escaped: false,
     caught: false,
     completed: false,
-    message: "Reach the north gate",
+    message: `Reach ${displayName(objectiveTarget(plan))}`,
     tone: "neutral",
   };
 }
@@ -45,6 +49,10 @@ export function completeRun(state) {
     message: "Escaped the gaol",
     tone: "success",
   };
+}
+
+export function completionSummary(state, totalAreas) {
+  return `${totalAreas} areas · ${state.moves} moves · ${state.movementCost} traversal cost`;
 }
 
 const contains = (region, point) => point.x >= region.min.x && point.x <= region.max.x
@@ -161,6 +169,39 @@ export function interactionAt(plan, scenarioId, state) {
     .filter(({ entity }) => entity?.anchor?.cell)
     .find(({ entity }) => Math.abs(entity.anchor.cell.x - state.player.x)
       + Math.abs(entity.anchor.cell.y - state.player.y) <= 1)?.interaction ?? null;
+}
+
+export function guidanceFor(plan, scenarioId, state) {
+  const target = objectiveTarget(plan);
+  const targetLabel = displayName(target);
+  if (state.completed) {
+    return { objective: "Escape complete", prompt: "R · Begin a new run", tone: "success" };
+  }
+  if (state.caught) {
+    return { objective: `Exit via ${targetLabel}`, prompt: "R · Restart the run", tone: "danger" };
+  }
+  if (state.escaped) {
+    return { objective: `Exited via ${targetLabel}`, prompt: "Entering the next area", tone: "success" };
+  }
+
+  const interaction = interactionAt(plan, scenarioId, state);
+  if (interaction) {
+    return {
+      objective: `Exit via ${targetLabel}`,
+      prompt: `E · ${displayName(interaction.action)} ${displayName(interaction.targetEntity)}`,
+      tone: "action",
+    };
+  }
+
+  const scenario = plan.scenarios.find((candidate) => candidate.id === scenarioId);
+  const movement = scenario?.movement[target];
+  return {
+    objective: `Exit via ${targetLabel}`,
+    prompt: movement?.disposition === "traversable"
+      ? `The way through ${targetLabel} is open`
+      : `Reach ${targetLabel}`,
+    tone: movement?.disposition === "traversable" ? "success" : "neutral",
+  };
 }
 
 export function attemptInteraction(plan, scenarioId, state) {

--- a/experiments/executable-gaol/src/play-state.test.mjs
+++ b/experiments/executable-gaol/src/play-state.test.mjs
@@ -1,7 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { attemptInteraction, createPlayState, attemptMove, interactionAt, terrainAt } from "./play-state.mjs";
+import {
+  attemptInteraction,
+  attemptMove,
+  completeRun,
+  completionSummary,
+  createPlayState,
+  guidanceFor,
+  interactionAt,
+  terrainAt,
+} from "./play-state.mjs";
 
 const plan = JSON.parse(readFileSync(new URL("../areas/north-gaol/rendering-plan.example.json", import.meta.url)));
 
@@ -59,6 +68,43 @@ test("interaction range does not invent remote actions", () => {
   const result = attemptInteraction(plan, "01-baseline", state);
   assert.equal(result.changed, false);
   assert.equal(result.scenarioId, "01-baseline");
+});
+
+test("guidance derives the objective and nearby prompt from plan data", () => {
+  const initial = createPlayState(plan);
+  assert.deepEqual(guidanceFor(plan, "01-baseline", initial), {
+    objective: "Exit via North Gate",
+    prompt: "Reach North Gate",
+    tone: "neutral",
+  });
+
+  const besideGate = { ...initial, player: { x: 5, y: 1, z: 0 } };
+  assert.deepEqual(guidanceFor(plan, "01-baseline", besideGate), {
+    objective: "Exit via North Gate",
+    prompt: "E · Ignite North Gate",
+    tone: "action",
+  });
+
+  assert.deepEqual(guidanceFor(plan, "03-breached-unsealed", initial), {
+    objective: "Exit via North Gate",
+    prompt: "The way through North Gate is open",
+    tone: "success",
+  });
+});
+
+test("completion guidance and summary report cumulative run state", () => {
+  const completed = completeRun({
+    ...createPlayState(plan),
+    areasCleared: 2,
+    moves: 41,
+    movementCost: 57,
+  });
+  assert.deepEqual(guidanceFor(plan, "04-breached-unsealed-dark", completed), {
+    objective: "Escape complete",
+    prompt: "R · Begin a new run",
+    tone: "success",
+  });
+  assert.equal(completionSummary(completed, 3), "3 areas · 41 moves · 57 traversal cost");
 });
 
 test("the brazier interaction follows the verified extinguish receipt", () => {

--- a/experiments/executable-gaol/src/verify.mjs
+++ b/experiments/executable-gaol/src/verify.mjs
@@ -14,6 +14,9 @@ if (plan.interactions.length !== 3) fail("expected three verified in-world inter
 if (plan.interactions.some((interaction) => interaction.inputStateHash !== plan.scenarios.find((scenario) => scenario.id === interaction.fromScenario)?.stateHash)) fail("interaction input hash is not scenario-bound");
 if (plan.interactions.some((interaction) => interaction.resultingStateHash !== plan.scenarios.find((scenario) => scenario.id === interaction.toScenario)?.stateHash)) fail("interaction result hash is not scenario-bound");
 if (plan.scenarios.some((scenario) => !scenario.stateHash)) fail("scenario is not runtime-bound");
+if (plan.presentation.objective?.kind !== "exit_via") fail("bounded area objective missing");
+if (plan.presentation.objective.target !== plan.presentation.primaryGate) fail("objective does not target primary gate");
+if (plan.entities.find((entity) => entity.id === plan.presentation.objective.target)?.kind !== "door") fail("objective does not target a compiled door");
 if (plan.scenarios[0].movement[plan.presentation.primaryGate].disposition !== "blocked") fail("baseline gate must be blocked");
 if (plan.scenarios[2].movement[plan.presentation.primaryGate].disposition !== "traversable") fail("breached/unsealed gate must be traversable");
 if (plan.scenarios[3].effectiveLight[plan.presentation.pursuitLight] !== false) fail("breached dark scenario must extinguish the pursuit light");

--- a/experiments/executable-gaol/viewer.html
+++ b/experiments/executable-gaol/viewer.html
@@ -14,8 +14,24 @@
   button { color:#d7ddd9; background:#202d35; border:1px solid #4c6068; border-radius:5px; padding:7px 11px; cursor:pointer }
   button[aria-pressed="true"] { color:#10161d; background:#8ee6e3; border-color:#bfffff }
   main { display:grid; place-items:center; padding:18px }
-  #frame { width:min(100%,1200px); aspect-ratio:20/9; box-shadow:0 28px 80px #0009; border:1px solid #3c4a51; line-height:0; background:#090e13 }
+  #stage { position:relative; width:min(100%,1200px); aspect-ratio:20/9 }
+  #frame { width:100%; height:100%; box-shadow:0 28px 80px #0009; border:1px solid #3c4a51; line-height:0; background:#090e13 }
   #frame canvas { width:100%; height:100%; display:block }
+  #play-hud { position:absolute; z-index:2; top:18px; left:18px; padding:11px 14px; background:#091117dc; border-left:3px solid #4d9f9f; box-shadow:0 8px 28px #0008; pointer-events:none }
+  #progress { color:#6f8288; font:10px ui-monospace,monospace; letter-spacing:.16em; text-transform:uppercase }
+  #objective { margin-top:3px; font-weight:650; letter-spacing:.04em }
+  #prompt { margin-top:5px; color:#9baaad; font:12px ui-monospace,monospace }
+  #prompt[data-tone="action"] { color:#f0bf73 } #prompt[data-tone="success"] { color:#8ee6e3 } #prompt[data-tone="danger"] { color:#d47158 }
+  #arrival { position:absolute; z-index:3; top:14%; left:50%; translate:-50% -8px; padding:13px 26px; text-align:center; background:#091117e8; border-top:1px solid #4d9f9f; border-bottom:1px solid #4d9f9f; opacity:0; transition:opacity .3s,translate .3s; pointer-events:none }
+  #arrival.active { opacity:1; translate:-50% 0 }
+  #arrival-kicker { color:#8ee6e3; font:10px ui-monospace,monospace; letter-spacing:.18em; text-transform:uppercase }
+  #arrival-title { margin-top:4px; font-size:19px; letter-spacing:.08em; text-transform:uppercase }
+  #completion { position:absolute; z-index:4; inset:0; display:grid; place-items:center; background:#071016c9; backdrop-filter:blur(3px) }
+  #completion[hidden] { display:none }
+  #completion-card { min-width:min(360px,calc(100vw - 60px)); padding:28px; text-align:center; background:#101b22; border:1px solid #659b9b; box-shadow:0 30px 90px #000 }
+  #completion-kicker { color:#8ee6e3; font:11px ui-monospace,monospace; letter-spacing:.2em; text-transform:uppercase }
+  #completion h2 { margin:8px 0 10px; font-size:27px; letter-spacing:.1em; text-transform:uppercase }
+  #completion-summary { margin:0 0 20px; color:#9baaad }
   footer { display:flex; flex-wrap:wrap; justify-content:center; gap:8px 24px; padding:11px 18px 15px; color:#8e9b9c; background:#0a1016dd; border-top:1px solid #26343b }
   #message[data-tone="blocked"], #message[data-tone="danger"] { color:#d47158 } #message[data-tone="success"] { color:#8ee6e3 } #message[data-tone="water"] { color:#70909a }
   @media (max-width:700px) {
@@ -25,15 +41,26 @@
     #states { order:3; flex-wrap:wrap }
     #forensic { order:4 }
     main { padding:10px }
+    #play-hud { top:9px; left:9px; padding:8px 10px }
+    #progress { display:none }
+    #objective { font-size:12px }
+    #prompt { font-size:10px }
     footer { justify-content:flex-start; font-size:12px }
   }
 </style>
 <header><h1>Nomos // executable gaol</h1><span id="look"></span><span id="areas"></span><span id="states"></span><button id="forensic" aria-pressed="false">Forensics</button></header>
-<main><div id="frame"></div></main>
+<main>
+  <div id="stage">
+    <div id="play-hud"><div id="progress"></div><div id="objective"></div><div id="prompt"></div></div>
+    <div id="arrival" aria-live="polite"><div id="arrival-kicker"></div><div id="arrival-title"></div></div>
+    <div id="frame"></div>
+    <div id="completion" hidden><div id="completion-card"><div id="completion-kicker">Run complete</div><h2>Gaol escaped</h2><p id="completion-summary"></p><button id="restart">Begin again</button></div></div>
+  </div>
+</main>
 <footer><span>Move: WASD / arrows · Interact: E · Forensic areas: [ ] · States: 1–5 · Reset run: R</span><span id="message"></span><span id="meter"></span></footer>
 <script type="module">
   import { createGaolRenderer } from "./webgl-renderer.mjs";
-  import { attemptInteraction, attemptMove, completeRun, createPlayState, enterArea, movementKeys } from "./play-state.mjs";
+  import { attemptInteraction, attemptMove, completeRun, completionSummary, createPlayState, enterArea, guidanceFor, movementKeys } from "./play-state.mjs";
   const collection = await fetch("./areas.json").then((response) => response.json());
   const plans = new Map(await Promise.all(collection.areas.map(async (area) => [
     area.id,
@@ -47,6 +74,15 @@
   const message = document.querySelector("#message");
   const meter = document.querySelector("#meter");
   const gpu = createGaolRenderer(frame);
+  const progress = document.querySelector("#progress");
+  const objective = document.querySelector("#objective");
+  const prompt = document.querySelector("#prompt");
+  const arrival = document.querySelector("#arrival");
+  const arrivalKicker = document.querySelector("#arrival-kicker");
+  const arrivalTitle = document.querySelector("#arrival-title");
+  const completion = document.querySelector("#completion");
+  const completionSummaryElement = document.querySelector("#completion-summary");
+  const restart = document.querySelector("#restart");
   let areaId = collection.startArea;
   let plan = plans.get(areaId);
   let selected = plan.scenarios[0].id;
@@ -54,6 +90,7 @@
   let visualPlayer = { ...play.player };
   let visualGaoler = { ...play.gaoler };
   let animating = false;
+  let arrivalTimer;
   const selectScenario = (scenarioId) => {
     selected = scenarioId;
     for (const child of states.children) child.ariaPressed = String(child.dataset.scenario === selected);
@@ -76,6 +113,21 @@
     const pursuitLight = plan.presentation.pursuitLight;
     const pursuit = play.caught ? "caught" : plan.scenarios.find((scenario) => scenario.id === selected)?.effectiveLight[pursuitLight] === false ? "hunting" : "dormant";
     meter.textContent = `areas ${play.areasCleared}/${collection.areas.length} · moves ${play.moves} · cost ${play.movementCost} · gaoler ${pursuit}`;
+    const guidance = guidanceFor(plan, selected, play);
+    progress.textContent = `Area ${Math.min(play.areasCleared + 1, collection.areas.length)} / ${collection.areas.length} · ${plan.area.label}`;
+    objective.textContent = guidance.objective;
+    prompt.textContent = guidance.prompt;
+    prompt.dataset.tone = guidance.tone;
+    completion.hidden = !play.completed;
+    if (play.completed) completionSummaryElement.textContent = completionSummary(play, collection.areas.length);
+  };
+  const showArrival = () => {
+    clearTimeout(arrivalTimer);
+    arrivalKicker.textContent = `Area ${Math.min(play.areasCleared + 1, collection.areas.length)} of ${collection.areas.length}`;
+    arrivalTitle.textContent = plan.area.label;
+    arrival.classList.remove("active");
+    requestAnimationFrame(() => arrival.classList.add("active"));
+    arrivalTimer = setTimeout(() => arrival.classList.remove("active"), 1400);
   };
   const reset = () => selectArea(collection.startArea, false);
   const selectArea = (nextAreaId, forensicJump = true) => {
@@ -90,6 +142,7 @@
     for (const child of areas.children) child.ariaPressed = String(child.dataset.area === areaId);
     buildScenarioButtons();
     draw();
+    showArrival();
   };
   const enterConnectedArea = (connection, previousState) => {
     areaId = connection.toArea;
@@ -101,6 +154,7 @@
     for (const child of areas.children) child.ariaPressed = String(child.dataset.area === areaId);
     buildScenarioButtons();
     draw();
+    showArrival();
   };
   const animateMove = (from, to, gaolerFrom, gaolerTo, cost, onComplete) => {
     const started = performance.now();
@@ -135,6 +189,7 @@
   }
   buildScenarioButtons();
   forensic.onclick = () => { forensic.ariaPressed = String(forensic.ariaPressed !== "true"); draw(); };
+  restart.onclick = reset;
   addEventListener("keydown", (event) => {
     if (event.code === "KeyR") { event.preventDefault(); reset(); return; }
     if ((event.code === "BracketLeft" || event.code === "BracketRight") && !animating) {
@@ -174,5 +229,6 @@
     else draw();
   });
   draw();
+  showArrival();
 </script>
 </html>


### PR DESCRIPTION
## Outcome

Adds a bounded `exit_via` objective to each authored area and projects it into the public rendering plan. Plan construction fails closed unless the objective contains exactly `kind` and `target`, names a compiled door, and matches the primary exit gate.

The WebGL viewer derives its objective text, nearby `E` action prompt, and open-passage guidance from that plan plus the existing hash-bound interaction edges. It also presents generic area-arrival progress and a final cumulative run summary without room-ID branches.

Closes #109.

## Evidence

- `experiments/executable-gaol/gaol verify` — pass, 25 tests
- two consecutive clean generations produced identical collection, plan, and SVG hashes
- full Chromium playthrough — all three gates opened through real browser input; completion visible; 27 moves / 37 traversal cost; zero console errors
- desktop initial HUD and completion frames visually inspected
- narrow completion frame visually inspected
- `experiments/executable-gaol/gaol site` — pass
- staged public file inventory contains no `.nomos`, World IR, or compiler-receipt files
- `cargo xtask boundary` — clean
- staged and unstaged `git diff --check` — clean

## Limits

- Objective vocabulary intentionally contains only `exit_via`; this is not a general quest system.
- Arrival and completion are presentation, not authoritative runtime state beyond the existing experimental run state.
- This remains quarantined and cannot satisfy Gate K or Gate 1.

## Stack

Draft, based on `experiment/issue-110-executable-gaol` / PR #111. Owner retains merge and disposition.