### PR TITLE
Fix narrow executable-gaol overlays

### DIFF
--- a/experiments/executable-gaol/viewer.html
+++ b/experiments/executable-gaol/viewer.html
@@ -42,6 +42,9 @@
     #forensic { order:4 }
     main { padding:10px }
     #play-hud { top:9px; left:9px; padding:8px 10px }
+    #arrival { top:auto; bottom:8px; width:max-content; max-width:calc(100% - 24px); box-sizing:border-box; padding:8px 16px; translate:-50% 8px }
+    #arrival.active { translate:-50% 0 }
+    #arrival-title { font-size:15px }
     #progress { display:none }
     #objective { font-size:12px }
     #prompt { font-size:10px }


### PR DESCRIPTION
Closes #114.

Moves the transient area-arrival card to the lower edge of the WebGL stage at narrow widths, keeps it width-bounded, and slightly tightens its typography. Desktop placement is unchanged. This is a CSS-only repair; rendering plans, renderer code, gameplay code, and area content are untouched.

Evidence:
- browser bounding-box proof at 320x700, 430x900, and 1440x900: no HUD/arrival overlap
- screenshots inspected at all three sizes
- zero browser console errors
- `experiments/executable-gaol/gaol verify`: 25/25 pass
- `cargo xtask boundary`: clean
- four RenderingPlan digests and the collection digest unchanged

This remains quarantined experimental work and is not Gate K evidence.