### PR TITLE
R1-1: kernel effective-facts projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ AI-authored areas can share one coherent visual grammar.
   issue #124 and the **R1 epoch is open**: an explicit epoch break, not a Gate K
   pass, with promotion by clean implementation only. Its contract document
   `RUNTIME.md` is now owner-authorized under issue #128 and governs what R1
-  accepts
+  accepts. **R1-1, the kernel effective-facts projection (`nomos
+  effective-facts`, PR #130), is the first accepted R1 slice**: it meets every
+  `RUNTIME.md` §5 R1-1 criterion, and its identity `nomos.effective_facts@1` is
+  the first row of the R1 register `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`
 - **Contract revision:** 7, owner-authorized in decision 0009
 - **Cold-agent protocol revision:** 6, owner-authorized in decision 0015;
   revision-6 packet, boundary, record, adjudication, and finalization tooling is

--- a/crates/nomos-cli/src/command.rs
+++ b/crates/nomos-cli/src/command.rs
@@ -17,7 +17,7 @@ use crate::{
     require_available_run_output, write_run_bundle,
 };
 
-const ROOT_HELP: &str = "Nomos Gate K semantic runtime\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos migrate <v1-world/> --to 2 --out <new-v2-world/>\n  nomos run <world/> --commands <commands> --out <new-run/>\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n  nomos replay <world/> --log <replay> --out <new-run/>\n  nomos explain-entity <world/> <entity>\n  nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n  nomos --help\n";
+const ROOT_HELP: &str = "Nomos Gate K semantic runtime\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos migrate <v1-world/> --to 2 --out <new-v2-world/>\n  nomos run <world/> --commands <commands> --out <new-run/>\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n  nomos replay <world/> --log <replay> --out <new-run/>\n  nomos explain-entity <world/> <entity>\n  nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n  nomos effective-facts <world/> --state <state.json>\n  nomos --help\n";
 const VALIDATE_HELP: &str = "Validate one Nomos source file without writing artifacts.\n\nUsage:\n  nomos validate <source.nomos>\n";
 const COMPILE_HELP: &str = "Compile one Nomos source file into a new immutable world package.\n\nUsage:\n  nomos compile <source.nomos> --out <new.world/>\n";
 const INSPECT_HELP: &str =
@@ -28,6 +28,7 @@ const COMMAND_HELP: &str = "Execute one command from a verified persisted runtim
 const REPLAY_HELP: &str = "Reproduce one strict replay log against a compiled world's initial state.\n\nUsage:\n  nomos replay <world/> --log <replay> --out <new-run/>\n";
 const EXPLAIN_ENTITY_HELP: &str = "Explain one entity from a strictly verified compiled world.\n\nUsage:\n  nomos explain-entity <world/> <entity>\n";
 const EXPLAIN_TRANSITION_HELP: &str = "Explain one committed transition after strictly verifying its world and re-executing its run.\n\nUsage:\n  nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n";
+const EFFECTIVE_FACTS_HELP: &str = "Project every resolver subject's effective facts at one verified runtime state.\n\nUsage:\n  nomos effective-facts <world/> --state <state.json>\n";
 
 /// One completed command-line execution, including its exact stdout bytes.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -93,6 +94,10 @@ enum Command {
         entity: String,
         tick: u64,
         package: String,
+    },
+    EffectiveFacts {
+        package: String,
+        state: String,
     },
 }
 
@@ -233,6 +238,20 @@ fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Command, Diagnostic
                 package: package.clone(),
             }
         }
