### PR TITLE
Draft decision 0017 for a post-Gate-K epoch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,13 @@ here is authority for any other project.
 - **Measure budgets; never assume them.** Build time, peak disk, validation
   latency, replay throughput, and package size are numbers in the record, not
   adjectives in a meeting.
-- **Gate K stays dependency-free by decision, not superstition.** No third-party
-  dependency enters the workspace before Gate K is disposed. This is the
-  temporary policy in `docs/decisions/0005-gate-k-dependency-policy.md`, not a
-  permanent claim that later gates should reimplement mature libraries.
+- **The kernel crates stay dependency-free by decision, not superstition.** The
+  six kernel crates admit no third-party dependency and `cargo xtask boundary`
+  still fails closed on them. Outside them, R1's dependency policy is set by
+  `docs/decisions/0017-post-gate-k-runtime-epoch.md`: a committed lockfile, each
+  dependency vendored or digest-pinned with its license preserved, and each
+  addition recorded in `RUNTIME.md`. This was never a permanent claim that later
+  epochs should reimplement mature libraries.
 - **Cold review is fuzzing, not authority.** A different model family may attack
   design or code under `docs/review/`; a human owner decides what matters. Use
   `docs/evaluation/COLD_AGENT_PROTOCOL.md` for formal cold-author and cold-debug

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ AI-authored areas can share one coherent visual grammar.
   through one projection-only WebGL renderer and one bounded procedural look.
   It is playable online and explicitly authorized to continue by decision
   0016, but remains non-authoritative and satisfies neither Gate K nor Gate 1
-- **Post-Gate-K epoch status:** decision 0017 is a **draft awaiting owner
-  authorization** under issue #124. It proposes an explicit R1 epoch break
-  governed by a not-yet-written `RUNTIME.md`, with promotion by clean
-  implementation only. Nothing in it is adopted, and no R1 work is authorized
-  until the owner records a disposition
+- **Post-Gate-K epoch status:** decision 0017 is **owner-authorized** under
+  issue #124 and the **R1 epoch is open**: an explicit epoch break, not a Gate K
+  pass, with promotion by clean implementation only. Its contract document
+  `RUNTIME.md` is still pending under issue #128, and nothing is accepted into
+  R1 until it exists
 - **Contract revision:** 7, owner-authorized in decision 0009
 - **Cold-agent protocol revision:** 6, owner-authorized in decision 0015;
   revision-6 packet, boundary, record, adjudication, and finalization tooling is

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ AI-authored areas can share one coherent visual grammar.
   through one projection-only WebGL renderer and one bounded procedural look.
   It is playable online and explicitly authorized to continue by decision
   0016, but remains non-authoritative and satisfies neither Gate K nor Gate 1
+- **Post-Gate-K epoch status:** decision 0017 is a **draft awaiting owner
+  authorization** under issue #124. It proposes an explicit R1 epoch break
+  governed by a not-yet-written `RUNTIME.md`, with promotion by clean
+  implementation only. Nothing in it is adopted, and no R1 work is authorized
+  until the owner records a disposition
 - **Contract revision:** 7, owner-authorized in decision 0009
 - **Cold-agent protocol revision:** 6, owner-authorized in decision 0015;
   revision-6 packet, boundary, record, adjudication, and finalization tooling is

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -87,10 +87,12 @@ iterations inside the quarantined executable study until concrete evidence
 justifies a separate decision to promote a boundary into a post-Gate-K runtime
 epoch.
 
-That separate decision is now drafted but not adopted: issue #124 carries the
-pending `docs/decisions/0017-post-gate-k-runtime-epoch.md`, with issue #125
-auditing presentation-boundary ownership and issue #126 sizing the kernel
-effective-facts projection that would be its first target.
+That separate decision is now owner-authorized:
+`docs/decisions/0017-post-gate-k-runtime-epoch.md` opens the R1 epoch under
+issue #124. Its contract document `RUNTIME.md` is pending under issue #128 and
+nothing is accepted into R1 until it exists; issue #125 audits
+presentation-boundary ownership and issue #126 sizes the kernel effective-facts
+projection that is R1's first target.
 
 Simulation-boundary expansion remains deferred while the visual grammar is
 being established. Do not reopen Gate K evaluation work or add proof machinery

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -87,6 +87,11 @@ iterations inside the quarantined executable study until concrete evidence
 justifies a separate decision to promote a boundary into a post-Gate-K runtime
 epoch.
 
+That separate decision is now drafted but not adopted: issue #124 carries the
+pending `docs/decisions/0017-post-gate-k-runtime-epoch.md`, with issue #125
+auditing presentation-boundary ownership and issue #126 sizing the kernel
+effective-facts projection that would be its first target.
+
 Simulation-boundary expansion remains deferred while the visual grammar is
 being established. Do not reopen Gate K evaluation work or add proof machinery
 unless the owner explicitly reverses decision 0016.

--- a/docs/decisions/0017-post-gate-k-runtime-epoch.md
+++ b/docs/decisions/0017-post-gate-k-runtime-epoch.md
@@ -1,0 +1,135 @@
+---
+title: Post-Gate-K runtime epoch (R1)
+status: Draft; awaiting owner authorization
+number: 0017
+date: 2026-08-25
+owner: Peter Permenter
+issue: 124
+gate_k_disposition: docs/decisions/0013-gate-k-disposition.md
+round_two_termination: docs/decisions/0016-terminate-gate-k-round-two.md
+contract_revision: 7
+r1_contract: RUNTIME.md
+---
+
+# Post-Gate-K runtime epoch (R1)
+
+## Decision authority
+
+This record is a draft prepared under issue #124. It has no effect until Peter
+Permenter records a disposition below.
+
+It proposes one thing: an explicit epoch break. Gate K is closed and cannot be
+retried, so the executable study currently has no authorized route into accepted
+work. R1 is that route, governed by its own contract document, and it is not a
+Gate K pass, a Gate K waiver, or a Gate 1 claim.
+
+## Evidence relied on
+
+The executable evidence is the quarantined study at
+`experiments/executable-gaol/`, authorized by decision 0016:
+
+- four separately authored areas — Cistern Walk, Ember Vault, Ossuary Reach, and
+  North Gaol — sharing one camera, palette, material set, assembly vocabulary,
+  and renderer, with doors, water, light, and composition derived from their own
+  `.nomos` sources and projections;
+- Ossuary Reach was added in commit `8f71e34` (issue #113, PR #115) with no edit
+  to any renderer source: the diff touches the new area's content, docs, the
+  contact sheet, four lines of Ember Vault exit routing to place the new area on
+  the route, and the shared area-collection test. `src/webgl-renderer.mjs`,
+  `src/build-plan.mjs`, `src/render-core.mjs`, and `viewer.html` are untouched;
+- the `gaol_procedural_01` look was added in commit `fec8cbb` (issue #118,
+  PR #119) touching only `src/webgl-renderer.mjs`, `src/webgl-viewer.test.mjs`,
+  `viewer.html`, and the README. No file under `areas/` changed.
+
+The semantic evidence is the two cold-agent rounds. Round one is recorded in
+decision 0013: the formal Gemini author produced a valid second approved door
+and the DeepSeek checker reproduced its package byte-for-byte; the formal
+DeepSeek debugger found the true seeded cause and Gemini independently confirmed
+it. Both runs failed criteria 17 and 18 on the frozen outside-path rubric, and
+that verdict stands. Round two is recorded in decision 0016: both subjects again
+produced materially correct semantic analysis under a clean boundary, and
+neither is a formal pass. Unfamiliar model families could operate the kernel;
+neither round proves the evaluation ceremony was completed.
+
+## What remains unchanged
+
+- Decision 0013 remains the controlling Gate K verdict: **failed**. Criteria 17
+  and 18 remain failed. No retry, round three, or protocol revision 7.
+- `KERNEL.md` revision 7 is frozen as the historical Gate K contract. R1 does not
+  amend it, and no R1 result may be read back onto it.
+- Every historical tag, candidate, task record, rehearsal, and failed or blocked
+  audit remains immutable evidence.
+- `experiments/` remains non-authoritative. Nothing there satisfies acceptance.
+
+## What changes
+
+The R1 epoch opens. A new contract document at `RUNTIME.md` in the repository
+root governs what R1 accepts; it is not yet written, and no R1 work is accepted
+before it exists. R1 restates its own acceptance criteria, budgets, and
+boundaries rather than inheriting Gate K's.
+
+Promotion happens by clean implementation only. Moving or copying
+`experiments/executable-gaol/` into the accepted tree is forbidden. The study is
+a specification and a comparison target for R1 work, never its source of truth.
+
+R1 dependency policy. Decision 0005 was scoped to Gate K and ended with the 0013
+disposition, which admitted no dependency automatically and required each later
+epoch to state its own policy. R1's policy is: third-party dependencies are
+permitted, subject to a committed lockfile; each dependency vendored in-tree or
+pinned by content digest; its license preserved in the tree; and each crate or
+package addition recorded in `RUNTIME.md` with version, provenance, why it beats
+a local implementation, whether it can affect authoritative determinism, and its
+offline-proof plan. The six kernel crates keep zero third-party dependencies
+until a later decision says otherwise, and `cargo xtask boundary` continues to
+fail closed on them.
+
+## First targets in order
+
+1. **Kernel effective-facts projection** — issue #126. A read-only kernel output
+   giving composed effective movement disposition, cost, reasons, and effective
+   light at a runtime state, so that
+   `experiments/executable-gaol/src/build-plan.mjs` stops reimplementing the
+   resolvers in JavaScript.
+2. **Rust rendering-plan compilation** replacing `build-plan.mjs`, consuming that
+   projection rather than recomputing it.
+3. **Typed presentation source** replacing the unversioned `area.json`, informed
+   by the ownership audit in issue #125.
+4. **Promoted viewer** with a vendored Three.js — today it is imported from
+   `https://cdn.jsdelivr.net/npm/three@0.185.1/...` at
+   `experiments/executable-gaol/src/webgl-renderer.mjs:1`, which R1's dependency
+   policy does not permit — plus a headless Chromium smoke lane in CI.
+5. **Authoritative movement and pursuit** — issue #117, deferred before
+   implementation with no committed changes. It reopens here, last, once the
+   presentation boundary above it is typed and owned.
+
+Each target is a separately falsifiable issue with its own evidence. The order is
+a dependency order, not a schedule.
+
+## Reading THESIS.md section 22
+
+`THESIS.md` is not edited by this record. Its section 22 criterion 1 — that Gate
+K passes `KERNEL.md` — is now unsatisfiable: decision 0013 records the failure
+and decision 0016 forbids any retry. Section 22 therefore stands as the
+historical adoption bar for the Gate K era, and it is not met and cannot be met.
+R1 defines its own adoption criteria in `RUNTIME.md`. Until those exist and are
+satisfied, section 22's conclusion holds unchanged: this thesis applies to no
+game project.
+
+## Explicit non-claims
+
+R1 does not claim that Gate K passed, that any failed attempt is repaired or
+relabelled, that Gate 0 or Gate 1 is satisfied, that the renderer or presentation
+semantics in `experiments/` are accepted, that the executable study is
+production art or deterministic across GPUs, or that Nomos has been adopted by
+any project. No new schema is declared by this record; schema identities are
+declared by the code that emits them, under `RUNTIME.md`.
+
+## Owner disposition
+
+_Not yet recorded._ Peter Permenter records exactly one outcome:
+
+1. **authorize** — R1 opens as written; `RUNTIME.md` is the next slice.
+2. **authorize with amendments** — R1 opens with the recorded changes to its
+   contract location, dependency policy, or target order.
+3. **decline** — no post-Gate-K epoch is authorized; the executable study
+   continues under decision 0016 alone with no promotion path.

--- a/docs/decisions/0017-post-gate-k-runtime-epoch.md
+++ b/docs/decisions/0017-post-gate-k-runtime-epoch.md
@@ -1,6 +1,6 @@
 ---
 title: Post-Gate-K runtime epoch (R1)
-status: Draft; awaiting owner authorization
+status: Owner-authorized; R1 epoch open
 number: 0017
 date: 2026-08-25
 owner: Peter Permenter
@@ -15,8 +15,8 @@ r1_contract: RUNTIME.md
 
 ## Decision authority
 
-This record is a draft prepared under issue #124. It has no effect until Peter
-Permenter records a disposition below.
+This record was prepared under issue #124. Peter Permenter authorized it on
+2026-08-25; the disposition is recorded below.
 
 It proposes one thing: an explicit epoch break. Gate K is closed and cannot be
 retried, so the executable study currently has no authorized route into accepted
@@ -126,10 +126,7 @@ declared by the code that emits them, under `RUNTIME.md`.
 
 ## Owner disposition
 
-_Not yet recorded._ Peter Permenter records exactly one outcome:
-
-1. **authorize** — R1 opens as written; `RUNTIME.md` is the next slice.
-2. **authorize with amendments** — R1 opens with the recorded changes to its
-   contract location, dependency policy, or target order.
-3. **decline** — no post-Gate-K epoch is authorized; the executable study
-   continues under decision 0016 alone with no promotion path.
+**Authorize.** Recorded by Peter Permenter on 2026-08-25, with no amendments.
+R1 opens as written: the epoch break, the contract location, the dependency
+policy, and the first-target order all stand as drafted. `RUNTIME.md` is the
+next slice, under issue #128.

--- a/docs/decisions/0017-post-gate-k-runtime-epoch.md
+++ b/docs/decisions/0017-post-gate-k-runtime-epoch.md
@@ -18,7 +18,7 @@ r1_contract: RUNTIME.md
 This record was prepared under issue #124. Peter Permenter authorized it on
 2026-08-25; the disposition is recorded below.
 
-It proposes one thing: an explicit epoch break. Gate K is closed and cannot be
+It records one thing: an explicit epoch break. Gate K is closed and cannot be
 retried, so the executable study currently has no authorized route into accepted
 work. R1 is that route, governed by its own contract document, and it is not a
 Gate K pass, a Gate K waiver, or a Gate 1 claim.


### PR DESCRIPTION
Decision 0017 is **owner-authorized**: Peter Permenter recorded option 1, authorize, on 2026-08-25 with no amendments, and the R1 epoch is open. Resolves issue #124.

## What this adds

`docs/decisions/0017-post-gate-k-runtime-epoch.md`, status **Owner-authorized;
R1 epoch open**. It records an explicit epoch break — working name **R1**
— because Gate K is closed as failed (decision 0013) and cannot be retried
(decision 0016), leaving the quarantined executable study with no authorized
route into accepted work.

The record:

- leaves decision 0013 controlling and `KERNEL.md` revision 7 frozen as the
  historical Gate K contract; no retry, no round three, no Gate 1 claim;
- opens R1 under a new contract document at `RUNTIME.md` (repo root, not yet
  written), with no R1 work accepted before it exists;
- requires promotion by clean implementation and forbids moving
  `experiments/executable-gaol/` into the accepted tree;
- states an R1 third-party dependency policy — permitted with a committed
  lockfile, vendored or digest-pinned, license preserved, each addition recorded
  in `RUNTIME.md`; the six kernel crates keep zero third-party dependencies;
- names the first targets in order: kernel effective-facts projection (#126),
  Rust rendering-plan compilation replacing `build-plan.mjs`, typed presentation
  source replacing `area.json` (informed by #125), promoted viewer with vendored
  Three.js and a headless Chromium smoke lane, then authoritative
  movement/pursuit (#117);
- records that `THESIS.md` §22 criterion 1 is now unsatisfiable and that R1
  adoption criteria will be defined in `RUNTIME.md` — without editing
  `THESIS.md`;
- declares explicit non-claims and no new schemas.

## Evidence relied on

Verified against the repository before it was stated:

- `8f71e34` "Author Ossuary Reach without renderer changes" (issue #113, PR #115)
  touches the new area's content, docs, the contact sheet, four lines of Ember
  Vault exit routing, and the shared area-collection test.
  `src/webgl-renderer.mjs`, `src/build-plan.mjs`, `src/render-core.mjs`, and
  `viewer.html` are untouched — the zero-renderer-edit claim holds, and the two
  edits outside the new area are named in the record rather than glossed.
- `fec8cbb` "Add procedural gaol look grammar" (issue #118, PR #119) touches only
  `src/webgl-renderer.mjs`, `src/webgl-viewer.test.mjs`, `viewer.html`, and the
  README. No file under `areas/` changed.
- Semantic evidence is cited from decisions 0013 and 0016: both cold-agent rounds
  produced materially correct semantic work, and neither is a formal pass.
- Three.js is currently a pinned CDN import at
  `experiments/executable-gaol/src/webgl-renderer.mjs:1`
  (`three@0.185.1` from jsdelivr), which is why vendoring it is named as work in
  target 4 rather than described as already done.

## Issue coverage

Issue #124 acceptance: the decision file exists with frontmatter matching prior
records and a draft status; it contains decision authority, evidence relied on,
what remains unchanged, what changes, the R1 contract location and dependency
policy, first-target order, and explicit non-claims. `README.md` "Status" gains
one bullet and `docs/HANDOFF.md` "What is next" gains one sentence, both marking
0017 as pending rather than adopted. `KERNEL.md`, `THESIS.md`, and every crate
are untouched. The final acceptance box — owner disposition recorded before
merge — is now satisfied: the "Owner disposition" section records **authorize**,
Peter Permenter, 2026-08-25, no amendments, with `RUNTIME.md` as the next slice
under issue #128.

## Note for the owner

Decision 0005's constraint had already ended at the 0013 disposition, which
required each later experiment to state its own policy. 0017 therefore *sets*
the R1 dependency policy that 0005 and 0013 left open rather than overriding a
live rule. With 0017 authorized, the stale `AGENTS.md` bullet is reworded in
this PR: the six kernel crates stay zero-third-party-dependency with
`cargo xtask boundary` failing closed on them, and 0017 governs R1's policy
outside them. No other `AGENTS.md` line changed, and its reading guidance
already points at the latest record under `docs/decisions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsZ5kuhqEodkjFWwdYu43F