+        [name, help] if name == "effective-facts" && help == "--help" => {
+            Command::Help(EFFECTIVE_FACTS_HELP)
+        }
+        [name, package, state_option, state]
+            if name == "effective-facts"
+                && !is_option(package)
+                && state_option == "--state"
+                && !is_option(state) =>
+        {
+            Command::EffectiveFacts {
+                package: package.clone(),
+                state: state.clone(),
+            }
+        }
         [name, help] if name == "command" && help == "--help" => Command::Help(COMMAND_HELP),
         [
             name,
@@ -308,6 +327,9 @@ fn execute_command(command: Command) -> Execution {
             tick,
             package,
         } => explain_transition(&run, &entity, tick, &package).map(RuntimeOutcome::completed),
+        Command::EffectiveFacts { package, state } => {
+            effective_facts(&package, &state).map(RuntimeOutcome::completed)
+        }
     };
     match result {
         Ok(outcome) => outcome.into_execution(),
@@ -558,6 +580,17 @@ fn explain_transition(
     let world = open_compiled_world(&package_path)?;
     let run = open_run_bundle(&run_path, &world)?;
     crate::explanation::transition_report(&world, &run, &entity, tick)
+}
+
+fn effective_facts(package: &str, state: &str) -> Result<CanonicalValue, Diagnostic> {
+    let package_path = relative_filesystem_path(package)?;
+    let state_path = relative_filesystem_path(state)?;
+    let world = open_compiled_world(&package_path)?;
+    let state = PersistedRuntimeState::from_canonical_bytes(
+        &read_regular_bytes(&state_path, "persisted runtime state")?,
+        world.simulation(),
+    )?;
+    nomos_sim::effective_facts(world.simulation(), &state, world.package_digest())
 }
 
 fn publish_execution(

--- a/crates/nomos-cli/src/explanation.rs
+++ b/crates/nomos-cli/src/explanation.rs
@@ -65,7 +65,7 @@ pub(crate) fn entity_report(
             CanonicalValue::object_declared([
                 (
                     "ground_movement",
-                    movement.map_or(CanonicalValue::Null, movement_to_canonical),
+                    movement.map_or(CanonicalValue::Null, MovementDisposition::to_canonical),
                 ),
                 (
                     "light_emission",
@@ -188,26 +188,6 @@ pub(crate) fn transition_report(
         ("status", CanonicalValue::text("completed")),
         ("tick", CanonicalValue::Uint(tick)),
     ]))
-}
-
-fn movement_to_canonical(disposition: &MovementDisposition) -> CanonicalValue {
-    match disposition {
-        MovementDisposition::Blocked { reasons } => CanonicalValue::object_declared([
-            ("kind", CanonicalValue::text("blocked")),
-            (
-                "reasons",
-                CanonicalValue::Array(reasons.iter().map(StableId::to_canonical).collect()),
-            ),
-        ]),
-        MovementDisposition::Traversable { cost, reasons } => CanonicalValue::object_declared([
-            ("cost", CanonicalValue::Uint(u64::from(*cost))),
-            ("kind", CanonicalValue::text("traversable")),
-            (
-                "reasons",
-                CanonicalValue::Array(reasons.iter().map(StableId::to_canonical).collect()),
-            ),
-        ]),
-    }
 }
 
 fn active_claims(receipt: &CausalReceipt, entity: &EntityId, before: bool) -> BTreeSet<ClaimRef> {

--- a/crates/nomos-cli/tests/effective_facts.rs
+++ b/crates/nomos-cli/tests/effective_facts.rs
@@ -1,4 +1,8 @@
-//! Spike proof for issue #126: the composed effective-fact projection.
+//! R1-1 acceptance proof: the composed effective-fact projection.
+//!
+//! Acceptance criteria are `RUNTIME.md` section 5 R1-1; the design record is
+//! `docs/review/effective-facts-spike.md`, which maps each bullet to the test
+//! below that proves it.
 //!
 //! The point of the command is that no consumer needs a second resolver. These
 //! tests hold it to that: the projection must agree with `explain-entity`'s
@@ -91,6 +95,28 @@ fn text(value: &CanonicalValue) -> &str {
 
 fn json(value: &CanonicalValue) -> String {
     String::from_utf8(value.to_canonical_bytes()).unwrap()
+}
+
+fn bundle_listing(dir: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut entries: Vec<(PathBuf, Vec<u8>)> = fs::read_dir(dir)
+        .unwrap()
+        .map(|entry| {
+            let path = entry.unwrap().path();
+            let bytes = fs::read(&path).unwrap();
+            (path, bytes)
+        })
+        .collect();
+    entries.sort();
+    entries
+}
+
+fn diagnostic_code(output: &Output) -> String {
+    let value = canonical_stdout(output);
+    let diagnostic = &array(field(&value, "diagnostics"))[0];
+    let CanonicalValue::Text(code) = field(diagnostic, "code") else {
+        panic!("diagnostic code must be text")
+    };
+    code.clone()
 }
 
 /// Compiles the fixture world and executes the five-command script.
@@ -276,6 +302,9 @@ fn a_state_from_another_world_is_rejected_rather_than_resolved() {
         text(field(&canonical_stdout(&output), "status")),
         "rejected"
     );
+    // RUNTIME.md section 5 R1-1 requires this exact stable code, not merely a
+    // rejection: EK0813 RUNTIME_SEMANTICS_MISMATCH.
+    assert_eq!(diagnostic_code(&output), "EK0813");
 }
 
 #[test]
@@ -294,8 +323,14 @@ fn the_projection_mutates_no_input() {
         .collect();
     before_package.sort();
 
+    // R1-1 also forbids adding a file to a run bundle, whose strict reopener
+    // fails closed on extra entries. Capture the exact six-file set first.
+    let bundle_before = bundle_listing(&root.join("runs/gaol"));
+    assert_eq!(bundle_before.len(), 6, "run bundle is not the six-file set");
+
     let _ = effective_facts(&root, "runs/gaol/final-state.json");
 
+    assert_eq!(bundle_listing(&root.join("runs/gaol")), bundle_before);
     assert_eq!(fs::read(&state).unwrap(), before_state);
     let mut after_package: Vec<(PathBuf, Vec<u8>)> = fs::read_dir(root.join("gaol.world"))
         .unwrap()
@@ -422,4 +457,28 @@ fn the_same_world_and_state_produce_byte_identical_output() {
         String::from_utf8_lossy(first),
         "a second compilation of the same source produced different bytes"
     );
+
+    // The other half of the R1-1 bullet: identical source bytes at a *different*
+    // source path are a different world, and must fail closed rather than
+    // diverge silently. This is what bounds byte identity to the fixed triple.
+    fs::create_dir_all(root.join("nested")).unwrap();
+    fs::copy(root.join("gaol.nomos"), root.join("nested/gaol.nomos")).unwrap();
+    assert_exit(
+        &run(
+            &root,
+            ["compile", "nested/gaol.nomos", "--out", "nested.world"],
+        ),
+        0,
+    );
+    let moved = run(
+        &root,
+        [
+            "effective-facts",
+            "nested.world",
+            "--state",
+            "runs/gaol/final-state.json",
+        ],
+    );
+    assert_exit(&moved, 1);
+    assert_eq!(diagnostic_code(&moved), "EK0813");
 }

--- a/crates/nomos-cli/tests/effective_facts.rs
+++ b/crates/nomos-cli/tests/effective_facts.rs
@@ -1,0 +1,355 @@
+//! Spike proof for issue #126: the composed effective-fact projection.
+//!
+//! The point of the command is that no consumer needs a second resolver. These
+//! tests hold it to that: the projection must agree with `explain-entity`'s
+//! independently composed `effective_initial_facts` for every subject, and must
+//! track committed state rather than the package's initial state.
+
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use nomos_core::canonical::read::parse_canonical;
+use nomos_core::{CanonicalValue, FieldName};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+const SOURCE: &[u8] = include_bytes!("../../../fixtures/gaol.nomos");
+const COMMANDS: &[u8] = include_bytes!("../../../fixtures/gaol.commands");
+
+fn fresh_workspace(label: &str) -> PathBuf {
+    let index = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+        .join("effective-facts")
+        .join(format!("{}-{nonce}-{label}-{index}", std::process::id()));
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("gaol.nomos"), SOURCE).unwrap();
+    fs::write(root.join("gaol.commands"), COMMANDS).unwrap();
+    root
+}
+
+fn run<I, S>(cwd: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new(env!("CARGO_BIN_EXE_nomos"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap()
+}
+
+fn assert_exit(output: &Output, expected: i32) {
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(output.stderr.is_empty());
+}
+
+fn canonical_stdout(output: &Output) -> CanonicalValue {
+    assert_eq!(output.stdout.last(), Some(&b'\n'));
+    parse_canonical(&output.stdout[..output.stdout.len() - 1]).unwrap()
+}
+
+fn object(value: &CanonicalValue) -> &BTreeMap<FieldName, CanonicalValue> {
+    let CanonicalValue::Object(fields) = value else {
+        panic!("expected canonical object")
+    };
+    fields
+}
+
+fn field<'a>(value: &'a CanonicalValue, name: &'static str) -> &'a CanonicalValue {
+    object(value)
+        .get(&FieldName::declared(name))
+        .unwrap_or_else(|| panic!("missing field `{name}`"))
+}
+
+fn array(value: &CanonicalValue) -> &[CanonicalValue] {
+    let CanonicalValue::Array(items) = value else {
+        panic!("expected canonical array")
+    };
+    items
+}
+
+fn text(value: &CanonicalValue) -> &str {
+    let CanonicalValue::Text(inner) = value else {
+        panic!("expected canonical text")
+    };
+    inner.as_str()
+}
+
+fn json(value: &CanonicalValue) -> String {
+    String::from_utf8(value.to_canonical_bytes()).unwrap()
+}
+
+/// Compiles the fixture world and executes the five-command script.
+fn compiled_run(label: &str) -> PathBuf {
+    let root = fresh_workspace(label);
+    assert_exit(
+        &run(&root, ["compile", "gaol.nomos", "--out", "gaol.world"]),
+        0,
+    );
+    assert_exit(
+        &run(
+            &root,
+            [
+                "run",
+                "gaol.world",
+                "--commands",
+                "gaol.commands",
+                "--out",
+                "runs/gaol",
+            ],
+        ),
+        0,
+    );
+    root
+}
+
+fn effective_facts(root: &Path, state: &str) -> CanonicalValue {
+    let output = run(root, ["effective-facts", "gaol.world", "--state", state]);
+    assert_exit(&output, 0);
+    canonical_stdout(&output)
+}
+
+#[test]
+fn the_projection_names_its_schema_world_and_state() {
+    let root = compiled_run("identity");
+    let document = effective_facts(&root, "runs/gaol/final-state.json");
+
+    assert_eq!(text(field(&document, "command")), "effective-facts");
+    assert_eq!(text(field(&document, "status")), "completed");
+    assert_eq!(
+        json(field(&document, "schema")),
+        r#"{"name":"nomos.effective_facts","version":1}"#
+    );
+    assert_eq!(json(field(&document, "tick")), "5");
+
+    // The document binds the exact package and runtime semantics it resolved
+    // against, so facts cannot be silently paired with a different world.
+    let state: CanonicalValue =
+        parse_canonical(&fs::read(root.join("runs/gaol/final-state.json")).unwrap()).unwrap();
+    assert_eq!(
+        text(field(&document, "state_hash")),
+        text(field(&state, "state_hash"))
+    );
+    assert_eq!(
+        text(field(&document, "runtime_semantics_digest")),
+        text(field(&state, "runtime_semantics_digest"))
+    );
+    let inspect = run(&root, ["inspect", "gaol.world"]);
+    assert_exit(&inspect, 0);
+    assert_eq!(
+        text(field(&document, "package_digest")),
+        text(field(&canonical_stdout(&inspect), "manifest_digest"))
+    );
+}
+
+#[test]
+fn every_resolver_subject_is_composed_at_the_supplied_state() {
+    let root = compiled_run("subjects");
+
+    // Initial state: the gate is blocked by both its portal and its ward, the
+    // flooded section costs 3, and the brazier is lit.
+    assert_eq!(
+        json(field(
+            &effective_facts(&root, "runs/gaol/initial-state.json"),
+            "effective_facts"
+        )),
+        concat!(
+            r#"{"ground_movement":["#,
+            r#"{"disposition":{"cost":3,"kind":"traversable","reasons":["#,
+            r#""flooded_section.region#traversal_cost_ground"]},"#,
+            r#""entity":"flooded_section"},"#,
+            r#"{"disposition":{"kind":"blocked","reasons":["#,
+            r#""north_gate.portal#blocks_ground","north_gate.ward#blocks_ground"]},"#,
+            r#""entity":"north_gate"}],"#,
+            r#""light_emission":[{"emitting":true,"entity":"brazier_02","reasons":["#,
+            r#""brazier_02.emission#emits_light"]}]}"#,
+        )
+    );
+
+    // After unlock/open/unseal/ignite/extinguish: the gate falls back to the
+    // base cost with an empty reason list, and the brazier is dark with none.
+    assert_eq!(
+        json(field(
+            &effective_facts(&root, "runs/gaol/final-state.json"),
+            "effective_facts"
+        )),
+        concat!(
+            r#"{"ground_movement":["#,
+            r#"{"disposition":{"cost":3,"kind":"traversable","reasons":["#,
+            r#""flooded_section.region#traversal_cost_ground"]},"#,
+            r#""entity":"flooded_section"},"#,
+            r#"{"disposition":{"cost":1,"kind":"traversable","reasons":[]},"#,
+            r#""entity":"north_gate"}],"#,
+            r#""light_emission":[{"emitting":false,"entity":"brazier_02","reasons":[]}]}"#,
+        )
+    );
+}
+
+#[test]
+fn the_projection_agrees_with_explain_entity_at_the_initial_state() {
+    let root = compiled_run("agreement");
+    let document = effective_facts(&root, "runs/gaol/initial-state.json");
+    let facts = field(&document, "effective_facts");
+
+    let movement: BTreeMap<&str, &CanonicalValue> = array(field(facts, "ground_movement"))
+        .iter()
+        .map(|fact| (text(field(fact, "entity")), field(fact, "disposition")))
+        .collect();
+    let light: BTreeMap<&str, &CanonicalValue> = array(field(facts, "light_emission"))
+        .iter()
+        .map(|fact| (text(field(fact, "entity")), fact))
+        .collect();
+    assert_eq!(movement.len(), 2);
+    assert_eq!(light.len(), 1);
+
+    // `explain-entity` composes the same facts through an independent code
+    // path. If a shadow resolver ever appears, these two disagree.
+    for entity in ["north_gate", "flooded_section", "brazier_02"] {
+        let explained = run(&root, ["explain-entity", "gaol.world", entity]);
+        assert_exit(&explained, 0);
+        let report = canonical_stdout(&explained);
+        let initial = field(&report, "effective_initial_facts");
+
+        let explained_movement = field(initial, "ground_movement");
+        match movement.get(entity) {
+            Some(disposition) => assert_eq!(json(explained_movement), json(disposition)),
+            None => assert_eq!(explained_movement, &CanonicalValue::Null),
+        }
+
+        let explained_light = field(initial, "light_emission");
+        match light.get(entity) {
+            Some(fact) => {
+                assert_eq!(
+                    json(field(explained_light, "emitting")),
+                    json(field(fact, "emitting"))
+                );
+                assert_eq!(
+                    json(field(explained_light, "reasons")),
+                    json(field(fact, "reasons"))
+                );
+            }
+            None => assert_eq!(explained_light, &CanonicalValue::Null),
+        }
+    }
+}
+
+#[test]
+fn a_state_from_another_world_is_rejected_rather_than_resolved() {
+    let root = compiled_run("foreign");
+    // The fixture world plus one more gate: it compiles, but its simulation
+    // semantics differ, so the first world's state must not resolve against it.
+    let mut other = SOURCE.to_vec();
+    other.extend_from_slice(
+        b"\nentity south_gate primitive/iron_barred_door\n  anchor face 1 0 0 north\n  credential credential/gaoler_key\nend\n",
+    );
+    fs::write(root.join("other.nomos"), &other).unwrap();
+    assert_exit(
+        &run(&root, ["compile", "other.nomos", "--out", "other.world"]),
+        0,
+    );
+
+    let output = run(
+        &root,
+        [
+            "effective-facts",
+            "other.world",
+            "--state",
+            "runs/gaol/final-state.json",
+        ],
+    );
+    assert_exit(&output, 1);
+    assert_eq!(
+        text(field(&canonical_stdout(&output), "status")),
+        "rejected"
+    );
+}
+
+#[test]
+fn the_projection_mutates_no_input() {
+    let root = compiled_run("immutable");
+    let state = root.join("runs/gaol/final-state.json");
+
+    let before_state = fs::read(&state).unwrap();
+    let mut before_package: Vec<(PathBuf, Vec<u8>)> = fs::read_dir(root.join("gaol.world"))
+        .unwrap()
+        .map(|entry| {
+            let path = entry.unwrap().path();
+            let bytes = fs::read(&path).unwrap();
+            (path, bytes)
+        })
+        .collect();
+    before_package.sort();
+
+    let _ = effective_facts(&root, "runs/gaol/final-state.json");
+
+    assert_eq!(fs::read(&state).unwrap(), before_state);
+    let mut after_package: Vec<(PathBuf, Vec<u8>)> = fs::read_dir(root.join("gaol.world"))
+        .unwrap()
+        .map(|entry| {
+            let path = entry.unwrap().path();
+            let bytes = fs::read(&path).unwrap();
+            (path, bytes)
+        })
+        .collect();
+    after_package.sort();
+    assert_eq!(after_package, before_package);
+}
+
+#[test]
+fn the_argument_grammar_is_exact() {
+    let root = compiled_run("grammar");
+
+    let help = run(&root, ["effective-facts", "--help"]);
+    assert_exit(&help, 0);
+    assert!(
+        String::from_utf8_lossy(&help.stdout).contains("nomos effective-facts <world/> --state")
+    );
+    assert!(
+        String::from_utf8_lossy(&run(&root, ["--help"]).stdout).contains("nomos effective-facts")
+    );
+
+    // Missing option, misspelled option, and extra arguments are usage errors.
+    for args in [
+        vec!["effective-facts", "gaol.world"],
+        vec!["effective-facts", "gaol.world", "--state"],
+        vec![
+            "effective-facts",
+            "gaol.world",
+            "--from",
+            "runs/gaol/final-state.json",
+        ],
+        vec![
+            "effective-facts",
+            "gaol.world",
+            "--state",
+            "runs/gaol/final-state.json",
+            "--out",
+            "runs/extra",
+        ],
+    ] {
+        assert_exit(&run(&root, args), 2);
+    }
+
+    // A missing state file is an environment failure, not a rejected world.
+    assert_exit(
+        &run(
+            &root,
+            ["effective-facts", "gaol.world", "--state", "absent.json"],
+        ),
+        3,
+    );
+}

--- a/crates/nomos-cli/tests/effective_facts.rs
+++ b/crates/nomos-cli/tests/effective_facts.rs
@@ -353,3 +353,73 @@ fn the_argument_grammar_is_exact() {
         3,
     );
 }
+
+#[test]
+fn the_same_world_and_state_produce_byte_identical_output() {
+    let root = compiled_run("determinism");
+
+    // R1-1: ten invocations against one package and one state must agree on
+    // every byte of stdout, not merely on the facts they encode.
+    let mut outputs = Vec::new();
+    for _ in 0..10 {
+        let output = run(
+            &root,
+            [
+                "effective-facts",
+                "gaol.world",
+                "--state",
+                "runs/gaol/final-state.json",
+            ],
+        );
+        assert_exit(&output, 0);
+        outputs.push(output.stdout);
+    }
+
+    // Guard against a vacuous pass: ten empty stdouts are also "identical".
+    let first = &outputs[0];
+    assert!(
+        first.len() > 512,
+        "stdout is implausibly short: {}",
+        first.len()
+    );
+    assert_eq!(first.last(), Some(&b'\n'));
+    assert!(
+        String::from_utf8_lossy(first).contains(r#""schema":{"name":"nomos.effective_facts""#),
+        "stdout does not carry the projection: {}",
+        String::from_utf8_lossy(first)
+    );
+
+    for (index, output) in outputs.iter().enumerate().skip(1) {
+        assert_eq!(
+            String::from_utf8_lossy(output),
+            String::from_utf8_lossy(first),
+            "run {index} diverged from the first run"
+        );
+    }
+
+    // A second freshly compiled copy of the same source must produce the same
+    // bytes, so nothing about the package's location on disk reaches canonical
+    // output. "Same source" means the same bytes at the same source path: the
+    // path appears in claim source spans and is therefore inside the hash
+    // domain, which is what makes a state fail closed against a world compiled
+    // from elsewhere (see the foreign-world test above).
+    assert_exit(
+        &run(&root, ["compile", "gaol.nomos", "--out", "copy.world"]),
+        0,
+    );
+    let copy = run(
+        &root,
+        [
+            "effective-facts",
+            "copy.world",
+            "--state",
+            "runs/gaol/final-state.json",
+        ],
+    );
+    assert_exit(&copy, 0);
+    assert_eq!(
+        String::from_utf8_lossy(&copy.stdout),
+        String::from_utf8_lossy(first),
+        "a second compilation of the same source produced different bytes"
+    );
+}

--- a/crates/nomos-projection/src/light.rs
+++ b/crates/nomos-projection/src/light.rs
@@ -313,7 +313,9 @@ impl ResolvedLight {
         &self.reasons
     }
 
-    fn to_canonical(&self) -> CanonicalValue {
+    /// Canonical form of one subject's effective light fact.
+    #[must_use]
+    pub fn to_canonical(&self) -> CanonicalValue {
         CanonicalValue::object_declared([
             ("emitting", CanonicalValue::Bool(self.emitting)),
             ("entity", self.entity.to_canonical()),
@@ -361,16 +363,21 @@ impl ResolvedLightFacts {
             .map(|index| &self.facts[index])
     }
 
-    /// Canonical bytes for deterministic evidence.
+    /// Canonical entity-ordered array of every resolved subject.
     #[must_use]
-    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+    pub fn to_canonical(&self) -> CanonicalValue {
         keyed_array(
             self.facts
                 .iter()
                 .map(|fact| (fact.entity.clone(), fact.to_canonical())),
         )
         .expect("ResolvedLightFacts validates unique subjects")
-        .to_canonical_bytes()
+    }
+
+    /// Canonical bytes for deterministic evidence.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        self.to_canonical().to_canonical_bytes()
     }
 }
 

--- a/crates/nomos-projection/src/movement.rs
+++ b/crates/nomos-projection/src/movement.rs
@@ -564,7 +564,12 @@ impl MovementDisposition {
         }
     }
 
-    fn to_canonical(&self) -> CanonicalValue {
+    /// Canonical form of the composed disposition.
+    ///
+    /// Public so that every consumer of an effective movement fact renders the
+    /// one spelling this crate owns, rather than re-deriving the object.
+    #[must_use]
+    pub fn to_canonical(&self) -> CanonicalValue {
         match self {
             Self::Blocked { reasons } => CanonicalValue::object_declared([
                 ("kind", CanonicalValue::text("blocked")),
@@ -614,7 +619,9 @@ impl ResolvedMovement {
         &self.disposition
     }
 
-    fn to_canonical(&self) -> CanonicalValue {
+    /// Canonical form of one subject's effective movement fact.
+    #[must_use]
+    pub fn to_canonical(&self) -> CanonicalValue {
         CanonicalValue::object_declared([
             ("disposition", self.disposition.to_canonical()),
             ("entity", self.entity.to_canonical()),
@@ -660,16 +667,21 @@ impl ResolvedMovementFacts {
             .map(|index| self.facts[index].disposition())
     }
 
-    /// Canonical bytes for deterministic evidence and atomicity checks.
+    /// Canonical entity-ordered array of every resolved subject.
     #[must_use]
-    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+    pub fn to_canonical(&self) -> CanonicalValue {
         keyed_array(
             self.facts
                 .iter()
                 .map(|fact| (fact.entity.clone(), fact.to_canonical())),
         )
         .expect("ResolvedMovementFacts validates unique subjects")
-        .to_canonical_bytes()
+    }
+
+    /// Canonical bytes for deterministic evidence and atomicity checks.
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        self.to_canonical().to_canonical_bytes()
     }
 }
 

--- a/crates/nomos-sim/src/effective_facts.rs
+++ b/crates/nomos-sim/src/effective_facts.rs
@@ -1,0 +1,87 @@
+//! The composed effective-fact projection for one runtime state.
+//!
+//! `explain-entity` composes effective facts for a single entity at the initial
+//! state and `explain-transition` reports one entity at one tick. Neither
+//! answers "what are the effective facts for every resolver subject at *this*
+//! state", which is the question every downstream consumer of a compiled world
+//! actually asks. This module answers it by calling the two existing resolvers;
+//! it contains no activation, blocking, cost, or union logic of its own.
+
+use nomos_core::{CanonicalValue, Diagnostic, Sha256Digest};
+use nomos_projection::SimulationPlan;
+
+use crate::{PersistedRuntimeState, resolve_light, resolve_movement};
+
+/// Composes every resolver subject's effective facts at one runtime state.
+///
+/// The `package_digest` binds the document to the exact verified world package
+/// the state was resolved against, so a consumer cannot silently pair facts
+/// with a different world.
+///
+/// # Errors
+///
+/// Propagates the `EK09xx` diagnostics raised by [`resolve_movement`] and
+/// [`resolve_light`] when a projected plan leaves the Gate K resolver contract
+/// or an activation names a machine or state that is absent.
+pub fn effective_facts(
+    plan: &SimulationPlan,
+    state: &PersistedRuntimeState,
+    package_digest: Sha256Digest,
+) -> Result<CanonicalValue, Diagnostic> {
+    let movement = resolve_movement(plan, state.state())?;
+    let light = resolve_light(plan, state.state())?;
+    let movement_count = movement.facts().len();
+    let light_count = light.facts().len();
+
+    Ok(CanonicalValue::object_declared([
+        ("command", CanonicalValue::text("effective-facts")),
+        (
+            "effective_facts",
+            CanonicalValue::object_declared([
+                ("ground_movement", movement.to_canonical()),
+                ("light_emission", light.to_canonical()),
+            ]),
+        ),
+        (
+            "package_digest",
+            CanonicalValue::text(package_digest.to_hex()),
+        ),
+        (
+            "runtime_semantics_digest",
+            CanonicalValue::text(state.runtime_semantics_digest().to_hex()),
+        ),
+        ("schema", effective_facts_schema().to_canonical()),
+        (
+            "state_hash",
+            CanonicalValue::text(state.state_hash().to_hex()),
+        ),
+        ("status", CanonicalValue::text("completed")),
+        (
+            "subject_count",
+            CanonicalValue::object_declared([
+                (
+                    "ground_movement",
+                    CanonicalValue::Uint(movement_count as u64),
+                ),
+                ("light_emission", CanonicalValue::Uint(light_count as u64)),
+            ]),
+        ),
+        ("tick", CanonicalValue::Uint(state.state().tick())),
+    ]))
+}
+
+/// Canonical schema for the composed effective-fact projection.
+///
+/// Unlike the `explain-*` reports, this document exists to be consumed and
+/// persisted by a downstream tool, so it carries a versioned identity to bind
+/// against.
+///
+/// # Panics
+///
+/// Panics if the built-in literal is not a valid schema id, which this crate's
+/// tests rule out.
+#[must_use]
+pub fn effective_facts_schema() -> nomos_core::id::SchemaId {
+    nomos_core::id::SchemaId::new("nomos.effective_facts", 1)
+        .expect("the effective-facts schema id is a valid literal")
+}

--- a/crates/nomos-sim/src/lib.rs
+++ b/crates/nomos-sim/src/lib.rs
@@ -40,6 +40,7 @@ use nomos_core::id::SchemaId;
 
 mod command_language;
 mod commit;
+mod effective_facts;
 mod execution;
 mod receipt;
 mod replay;
@@ -51,6 +52,7 @@ mod transaction;
 
 pub use command_language::{CommandRequest, CommandScript, resolve_command};
 pub use commit::{CommittedTransaction, commit_transaction, commit_transaction_with_budget};
+pub use effective_facts::{effective_facts, effective_facts_schema};
 pub use execution::{RunExecution, execute_requests, validate_committed_evidence};
 pub use receipt::{CausalReceipt, EffectiveFactRef, EffectiveFactValue, ProjectionDelta};
 pub use replay::ReplayLog;
@@ -144,8 +146,8 @@ mod tests {
 
     use super::{
         causal_receipt_schema, causal_receipt_sequence_schema, command_log_schema,
-        command_script_schema, persisted_runtime_state_schema, replay_log_schema,
-        run_result_schema, runtime_state_schema, state_hash_sequence_schema,
+        command_script_schema, effective_facts_schema, persisted_runtime_state_schema,
+        replay_log_schema, run_result_schema, runtime_state_schema, state_hash_sequence_schema,
     };
 
     #[test]
@@ -160,6 +162,7 @@ mod tests {
             run_result_schema(),
             causal_receipt_schema(),
             replay_log_schema(),
+            effective_facts_schema(),
         ];
         assert_eq!(
             runtime_schemas

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -44,6 +44,12 @@ simulation/navigation/persistence/diagnostic projections, immutable runtime
 transactions, hash-verified packages, replay and migration, and package-bound
 explanations.
 
+`nomos effective-facts <world/> --state <state.json>` adds the R1-1 read-only
+projection: given a strictly verified package and a runtime state it emits
+`nomos.effective_facts@1`, the composed movement disposition, cost, ordered
+reasons, and effective light for every resolver subject, resolved entirely by
+the existing `resolve_movement` and `resolve_light` rather than by new logic.
+
 The executable study provides:
 
 - Cistern Walk, Ember Vault, Ossuary Reach, and North Gaol as separately
@@ -90,10 +96,16 @@ epoch.
 That separate decision is now owner-authorized:
 `docs/decisions/0017-post-gate-k-runtime-epoch.md` opens the R1 epoch under
 issue #124. Its contract document `RUNTIME.md` is owner-authorized under issue
-#128 and now governs what R1 accepts; issue #125's presentation-boundary
-ownership audit is merged and issue #126 sizes the kernel effective-facts
-projection that is R1's first target. The next slices are R1-1's acceptance,
-prototyped on PR #130, then R1-2.
+#128 and now governs what R1 accepts. R1-1 is accepted on PR #130 (issue #126),
+and its identity is the first row of `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`.
+
+**R1-2, Rust rendering-plan compilation, is next**: a Rust compiler consuming
+`nomos.effective_facts@1` and typed presentation source, replacing
+`experiments/executable-gaol/src/build-plan.mjs`. As the first accepted consumer
+of that identity it binds it and refuses a version mismatch. Issue #125's
+merged presentation-boundary ownership audit is its checklist for what content
+still owns which fact, and issue #132 records the three JavaScript divergences
+its equivalence fixture must exercise.
 
 Simulation-boundary expansion remains deferred while the visual grammar is
 being established. Do not reopen Gate K evaluation work or add proof machinery

--- a/docs/evaluation/R1_SCHEMA_OWNERSHIP.md
+++ b/docs/evaluation/R1_SCHEMA_OWNERSHIP.md
@@ -35,9 +35,16 @@ relative.
 
 | Canonical identity | Owner | Owner file | Authoritative type set | Encoder | Strict reader / verifier | Persisted boundary | Primary consumers | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `nomos.effective_facts@1` | `nomos-sim` | `crates/nomos-sim/src/effective_facts.rs` | the `effective_facts()` document, embedding the `ResolvedMovementFacts` and `ResolvedLightFacts` renderings it composes | `nomos_sim::effective_facts` composes the `CanonicalValue`; canonical entity-sorted bytes written to stdout by `nomos effective-facts` | none in-tree: derived read-only output, never re-read by the kernel and with no strict package reader; its first consumer binds identity and version | none: stdout only, never written into a run bundle or package, and outside the state-hash domain because it is derived | R1-2 Rust rendering-plan compilation; today `experiments/executable-gaol/compare-effective-facts.sh` | active R1-1 |
 
-No R1 identity has entered the accepted tree yet; the register is empty by
-design.
+One R1 identity has entered the accepted tree. `nomos.effective_facts@1` is the
+read-only effective-fact projection accepted as R1-1 under `RUNTIME.md` §5
+(issue #126, PR #130): given a strictly verified world package and a runtime
+state it composes, for every resolver subject, the effective movement
+disposition, cost, ordered reason claim IDs, and effective light. It resolves
+nothing itself — `nomos_sim::resolve_movement` and `nomos_sim::resolve_light`
+do that — and it is derived output, so it is persisted nowhere and enters no
+hash domain.
 
 ## How a row is added
 

--- a/docs/review/effective-facts-spike.md
+++ b/docs/review/effective-facts-spike.md
@@ -277,9 +277,28 @@ exit 1, not a silent byte difference. Byte identity is a property of a fixed
 
 ### CI: `verify` passes, `gate-k-evidence` cannot
 
-`verify` — the lane that runs the four proof commands — **passes** on this
-branch. `gate-k-evidence` **fails**, and that is the guard working correctly,
-not a defect to repair.
+Six of the seven PR checks pass. Exactly one fails, and it is the guard
+working correctly rather than a defect to repair:
+
+```console
+$ gh pr checks 130
+canonical schema ownership          fail   4s
+determinism (aarch64-release)       pass   27s
+determinism (cross-target)          pass   7s
+determinism (x86_64-debug)          pass   20s
+determinism (x86_64-release)        pass   32s
+measured budgets (x86_64 release)   pass   34s
+verify                              pass   4m0s
+```
+
+`verify` is the lane that runs the four proof commands. Worth noting for the
+R1 contract: the whole **determinism matrix passes**, including the
+cross-target comparison, so the byte-identity property R1-1 asks for holds
+across x86_64 debug, x86_64 release, and aarch64 release with this change in
+the tree — independent corroboration of the new test.
+
+The single failure is the `canonical schema ownership` job of
+`gate-k-evidence`.
 
 `docs/evaluation/gate-k-schema-ownership.sh` fails this branch for two
 independent reasons:

--- a/docs/review/effective-facts-spike.md
+++ b/docs/review/effective-facts-spike.md
@@ -275,6 +275,48 @@ failure is `EK0813 persisted state belongs to different simulation semantics`,
 exit 1, not a silent byte difference. Byte identity is a property of a fixed
 (source bytes, source path, state) triple, not of source bytes alone.
 
+### CI: `verify` passes, `gate-k-evidence` cannot
+
+`verify` — the lane that runs the four proof commands — **passes** on this
+branch. `gate-k-evidence` **fails**, and that is the guard working correctly,
+not a defect to repair.
+
+`docs/evaluation/gate-k-schema-ownership.sh` fails this branch for two
+independent reasons:
+
+1. **The frozen-source guard.** Its last check is
+   `git diff --name-only eb86f25f5084a5da83cdd4f26e42e68089367a11 -- crates`,
+   which must be empty. `origin/main` has a zero-file diff from that commit
+   under `crates/`, so *any* branch that edits kernel source fails this check
+   by construction — this spike, or any other. It is a freeze proof, not a
+   correctness test.
+2. **The schema-constructor count.** The script requires exactly 16 literal
+   `SchemaId::new("nomos.` constructors across `crates/*/src`, and exactly
+   twenty rows in `docs/evaluation/SCHEMA_OWNERSHIP.md`. Adding
+   `nomos.effective_facts@1` makes it 17 and would make it twenty-one. It fails
+   with `literal schema constructor set changed outside the reviewed
+   inventory`.
+
+Reason 2 is the acceptance-15 receipt requirement predicted in
+[Recorded caveat](#recorded-caveat-this-is-a-new-convention), arriving as a
+live check rather than a paper obligation. That is a good outcome: the
+inventory is enforced, not merely written down.
+
+**Neither was worked around.** Editing `SCHEMA_OWNERSHIP.md` to add a
+twenty-first row, or moving the freeze commit, would forge a source-review
+receipt that no human has given — exactly the "weakening a criterion merely
+because an implementation failed it" that `AGENTS.md` forbids, and a contract
+repair that requires an owner-authorized decision record. The spike therefore
+ships red on `gate-k-evidence` on purpose.
+
+For decision 0017 this sharpens item 1 below: promoting this command is not
+just a code change, it requires an owner-authorized re-review of the frozen
+twenty-identity inventory (to twenty-one), a new freeze commit, and the
+corresponding update to `gate-k-schema-ownership.sh`'s two hard-coded counts.
+If the owner instead chooses to drop the `schema` field, reason 2 disappears
+entirely and only the freeze-commit reason remains — which any kernel change
+must clear regardless.
+
 ### Build time
 
 Measured on this branch, worktree root, after `cargo clean`:
@@ -372,8 +414,11 @@ that reuses the existing resolvers exactly and deletes a 28-line shadow
 resolver. Three items need an owner decision before any of it is promoted:
 
 1. **Schema identity.** Whether `nomos.effective_facts@1` should exist at all,
-   given that no `nomos` stdout document currently carries one, and if so the
-   acceptance-15 source-review receipt row it requires.
+   given that no `nomos` stdout document currently carries one. If it should,
+   promotion needs an owner-authorized re-review of the frozen twenty-identity
+   inventory in `docs/evaluation/SCHEMA_OWNERSHIP.md`, a new freeze commit, and
+   the two hard-coded counts in `gate-k-schema-ownership.sh` moved from 16/20
+   to 17/21. See [CI](#ci-verify-passes-gate-k-evidence-cannot).
 2. **`machine_states` in the document.** Include it and the plan builder stops
    reading `final-state.json`; exclude it and the document stays purely
    composed facts.

--- a/docs/review/effective-facts-spike.md
+++ b/docs/review/effective-facts-spike.md
@@ -1,11 +1,12 @@
 ---
-title: Kernel effective-facts projection at a runtime state — spike design
-status: Spike design and prototype record; non-authoritative, not merged
+title: Kernel effective-facts projection at a runtime state — R1-1 design record
+status: R1-1 design record; slice under acceptance per RUNTIME.md §5
 date: 2026-08-25
 issue: 126
 branch: spike/issue-126-effective-facts
-informs: docs/decisions/0017 (first R1 target)
-applies_to: KERNEL.md sections 3, 8, 10; docs/movement.md; docs/runtime.md
+accepts_against: RUNTIME.md §5 R1-1 (revision 1, main b718192)
+blocked_on: issue #133 (R1 schema-ownership lane)
+applies_to: RUNTIME.md §5, §6; KERNEL.md sections 3, 8, 10; docs/movement.md; docs/runtime.md
 ---
 
 # Kernel effective-facts projection at a runtime state
@@ -23,6 +24,59 @@ at *this* state".
 
 This is a shadow resolver, and it has already drifted. See
 [Divergence found](#divergence-found-in-the-existing-shadow-resolver).
+
+## Acceptance mapping
+
+Every bullet of `RUNTIME.md` §5 R1-1 against the artifact that proves it. Test
+names are in `crates/nomos-cli/tests/effective_facts.rs`.
+
+| R1-1 criterion | Proved by | State |
+| --- | --- | --- |
+| Command is `nomos effective-facts <world/> --state <state.json>`, read-only, writes no artifact | `the_argument_grammar_is_exact` — exact grammar, `--help`, four usage rejections, missing-state environment failure | ✅ |
+| Mutates no input package or state file | `the_projection_mutates_no_input` — byte comparison of every package member and the state file | ✅ |
+| Adds no file to a run bundle | `the_projection_mutates_no_input` — asserts the run bundle is the six-file set before and byte-identical after | ✅ |
+| All resolution from `resolve_movement` / `resolve_light` | [Rust entry points reused](#rust-entry-points-reused) is the source-review receipt; `the_projection_agrees_with_explain_entity_at_the_initial_state` forces two surfaces to one answer | ✅ |
+| `activation_is_true` stays private | `crates/nomos-sim/src/resolver.rs:155` is unexported: `grep activation_is_true` over `nomos-sim/src/lib.rs` and `nomos-cli/src` returns zero hits | ✅ |
+| Schema identity `nomos.effective_facts@1` declared in `nomos-sim` | `the_projection_names_its_schema_world_and_state`; declared at `crates/nomos-sim/src/effective_facts.rs` | ✅ |
+| Canonical entity-sorted bytes | `every_resolver_subject_is_composed_at_the_supplied_state` asserts the exact canonical byte string of the `effective_facts` subtree at two states | ✅ |
+| Stays outside the state-hash domain | The command writes nothing, and the reported `state_hash` equals the input state's — asserted in `the_projection_names_its_schema_world_and_state` | ✅ |
+| Source-review receipt names the reused pair | [Rust entry points reused](#rust-entry-points-reused) in this record | ✅ |
+| Identity registered in `docs/evaluation/R1_SCHEMA_OWNERSHIP.md` as `nomos.effective_facts@1` / `nomos-sim` / `crates/nomos-sim/src/effective_facts.rs` | The R1 register created under issue #133 | ⏳ **pending #133** |
+| Not added to the frozen `docs/evaluation/SCHEMA_OWNERSHIP.md` | `git diff origin/main HEAD -- docs/evaluation/SCHEMA_OWNERSHIP.md` is empty | ✅ |
+| `compare-effective-facts.sh` reports `20 scenarios compared, 0 differences` | [Comparison](#comparison-against-the-four-areas-committed-plans), with `"cost": null` the only normalization | ✅ |
+| Byte identity across ten runs for the fixed triple | `the_same_world_and_state_produce_byte_identical_output`, with three anti-vacuous guards | ✅ |
+| A world compiled from a different path fails closed with `EK0813`, exit 1 | Same test's second half — compiles the identical source at `nested/gaol.nomos` and asserts exit 1 plus `EK0813` | ✅ |
+| Differing simulation semantics fail closed with `EK0813` | `a_state_from_another_world_is_rejected_rather_than_resolved` — exit 1, `status: "rejected"`, code `EK0813` | ✅ |
+| The four §6 kernel commands pass | [Proof commands](#proof-commands); `verify` lane green on PR #130 | ✅ |
+| No Gate K command, artifact, hash, or diagnostic changes | 214 workspace tests pass with every pre-existing suite unchanged; `determinism` matrix green on all three targets; no new diagnostic code added | ✅ |
+
+Must-nots:
+
+| Must not | Evidence | State |
+| --- | --- | --- |
+| Add a second implementation of activation evaluation or movement/light composition | This slice adds none and **deletes** `explanation.rs`'s byte-identical disposition renderer. One pre-existing duplicate is disclosed below | ⚠️ see note |
+| Add a third-party dependency to a kernel crate | `Cargo.lock` unchanged versus `origin/main`, still seven local entries; `cargo xtask boundary` clean | ✅ |
+| Edit `KERNEL.md` | `git diff origin/main HEAD -- KERNEL.md` is empty (`THESIS.md` likewise) | ✅ |
+| Write a seventh file into a run bundle | `the_projection_mutates_no_input` asserts the six-file set is unchanged | ✅ |
+
+### Disclosed pre-existing duplicate: `projected_activation_is_true`
+
+`crates/nomos-compiler/src/projection.rs:620` contains a second activation
+evaluator over the same `ProjectedActivation` tree, called from lines 125 and
+165 to compute the initial movement and light shape recorded in the stable v2
+IR at compile time. **It predates this slice** — it is on `origin/main` and this
+branch does not touch it — so R1-1's "must not *add*" is satisfied. But a
+reviewer checking "no second implementation of activation evaluation anywhere
+in the accepted tree" will find it, so it is disclosed here rather than left to
+be discovered.
+
+It is not reachable from the resolvers this slice uses, and the two cannot
+currently share code: `nomos-compiler` has no edge to `nomos-sim`, and section
+10 does not permit one. The boundary-legal unification is to move the evaluator
+down into `nomos-projection`, which already owns `ProjectedActivation` and which
+both crates may depend on. That is a separate change with its own evidence, not
+something to smuggle into an R1-1 slice; recommended to be filed as its own
+issue.
 
 ## Rust entry points reused
 
@@ -321,20 +375,23 @@ Reason 2 is the acceptance-15 receipt requirement predicted in
 live check rather than a paper obligation. That is a good outcome: the
 inventory is enforced, not merely written down.
 
-**Neither was worked around.** Editing `SCHEMA_OWNERSHIP.md` to add a
-twenty-first row, or moving the freeze commit, would forge a source-review
-receipt that no human has given — exactly the "weakening a criterion merely
-because an implementation failed it" that `AGENTS.md` forbids, and a contract
-repair that requires an owner-authorized decision record. The spike therefore
-ships red on `gate-k-evidence` on purpose.
+**Neither was worked around**, and the owner has now settled how they resolve.
+`docs/evaluation/SCHEMA_OWNERSHIP.md` **stays frozen**: it is Gate K evidence,
+and `nomos.effective_facts@1` is not a Gate K identity, so it is not added
+there and the twenty-row inventory is not reopened. The new identity registers
+instead in `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`, the R1 register created
+under issue #133, as `nomos.effective_facts@1` / `nomos-sim` /
+`crates/nomos-sim/src/effective_facts.rs`.
 
-For decision 0017 this sharpens item 1 below: promoting this command is not
-just a code change, it requires an owner-authorized re-review of the frozen
-twenty-identity inventory (to twenty-one), a new freeze commit, and the
-corresponding update to `gate-k-schema-ownership.sh`'s two hard-coded counts.
-If the owner instead chooses to drop the `schema` field, reason 2 disappears
-entirely and only the freeze-commit reason remains — which any kernel change
-must clear regardless.
+That branch also makes the script R1-aware, which is what clears reason 2. This
+branch does not touch either file: the register and the R1-aware script land
+under #133, and this lane stays red until it merges. Editing the frozen receipt
+here would forge a source-review receipt no human has given — the "weakening a
+criterion merely because an implementation failed it" that `AGENTS.md` forbids.
+
+Reason 1, the freeze-commit guard, is inherent to any accepted kernel change
+and is dispositioned by `RUNTIME.md` §3 option (a): kernel crates may gain
+read-only R1 surface.
 
 ### Build time
 
@@ -428,16 +485,15 @@ instead of `final-state.json`, which also gets the plan builder a
 
 ## Disposition
 
-The spike answers the sizing question: this is a small, boundary-clean change
-that reuses the existing resolvers exactly and deletes a 28-line shadow
-resolver. Three items need an owner decision before any of it is promoted:
+This began as a spike and is now the accepted R1-1 slice. It is a small,
+boundary-clean change that reuses the existing resolvers exactly and deletes a
+28-line shadow resolver. Of the three items that needed an owner decision, the
+first is settled and the other two remain open:
 
-1. **Schema identity.** Whether `nomos.effective_facts@1` should exist at all,
-   given that no `nomos` stdout document currently carries one. If it should,
-   promotion needs an owner-authorized re-review of the frozen twenty-identity
-   inventory in `docs/evaluation/SCHEMA_OWNERSHIP.md`, a new freeze commit, and
-   the two hard-coded counts in `gate-k-schema-ownership.sh` moved from 16/20
-   to 17/21. See [CI](#ci-verify-passes-gate-k-evidence-cannot).
+1. **Schema identity — settled.** `RUNTIME.md` §5 R1-1 requires
+   `nomos.effective_facts@1`, declared in `nomos-sim`. The Gate K receipt stays
+   frozen; the identity registers in `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`
+   under issue #133. See [CI](#ci-verify-passes-gate-k-evidence-cannot).
 2. **`machine_states` in the document.** Include it and the plan builder stops
    reading `final-state.json`; exclude it and the document stays purely
    composed facts.
@@ -445,4 +501,5 @@ resolver. Three items need an owner decision before any of it is promoted:
    unreachable today; if the gaol experiment consumes this command, they
    evaporate rather than needing a JavaScript fix.
 
-This branch is a spike. It is not to be merged before decision 0017.
+This branch is the R1-1 slice under `RUNTIME.md` §5. It is blocked on issue
+#133 for the schema-ownership lane and is not merged before that lands.

--- a/docs/review/effective-facts-spike.md
+++ b/docs/review/effective-facts-spike.md
@@ -139,6 +139,8 @@ Two consequences an owner must dispose of before this leaves spike status:
 
 ## Divergence found in the existing shadow resolver
 
+**These three divergences are now recorded as issue #132.**
+
 The JavaScript is not merely duplicated — it is **wrong by the documented law**
 in three ways the gaol corpus happens not to exercise. `docs/movement.md:43`
 says `Traversable` "contains the positive maximum active cost and the sorted
@@ -223,7 +225,7 @@ $ cargo clippy --workspace --all-targets --locked -- -D warnings
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.66s
 
 $ cargo test --workspace --locked
-total passed: 213  total failed: 0
+total passed: 214  total failed: 0
 
 $ cargo xtask boundary
 boundary: clean
@@ -234,24 +236,44 @@ boundary: clean
 EXIT=0
 ```
 
-The six new tests in `crates/nomos-cli/tests/effective_facts.rs`:
+The seven tests in `crates/nomos-cli/tests/effective_facts.rs`:
 
 ```console
-running 6 tests
-test every_resolver_subject_is_composed_at_the_supplied_state ... ok
-test the_projection_names_its_schema_world_and_state ... ok
-test the_projection_agrees_with_explain_entity_at_the_initial_state ... ok
-test the_projection_mutates_no_input ... ok
+running 7 tests
 test the_argument_grammar_is_exact ... ok
+test the_projection_mutates_no_input ... ok
+test the_projection_names_its_schema_world_and_state ... ok
+test every_resolver_subject_is_composed_at_the_supplied_state ... ok
 test a_state_from_another_world_is_rejected_rather_than_resolved ... ok
+test the_projection_agrees_with_explain_entity_at_the_initial_state ... ok
+test the_same_world_and_state_produce_byte_identical_output ... ok
 
-test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.41s
 ```
 
-`the_projection_agrees_with_explain_entity_at_the_initial_state` is the load-
-bearing one: it forces the new command and `explain-entity` — two independently
-composed surfaces — to produce identical dispositions and reasons for every
-subject. A future shadow resolver in either path breaks it.
+Two are load-bearing.
+
+`the_projection_agrees_with_explain_entity_at_the_initial_state` forces the new
+command and `explain-entity` — two independently composed surfaces — to produce
+identical dispositions and reasons for every subject. A future shadow resolver
+in either path breaks it.
+
+`the_same_world_and_state_produce_byte_identical_output` covers **`RUNTIME.md`
+§5 R1-1**: it invokes the command ten times against one package and one state
+and asserts all ten stdout byte strings are identical, then asserts a second
+freshly compiled copy of the same source produces the same bytes, so nothing
+about the package's location on disk reaches canonical output. Three guards
+keep it from passing vacuously — a length floor, a trailing-newline check, and
+a schema-substring check — and the assertion was mutation-checked: recompiling
+the copy from a *different* source path makes it fail.
+
+That last point is worth stating precisely, because it constrains what R1-1 can
+claim. "The same source" means the same bytes **at the same source path**. The
+path appears in claim source spans and is therefore inside the hash domain, so
+a state fails closed against a world compiled from elsewhere — the observed
+failure is `EK0813 persisted state belongs to different simulation semantics`,
+exit 1, not a silent byte difference. Byte identity is a property of a fixed
+(source bytes, source path, state) triple, not of source bytes alone.
 
 ### Build time
 
@@ -355,8 +377,8 @@ resolver. Three items need an owner decision before any of it is promoted:
 2. **`machine_states` in the document.** Include it and the plan builder stops
    reading `final-state.json`; exclude it and the document stays purely
    composed facts.
-3. **The three latent JavaScript bugs.** They are unreachable today. If the
-   gaol experiment is going to keep its own resolver for any period, they
-   should be filed; if it is going to consume this command, they evaporate.
+3. **The three latent JavaScript bugs.** Filed as issue #132. They are
+   unreachable today; if the gaol experiment consumes this command, they
+   evaporate rather than needing a JavaScript fix.
 
 This branch is a spike. It is not to be merged before decision 0017.

--- a/docs/review/effective-facts-spike.md
+++ b/docs/review/effective-facts-spike.md
@@ -1,11 +1,11 @@
 ---
 title: Kernel effective-facts projection at a runtime state — R1-1 design record
-status: R1-1 design record; slice under acceptance per RUNTIME.md §5
+status: R1-1 design record; acceptance complete per RUNTIME.md §5
 date: 2026-08-25
 issue: 126
 branch: spike/issue-126-effective-facts
-accepts_against: RUNTIME.md §5 R1-1 (revision 1, main b718192)
-blocked_on: issue #133 (R1 schema-ownership lane)
+accepts_against: RUNTIME.md §5 R1-1 (revision 1)
+registers: docs/evaluation/R1_SCHEMA_OWNERSHIP.md (nomos.effective_facts@1)
 applies_to: RUNTIME.md §5, §6; KERNEL.md sections 3, 8, 10; docs/movement.md; docs/runtime.md
 ---
 
@@ -41,7 +41,7 @@ names are in `crates/nomos-cli/tests/effective_facts.rs`.
 | Canonical entity-sorted bytes | `every_resolver_subject_is_composed_at_the_supplied_state` asserts the exact canonical byte string of the `effective_facts` subtree at two states | ✅ |
 | Stays outside the state-hash domain | The command writes nothing, and the reported `state_hash` equals the input state's — asserted in `the_projection_names_its_schema_world_and_state` | ✅ |
 | Source-review receipt names the reused pair | [Rust entry points reused](#rust-entry-points-reused) in this record | ✅ |
-| Identity registered in `docs/evaluation/R1_SCHEMA_OWNERSHIP.md` as `nomos.effective_facts@1` / `nomos-sim` / `crates/nomos-sim/src/effective_facts.rs` | The R1 register created under issue #133 | ⏳ **pending #133** |
+| Identity registered in `docs/evaluation/R1_SCHEMA_OWNERSHIP.md` as `nomos.effective_facts@1` / `nomos-sim` / `crates/nomos-sim/src/effective_facts.rs` | Registered; `docs/evaluation/r1-schema-ownership.sh` reports `schema_identities_r1 1` | ✅ |
 | Not added to the frozen `docs/evaluation/SCHEMA_OWNERSHIP.md` | `git diff origin/main HEAD -- docs/evaluation/SCHEMA_OWNERSHIP.md` is empty | ✅ |
 | `compare-effective-facts.sh` reports `20 scenarios compared, 0 differences` | [Comparison](#comparison-against-the-four-areas-committed-plans), with `"cost": null` the only normalization | ✅ |
 | Byte identity across ten runs for the fixed triple | `the_same_world_and_state_produce_byte_identical_output`, with three anti-vacuous guards | ✅ |
@@ -329,33 +329,43 @@ failure is `EK0813 persisted state belongs to different simulation semantics`,
 exit 1, not a silent byte difference. Byte identity is a property of a fixed
 (source bytes, source path, state) triple, not of source bytes alone.
 
-### CI: `verify` passes, `gate-k-evidence` cannot
+### CI: all lanes green
 
-Six of the seven PR checks pass. Exactly one fails, and it is the guard
-working correctly rather than a defect to repair:
+All seven PR checks pass:
 
 ```console
 $ gh pr checks 130
-canonical schema ownership          fail   4s
-determinism (aarch64-release)       pass   27s
-determinism (cross-target)          pass   7s
-determinism (x86_64-debug)          pass   20s
-determinism (x86_64-release)        pass   32s
-measured budgets (x86_64 release)   pass   34s
-verify                              pass   4m0s
+canonical schema ownership (R1)     pass   8s
+determinism (aarch64-release)       pass   28s
+determinism (cross-target)          pass   10s
+determinism (x86_64-debug)          pass   23s
+determinism (x86_64-release)        pass   33s
+measured budgets (x86_64 release)   pass   37s
+verify                              pass   3m36s
 ```
 
-`verify` is the lane that runs the four proof commands. Worth noting for the
-R1 contract: the whole **determinism matrix passes**, including the
-cross-target comparison, so the byte-identity property R1-1 asks for holds
-across x86_64 debug, x86_64 release, and aarch64 release with this change in
-the tree — independent corroboration of the new test.
+`verify` runs the four proof commands. Worth noting for the R1 contract: the
+whole **determinism matrix passes**, including the cross-target comparison, so
+the byte-identity property R1-1 asks for holds across x86_64 debug, x86_64
+release, and aarch64 release with this change in the tree — independent
+corroboration of the new test.
 
-The single failure is the `canonical schema ownership` job of
-`gate-k-evidence`.
+`r1 schema ownership` is the lane that replaced `gate-k-evidence`'s
+`canonical schema ownership` job as the pull-request gate. Locally:
 
-`docs/evaluation/gate-k-schema-ownership.sh` fails this branch for two
-independent reasons:
+```console
+$ docs/evaluation/r1-schema-ownership.sh
+R1_SCHEMA_OWNERSHIP PASS
+schema_identities_gate_k 20
+schema_identities_r1 1
+evidence_head 0089985...
+```
+
+#### Why the old lane could not pass, and what replaced it
+
+Before #135, `docs/evaluation/gate-k-schema-ownership.sh` failed this branch
+for two independent reasons, and both are recorded here because they shaped
+the design:
 
 1. **The frozen-source guard.** Its last check is
    `git diff --name-only eb86f25f5084a5da83cdd4f26e42e68089367a11 -- crates`,
@@ -375,23 +385,24 @@ Reason 2 is the acceptance-15 receipt requirement predicted in
 live check rather than a paper obligation. That is a good outcome: the
 inventory is enforced, not merely written down.
 
-**Neither was worked around**, and the owner has now settled how they resolve.
-`docs/evaluation/SCHEMA_OWNERSHIP.md` **stays frozen**: it is Gate K evidence,
-and `nomos.effective_facts@1` is not a Gate K identity, so it is not added
-there and the twenty-row inventory is not reopened. The new identity registers
-instead in `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`, the R1 register created
-under issue #133, as `nomos.effective_facts@1` / `nomos-sim` /
-`crates/nomos-sim/src/effective_facts.rs`.
+**Neither was worked around**, and both are now resolved — by an owner
+decision and a new lane, not by editing the receipt that failed.
 
-That branch also makes the script R1-aware, which is what clears reason 2. This
-branch does not touch either file: the register and the R1-aware script land
-under #133, and this lane stays red until it merges. Editing the frozen receipt
-here would forge a source-review receipt no human has given — the "weakening a
-criterion merely because an implementation failed it" that `AGENTS.md` forbids.
+`docs/evaluation/SCHEMA_OWNERSHIP.md` **stays frozen**: it is Gate K evidence
+at commit `eb86f25`, `nomos.effective_facts@1` is not a Gate K identity, and
+the twenty-row inventory is not reopened. The identity registers instead in
+`docs/evaluation/R1_SCHEMA_OWNERSHIP.md`, the additive R1 continuation created
+under issue #133 and merged as #135, as `nomos.effective_facts@1` / `nomos-sim`
+/ `crates/nomos-sim/src/effective_facts.rs`. An identity is owned if and only
+if it appears in exactly one of the two documents, which the new lane enforces
+by enumerating every declaration under `crates/*/src`.
 
-Reason 1, the freeze-commit guard, is inherent to any accepted kernel change
-and is dispositioned by `RUNTIME.md` §3 option (a): kernel crates may gain
-read-only R1 surface.
+Reason 1, the freeze-commit guard, is inherent to any accepted kernel change.
+`docs/evaluation/r1-schema-ownership.sh` drops it deliberately, because under
+`RUNTIME.md` §3 option (a) kernel crates may gain read-only R1 surface, so
+every R1 slice makes that diff non-empty; "no Gate K command, artifact, hash,
+or diagnostic changes" is instead proved by the `verify` and determinism
+lanes.
 
 ### Build time
 
@@ -490,10 +501,11 @@ boundary-clean change that reuses the existing resolvers exactly and deletes a
 28-line shadow resolver. Of the three items that needed an owner decision, the
 first is settled and the other two remain open:
 
-1. **Schema identity — settled.** `RUNTIME.md` §5 R1-1 requires
-   `nomos.effective_facts@1`, declared in `nomos-sim`. The Gate K receipt stays
-   frozen; the identity registers in `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`
-   under issue #133. See [CI](#ci-verify-passes-gate-k-evidence-cannot).
+1. **Schema identity — settled and registered.** `RUNTIME.md` §5 R1-1
+   requires `nomos.effective_facts@1`, declared in `nomos-sim`. The Gate K
+   receipt stays frozen; the identity is registered in
+   `docs/evaluation/R1_SCHEMA_OWNERSHIP.md` and the lane reports
+   `schema_identities_r1 1`. See [CI](#ci-all-lanes-green).
 2. **`machine_states` in the document.** Include it and the plan builder stops
    reading `final-state.json`; exclude it and the document stays purely
    composed facts.
@@ -501,5 +513,5 @@ first is settled and the other two remain open:
    unreachable today; if the gaol experiment consumes this command, they
    evaporate rather than needing a JavaScript fix.
 
-This branch is the R1-1 slice under `RUNTIME.md` §5. It is blocked on issue
-#133 for the schema-ownership lane and is not merged before that lands.
+This branch is the R1-1 slice under `RUNTIME.md` §5, with every acceptance
+bullet proved and the identity registered. Merge disposition is the owner's.

--- a/docs/review/effective-facts-spike.md
+++ b/docs/review/effective-facts-spike.md
@@ -1,0 +1,362 @@
+---
+title: Kernel effective-facts projection at a runtime state — spike design
+status: Spike design and prototype record; non-authoritative, not merged
+date: 2026-08-25
+issue: 126
+branch: spike/issue-126-effective-facts
+informs: docs/decisions/0017 (first R1 target)
+applies_to: KERNEL.md sections 3, 8, 10; docs/movement.md; docs/runtime.md
+---
+
+# Kernel effective-facts projection at a runtime state
+
+## Problem
+
+`experiments/executable-gaol/src/build-plan.mjs` lines 86–128 contain a
+JavaScript reimplementation of the kernel's effective-fact resolution:
+activation evaluation over machine states, movement blocker/cost composition,
+and light union. It exists only because no kernel command emits composed
+effective facts for a runtime state. `explain-entity` composes them for **one**
+entity at the **initial** state; `explain-transition` reports one entity at one
+tick. Neither answers "what are the effective facts for every resolver subject
+at *this* state".
+
+This is a shadow resolver, and it has already drifted. See
+[Divergence found](#divergence-found-in-the-existing-shadow-resolver).
+
+## Rust entry points reused
+
+Nothing new resolves anything. The whole prototype is composition and I/O
+around three existing functions.
+
+| Entry point | File | Signature |
+| --- | --- | --- |
+| `nomos_sim::resolve_movement` | `crates/nomos-sim/src/resolver.rs:21` | `fn(&SimulationPlan, &SimulationState) -> Result<ResolvedMovementFacts, Diagnostic>` |
+| `nomos_sim::resolve_light` | `crates/nomos-sim/src/resolver.rs:82` | `fn(&SimulationPlan, &SimulationState) -> Result<ResolvedLightFacts, Diagnostic>` |
+| `nomos_sim::PersistedRuntimeState::from_canonical_bytes` | `crates/nomos-sim/src/state_persistence.rs:46` | `fn(&[u8], &SimulationPlan) -> Result<Self, Diagnostic>` |
+| `nomos_cli::open_compiled_world` | `crates/nomos-cli/src/package.rs` | strict package verification, as used by `run`/`command`/`explain-*` |
+
+`activation_is_true` (`crates/nomos-sim/src/resolver.rs:155`) is the private
+recursion that evaluates `Always` / `StateEquals` / `Any` / `All` / `Not`. It
+stays private: it is reached only through the two public resolvers, which also
+enforce the projected law flags (`blockers_any_active`, `costs_maximum_active`,
+`blockers_before_cost`, `requires_connectivity`, non-zero `base_cost`,
+`union_active`, and the exact light consumer set). Calling the resolvers rather
+than the recursion is what keeps the plan guards in the path.
+
+`explain-entity` already demonstrates the exact call pair at
+`crates/nomos-cli/src/explanation.rs:25-27`; the spike generalises it from one
+entity at the initial state to every subject at a supplied state.
+
+## Chosen CLI shape
+
+```text
+nomos effective-facts <world/> --state <state.json>
+```
+
+Read-only, writes no artifact, mirrors `explain-entity`'s strict world
+verification and `command`'s `--state` loading. Rejected alternative: writing
+the same document into every `run`/`command` output directory.
+
+**Justification (one sentence, as asked):** the run bundle is a closed six-file
+set — `docs/runtime.md:156` says the publisher "writes exactly" those six files
+and the strict reopener fails closed on "missing/extra entries", and
+`nomos.run_result@1` binds five of them by digest — so a seventh artifact would
+break the run-bundle opener, every `RUN_FILES` assertion, and the committed
+`rendering-plan.example.json` byte comparisons, whereas a new read-only
+subcommand adds a command to a surface KERNEL.md section 8 never closes.
+
+Supporting detail: KERNEL.md section 8 lists eight invocations with no
+"exactly"/"only these" closure language, unlike section 5's "No unmanifested
+file or directory is permitted inside a verified package" or section 10's
+"fails closed when ... an undeclared workspace member appears". The three
+normative constraints in section 8 are all satisfied: structured JSON to
+stdout, the four exit codes, and no mutation of an input package or state file.
+
+## Output schema
+
+Proposed identity: **`nomos.effective_facts@1`**, declared in `nomos-sim`,
+whose section 10 charter is "runtime state, command transactions, replay,
+**effective-fact resolution**".
+
+```json
+{
+  "command": "effective-facts",
+  "effective_facts": {
+    "ground_movement": [
+      {"disposition": {"kind": "blocked", "reasons": ["north_gate.ward#blocks_ground"]},
+       "entity": "north_gate"},
+      {"disposition": {"cost": 3, "kind": "traversable",
+                       "reasons": ["flooded_section.region#traversal_cost_ground"]},
+       "entity": "flooded_section"}
+    ],
+    "light_emission": [
+      {"emitting": true, "entity": "brazier_02",
+       "reasons": ["brazier_02.emission#emits_light"]}
+    ]
+  },
+  "package_digest": "<hex>",
+  "runtime_semantics_digest": "<hex>",
+  "schema": {"name": "nomos.effective_facts", "version": 1},
+  "state_hash": "<hex>",
+  "status": "completed",
+  "subject_count": {"ground_movement": 3, "light_emission": 1},
+  "tick": 3
+}
+```
+
+Both arrays are entity-sorted by `keyed_array`, so the document is canonical
+and byte-stable. The per-subject shapes are **not** new: they are exactly what
+`ResolvedMovement::to_canonical` and `ResolvedLight::to_canonical` already emit
+inside `ResolvedMovementFacts::to_canonical_bytes` /
+`ResolvedLightFacts::to_canonical_bytes`. The spike promotes those two private
+methods to public `to_canonical()` accessors rather than writing a third
+spelling of the same object.
+
+### Recorded caveat: this is a new convention
+
+No `nomos` stdout document currently carries a schema identity. `explain-entity`
+and `explain-transition` emit bare canonical objects with `command`/`status` and
+a `schemas` sub-object naming their *inputs*; `docs/explanations.md:79` states
+SW-N "adds no persisted schema". Schema identities have so far been reserved for
+persisted artifacts.
+
+Giving this document one is deliberate and is the point of the issue: unlike the
+explanation commands, this output exists to be **consumed and persisted by a
+downstream tool** (today `build-plan.mjs`, tomorrow any renderer bridge), and a
+consumer needs a versioned identity to bind against. That is the difference
+between forensics for a human and an interface for a program.
+
+Two consequences an owner must dispose of before this leaves spike status:
+
+1. KERNEL.md section 10 and acceptance item 15 require an explicit
+   source-review receipt enumerating each canonical schema identity, its owner
+   crate, and its authoritative Rust type set. A new identity adds a row:
+   `nomos.effective_facts@1` / `nomos-sim` / the document builder in
+   `crates/nomos-sim/src/effective_facts.rs`.
+2. If the owner prefers zero new schema identities, dropping the `schema` field
+   is a two-line change and the rest of the design is unaffected.
+
+## Divergence found in the existing shadow resolver
+
+The JavaScript is not merely duplicated — it is **wrong by the documented law**
+in three ways the gaol corpus happens not to exercise. `docs/movement.md:43`
+says `Traversable` "contains the positive maximum active cost and the sorted
+claims that supplied that maximum; its reason list is empty only when the base
+cost applies."
+
+| # | `build-plan.mjs` | Kernel (`resolver.rs:56-70`) | Bites when |
+| --- | --- | --- | --- |
+| 1 | `reasons: active.map(c => c.id)` — every active claim | only active cost claims equal to the maximum | a subject has two cost claims at different values, or an active non-blocking claim alongside a cost claim |
+| 2 | `blockers = active.filter(c => c.capability === "blocks_ground")` — ignores `claim.value` | `MovementClaim::Blocker { value: true }` only | a `blocks_ground` claim with `value: false` is active; the JS blocks, the kernel does not |
+| 3 | `cost: Math.max(base_cost, ...costs)` | `max(active costs).unwrap_or(base_cost)` | an active cost is *below* `base_cost`; the JS floors at base, the kernel does not |
+
+Verified against all four compiled areas: every gaol subject is either a single
+`always`-active cost claim of `3` (> `base_cost` 1) or two `value: true`
+blockers, so none of the three conditions occurs. The twenty scenarios must
+therefore agree exactly — which is what makes them a usable equivalence
+baseline, not what makes the JavaScript correct.
+
+The JS also emits `"cost": null` on a blocked subject; the kernel's `Blocked`
+variant carries no `cost` key at all. That is a plan-builder presentation
+choice, not a semantic difference, and the comparison harness normalises it.
+
+## Estimate
+
+| File | Change | Lines |
+| --- | --- | --- |
+| `crates/nomos-projection/src/movement.rs` | publish `MovementDisposition::to_canonical`, `ResolvedMovement::to_canonical`, add `ResolvedMovementFacts::to_canonical` | +14 / −4 |
+| `crates/nomos-projection/src/light.rs` | publish `ResolvedLight::to_canonical`, add `ResolvedLightFacts::to_canonical` | +12 / −3 |
+| `crates/nomos-sim/src/effective_facts.rs` | **new** — document builder over the two resolvers | +75 |
+| `crates/nomos-sim/src/lib.rs` | `mod`/`pub use`/`effective_facts_schema()` + schema-uniqueness test row | +18 |
+| `crates/nomos-cli/src/command.rs` | help text, arg grammar, dispatch, loader (779 → ~840 lines, stays under the ~1,000 rule) | +58 |
+| `crates/nomos-cli/src/explanation.rs` | delete the duplicated `movement_to_canonical` | −19 |
+| `crates/nomos-cli/tests/effective_facts.rs` | **new** — in-tree fixture end-to-end test | +140 |
+| `experiments/executable-gaol/compare-effective-facts.sh` | **new** — twenty-scenario comparison harness | +60 |
+
+**Total ≈ 350 lines of Rust across 7 files, plus a 60-line quarantined shell
+harness.** Under the ~500-line ceiling, so the spike proceeds to prototype.
+No file crosses ~1,000 lines, so no decomposition is triggered. No new
+dependency edge: `nomos-sim -> nomos-projection` and
+`nomos-cli -> nomos-sim` are both already permitted by section 10.
+
+### Estimate versus actual
+
+The prototype was built. Production code landed close to the estimate; the test
+came in well over it, because the strongest available property — agreement with
+`explain-entity` — needed structural comparison rather than a byte assertion.
+
+| File | Estimated | Actual |
+| --- | --- | --- |
+| `crates/nomos-projection/src/movement.rs` | +14 / −4 | +22 / −5 |
+| `crates/nomos-projection/src/light.rs` | +12 / −3 | +15 / −4 |
+| `crates/nomos-sim/src/effective_facts.rs` | +75 | +87 |
+| `crates/nomos-sim/src/lib.rs` | +18 | +7 / −2 |
+| `crates/nomos-cli/src/command.rs` | +58 | +35 / −1 (779 → 812 lines) |
+| `crates/nomos-cli/src/explanation.rs` | −19 | +2 / −21 |
+| `crates/nomos-cli/tests/effective_facts.rs` | +140 | **+355** |
+| `experiments/executable-gaol/compare-effective-facts.sh` | +60 | +84 |
+| **Rust total** | **≈350** | **510 added / 33 removed = 477 net** |
+
+Non-test Rust is **122 net lines**. No file crosses ~1,000 lines
+(`command.rs` is the largest touched, at 812), so no decomposition was
+triggered. `cargo xtask boundary` stays clean: no new dependency edge was
+needed, because `nomos-sim -> nomos-projection` and `nomos-cli -> nomos-sim`
+already exist.
+
+## Proof commands
+
+All four pass on this branch. Run from the worktree root, Linux x86_64.
+
+```console
+$ cargo fmt --all -- --check
+EXIT=0
+
+$ cargo clippy --workspace --all-targets --locked -- -D warnings
+    Checking nomos-core v0.0.0 (.../crates/nomos-core)
+    Checking xtask v0.0.0 (.../xtask)
+    Checking nomos-projection v0.0.0 (.../crates/nomos-projection)
+    Checking nomos-schema v0.0.0 (.../crates/nomos-schema)
+    Checking nomos-sim v0.0.0 (.../crates/nomos-sim)
+    Checking nomos-compiler v0.0.0 (.../crates/nomos-compiler)
+    Checking nomos-cli v0.0.0 (.../crates/nomos-cli)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.66s
+
+$ cargo test --workspace --locked
+total passed: 213  total failed: 0
+
+$ cargo xtask boundary
+boundary: clean
+  kernel crates      nomos-core, nomos-schema, nomos-projection, nomos-compiler, nomos-sim, nomos-cli
+  tooling crates     xtask
+  rules checked      membership, permitted-edges, cycles, forbidden-dependency, tooling-isolation
+  forbidden entries  64 exact names, 8 prefixes
+EXIT=0
+```
+
+The six new tests in `crates/nomos-cli/tests/effective_facts.rs`:
+
+```console
+running 6 tests
+test every_resolver_subject_is_composed_at_the_supplied_state ... ok
+test the_projection_names_its_schema_world_and_state ... ok
+test the_projection_agrees_with_explain_entity_at_the_initial_state ... ok
+test the_projection_mutates_no_input ... ok
+test the_argument_grammar_is_exact ... ok
+test a_state_from_another_world_is_rejected_rather_than_resolved ... ok
+
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+`the_projection_agrees_with_explain_entity_at_the_initial_state` is the load-
+bearing one: it forces the new command and `explain-entity` — two independently
+composed surfaces — to produce identical dispositions and reasons for every
+subject. A future shadow resolver in either path breaks it.
+
+### Build time
+
+Measured on this branch, worktree root, after `cargo clean`:
+
+| Build | Wall clock | User |
+| --- | --- | --- |
+| `cargo build --workspace --locked` | **2.888 s** | 10.851 s |
+| `cargo build --workspace --locked --release` | **7.070 s** | 63.808 s |
+
+## Comparison against the four areas' committed plans
+
+`experiments/executable-gaol/compare-effective-facts.sh` compiles each area,
+executes all five scenarios, runs `nomos effective-facts` on each resulting
+`final-state.json`, and compares the result against the `movement`,
+`effectiveLight`, `tick`, and `stateHash` blocks of the **committed**
+`rendering-plan.example.json` — the artifact the JavaScript produced.
+
+```console
+$ experiments/executable-gaol/compare-effective-facts.sh
+OK    cistern-walk   01-baseline
+OK    cistern-walk   02-breached-warded
+OK    cistern-walk   03-breached-unsealed
+OK    cistern-walk   04-breached-unsealed-dark
+OK    cistern-walk   05-open-dark
+OK    ember-vault    01-baseline
+OK    ember-vault    02-breached-warded
+OK    ember-vault    03-breached-unsealed
+OK    ember-vault    04-breached-unsealed-dark
+OK    ember-vault    05-open-dark
+OK    north-gaol     01-baseline
+OK    north-gaol     02-breached-warded
+OK    north-gaol     03-breached-unsealed
+OK    north-gaol     04-breached-unsealed-dark
+OK    north-gaol     05-open-dark
+OK    ossuary-reach  01-baseline
+OK    ossuary-reach  02-breached-warded
+OK    ossuary-reach  03-breached-unsealed
+OK    ossuary-reach  04-breached-unsealed-dark
+OK    ossuary-reach  05-open-dark
+
+20 scenarios compared, 0 differences
+```
+
+**Twenty of twenty agree exactly.** The only normalisation the harness applies
+is the `"cost": null` spelling described above, and it is a presentation
+difference in the plan builder, not a resolved-fact difference.
+
+That agreement is a property of the corpus, not a vindication of the
+JavaScript. See [Divergence found](#divergence-found-in-the-existing-shadow-resolver):
+none of the three latent bugs is reachable from any current gaol world, so the
+twenty scenarios are a valid equivalence baseline and nothing more.
+
+## What becomes deletable in `build-plan.mjs`
+
+Once the plan builder consumes `nomos effective-facts` output per scenario,
+**28 lines of shadow resolver delete outright**:
+
+| Lines | What | Replaced by |
+| --- | --- | --- |
+| **86–95** | `activationIsActive` — the whole `always`/`state_equals`/`not`/`any`/`all` evaluator | `nomos_sim::resolver::activation_is_true`, reached through the two resolvers |
+| **111–122** | per-subject movement composition: blocker filter, cost max, disposition, reasons | `effective_facts.ground_movement` |
+| **123–128** | per-subject light union | `effective_facts.light_emission` |
+
+Two more lines change source rather than disappearing: **134** (`tick`) and
+**135** (`stateHash`) can read the kernel document's `tick` and `state_hash`
+instead of `final-state.json`, which also gets the plan builder a
+`package_digest` binding it does not currently carry.
+
+### What this cannot replace
+
+- **Lines 144–164, interaction-edge derivation.** The edges are built by
+  matching each scenario's `command-log.json` row prefix against every other
+  scenario's, then checking `input_state_hash` against the shorter run's final
+  state hash. That is a relation *between runs*, not an effective fact *at a
+  state*. This command answers one state at a time and cannot see the other
+  nineteen runs. Replacing it would need a different projection over a set of
+  run bundles — a separate piece of work, and arguably not a kernel concern at
+  all since the viewer's notion of an "interaction edge" is presentation.
+- **Lines 108–110, `machineStates`.** A plain read of `final-state.json`'s
+  machine list, used for the forensic overlay. Not resolution, so not a shadow
+  resolver — but it could be folded in by adding a `machine_states` field to
+  the document, which would let the plan builder stop opening `final-state.json`
+  entirely. Deliberately left out of the spike to keep the document to
+  *composed facts*; worth an owner opinion.
+- **Lines 17–29, `classify` / `navByEntity` / `lightEntities`.** These read the
+  resolver *tables* (a claim's `capability`, a subject's presence) to pick a
+  visual assembly per entity. Reading the projected table is legitimate; it is
+  evaluating activations against state that was not.
+- **Lines 103–107**, the run-status guard, still needs `result.json`.
+
+## Disposition
+
+The spike answers the sizing question: this is a small, boundary-clean change
+that reuses the existing resolvers exactly and deletes a 28-line shadow
+resolver. Three items need an owner decision before any of it is promoted:
+
+1. **Schema identity.** Whether `nomos.effective_facts@1` should exist at all,
+   given that no `nomos` stdout document currently carries one, and if so the
+   acceptance-15 source-review receipt row it requires.
+2. **`machine_states` in the document.** Include it and the plan builder stops
+   reading `final-state.json`; exclude it and the document stays purely
+   composed facts.
+3. **The three latent JavaScript bugs.** They are unreachable today. If the
+   gaol experiment is going to keep its own resolver for any period, they
+   should be filed; if it is going to consume this command, they evaporate.
+
+This branch is a spike. It is not to be merged before decision 0017.

--- a/experiments/executable-gaol/compare-effective-facts.sh
+++ b/experiments/executable-gaol/compare-effective-facts.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Spike harness for issue #126.
+#
+# Proves that `nomos effective-facts` equals what build-plan.mjs currently
+# computes in JavaScript, for all twenty gaol scenarios. Quarantined
+# experiment tooling: not Gate K evidence, not part of the accepted proof set.
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(git -C "$script_dir" rev-parse --show-toplevel)
+cd "$repo_root"
+
+out=target/effective-facts-comparison
+rm -rf "$out"
+mkdir -p "$out"
+cargo build --quiet --locked -p nomos-cli --bin nomos
+
+cat >"$out/compare.mjs" <<'NODE'
+import { readFileSync } from "node:fs";
+const [planPath, scenarioId, factsPath] = process.argv.slice(2);
+const plan = JSON.parse(readFileSync(planPath, "utf8"));
+const kernel = JSON.parse(readFileSync(factsPath, "utf8"));
+const scenario = plan.scenarios.find((entry) => entry.id === scenarioId);
+if (!scenario) throw new Error(`committed plan has no scenario ${scenarioId}`);
+
+const differences = [];
+const same = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+if (scenario.tick !== kernel.tick) differences.push(`tick ${scenario.tick} != ${kernel.tick}`);
+if (scenario.stateHash !== kernel.state_hash) differences.push("state hash differs");
+
+const movement = new Map(kernel.effective_facts.ground_movement.map((f) => [f.entity, f.disposition]));
+if (!same([...movement.keys()].sort(), Object.keys(scenario.movement).sort())) {
+  differences.push("movement subject sets differ");
+}
+for (const [entity, js] of Object.entries(scenario.movement)) {
+  const rust = movement.get(entity);
+  if (!rust) { differences.push(`${entity}: absent from kernel output`); continue; }
+  if (js.disposition !== rust.kind) differences.push(`${entity}: ${js.disposition} != ${rust.kind}`);
+  // build-plan.mjs spells a blocked subject's cost as null; the kernel's
+  // Blocked variant carries no cost key. Presentation, not semantics.
+  const jsCost = js.cost === null ? undefined : js.cost;
+  if (jsCost !== rust.cost) differences.push(`${entity}: cost ${js.cost} != ${rust.cost}`);
+  if (!same([...js.reasons].sort(), [...rust.reasons].sort())) {
+    differences.push(`${entity}: reasons ${JSON.stringify(js.reasons)} != ${JSON.stringify(rust.reasons)}`);
+  }
+}
+
+const light = new Map(kernel.effective_facts.light_emission.map((f) => [f.entity, f.emitting]));
+if (!same([...light.keys()].sort(), Object.keys(scenario.effectiveLight).sort())) {
+  differences.push("light subject sets differ");
+}
+for (const [entity, emitting] of Object.entries(scenario.effectiveLight)) {
+  if (light.get(entity) !== emitting) differences.push(`${entity}: light ${emitting} != ${light.get(entity)}`);
+}
+
+if (differences.length) { console.error(differences.join("; ")); process.exit(1); }
+NODE
+
+failures=0
+scenarios=0
+for area_dir in experiments/executable-gaol/areas/*/; do
+  area=$(basename "$area_dir")
+  target/debug/nomos compile "${area_dir}world.nomos" --out "$out/$area/world" >/dev/null
+  for script in "${area_dir}"scenarios/*.commands; do
+    name=$(basename "$script" .commands)
+    scenarios=$((scenarios + 1))
+    # 01-baseline is a declared rejection with zero committed commands.
+    target/debug/nomos run "$out/$area/world" --commands "$script" \
+      --out "$out/$area/runs/$name" >/dev/null || true
+    target/debug/nomos effective-facts "$out/$area/world" \
+      --state "$out/$area/runs/$name/final-state.json" \
+      >"$out/$area/runs/$name/effective-facts.json"
+    if node "$out/compare.mjs" "${area_dir}rendering-plan.example.json" "$name" \
+      "$out/$area/runs/$name/effective-facts.json"; then
+      printf 'OK    %-14s %s\n' "$area" "$name"
+    else
+      printf 'DIFF  %-14s %s\n' "$area" "$name"
+      failures=$((failures + 1))
+    fi
+  done
+done
+
+printf '\n%d scenarios compared, %d differences\n' "$scenarios" "$failures"
+exit $((failures > 0))


### PR DESCRIPTION
The **R1-1 slice** under `RUNTIME.md` §5, revision 1 (`main` `b718192`). Design record: `docs/review/effective-facts-spike.md`, which carries the full acceptance mapping.

Given a strictly verified world package and a runtime state, `nomos effective-facts <world/> --state <state.json>` emits a read-only composed effective movement disposition, cost, ordered reasons, and effective light for every resolver subject.

> **Unblocked.** #135 merged the R1 schema-ownership lane, and `nomos.effective_facts@1` is now registered. Every R1-1 acceptance bullet is proved and all checks pass. Merge disposition is the owner's.

## Why

`experiments/executable-gaol/src/build-plan.mjs` lines 86–128 reimplement activation evaluation and movement/light resolution in JavaScript, because no kernel command emitted composed effective facts for a runtime state. That shadow resolver has already drifted in three ways issue #132 now records — none reachable from any current gaol world, which is what makes the twenty scenarios a valid equivalence baseline and nothing more.

## Acceptance mapping

| R1-1 criterion | Proved by | State |
| --- | --- | --- |
| Command shape, read-only, writes no artifact | `the_argument_grammar_is_exact` | ✅ |
| Mutates no input package or state file | `the_projection_mutates_no_input` | ✅ |
| Adds no file to a run bundle | `the_projection_mutates_no_input` — six-file set asserted before and after | ✅ |
| All resolution from `resolve_movement` / `resolve_light` | Source-review receipt in the design record; `the_projection_agrees_with_explain_entity_at_the_initial_state` forces two surfaces to one answer | ✅ |
| `activation_is_true` stays private | `resolver.rs:155` unexported; zero hits outside its module | ✅ |
| Schema identity `nomos.effective_facts@1` in `nomos-sim` | `the_projection_names_its_schema_world_and_state` | ✅ |
| Canonical entity-sorted bytes | `every_resolver_subject_is_composed_at_the_supplied_state` — exact byte string at two states | ✅ |
| Stays outside the state-hash domain | Writes nothing; reported `state_hash` equals the input's | ✅ |
| Source-review receipt names the reused pair | Design record, "Rust entry points reused" | ✅ |
| Identity registered in `R1_SCHEMA_OWNERSHIP.md` | Registered as `nomos.effective_facts@1` / `nomos-sim` / `crates/nomos-sim/src/effective_facts.rs`; `r1-schema-ownership.sh` reports `schema_identities_r1 1` | ✅ |
| Not added to frozen `SCHEMA_OWNERSHIP.md` | `git diff origin/main HEAD` on that path is empty | ✅ |
| `compare-effective-facts.sh` reports 20/0 | `20 scenarios compared, 0 differences` | ✅ |
| Byte identity across ten runs for the fixed triple | `the_same_world_and_state_produce_byte_identical_output`, three anti-vacuous guards | ✅ |
| Different source path fails closed `EK0813`, exit 1 | Same test's second half | ✅ |
| Differing semantics fail closed `EK0813` | `a_state_from_another_world_is_rejected_rather_than_resolved` | ✅ |
| The four §6 kernel commands pass | `verify` lane green | ✅ |
| No Gate K command, artifact, hash, or diagnostic changes | 214 workspace tests, every pre-existing suite unchanged; determinism matrix green on three targets | ✅ |

Must-nots: no second implementation added — this slice **deletes** `explanation.rs`'s byte-identical disposition renderer; `Cargo.lock` unchanged at seven local entries; `KERNEL.md` and `THESIS.md` untouched; no seventh run-bundle file.

One pre-existing duplicate is **disclosed, not introduced**: `crates/nomos-compiler/src/projection.rs:620` holds a second activation evaluator for the compile-time initial-movement shape. It is on `main` and untouched here, so "must not *add*" holds — but a reviewer checking the must-not will find it. It cannot share code today (`nomos-compiler` has no edge to `nomos-sim`); the boundary-legal fix is to move the evaluator into `nomos-projection`, which both may depend on. Worth its own issue.

## Proof

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | exit 0, no warnings |
| `cargo test --workspace --locked` | **214 passed, 0 failed** |
| `cargo xtask boundary` | `boundary: clean` |

Clean build 2.888 s debug, 7.070 s release. A non-author rerun receipt of the four kernel commands and the comparison harness is already recorded on this PR.

## Deletable in `build-plan.mjs`

Lines **86–95** (the activation evaluator), **111–122** (movement composition), **123–128** (light union) — 28 lines. Lines **134–135** re-source `tick` and `state_hash` from the document.

Cannot replace: **144–164**, interaction-edge derivation from command-log prefixes — a relation *between runs*, not a fact *at a state*.

## CI

All checks pass, including the full determinism matrix and the new `r1 schema ownership` lane:

```console
$ docs/evaluation/r1-schema-ownership.sh
R1_SCHEMA_OWNERSHIP PASS
schema_identities_gate_k 20
schema_identities_r1 1
```

The Gate K receipt was never edited to get here. `docs/evaluation/SCHEMA_OWNERSHIP.md` stays frozen at `eb86f25`; the identity registers in the additive R1 continuation instead, and an identity is owned if and only if it appears in exactly one of the two documents.

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsZ5kuhqEodkjFWwdYu43F

