### PR TITLE
Enforce R1 workspace membership in the boundary check

### DIFF
--- a/RUNTIME.md
+++ b/RUNTIME.md
@@ -116,11 +116,17 @@ an R1 crate or the viewer parsing `.nomos` source, Canonical World IR, or
 compiler receipts; one canonical schema identity defined in more than one crate;
 an undeclared workspace member.
 
-Extending `cargo xtask boundary` to enforce R1 membership, edge direction,
-kernel purity, and viewer isolation is a target of the first R1 slice, not a
-present claim: today the checker knows only the Gate K list, and its
-`membership` rule fails closed on any new member until it is extended and this
-section names that member.
+### Declared R1 members
+
+None. `R1_CRATES` in `xtask/src/boundary.rs` mirrors this list, and `cargo xtask
+boundary` enforces it: a workspace member that is neither a kernel crate,
+declared tooling, nor named here fails its `membership` rule, and its report
+counts what is declared as `r1 members N`.
+
+The checker enforces R1 membership, edge direction, and kernel purity as of
+issue #137; the planted-violation tests in `xtask/src/planted.rs` prove each of
+those rules refuses. Viewer isolation is not enforced yet — no `apps/` member
+exists — and joins the checker with R1-4.
 
 ## 4. Dependency policy
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -87,7 +87,9 @@ cargo xtask boundary [--manifest-path <path/to/Cargo.toml>]
 
 Exit codes follow `KERNEL.md` section 8: `0` clean, `1` violations, `2` invalid
 usage, `3` environment failure. It reads `cargo metadata --all-features` and
-enforces five rules:
+enforces five rules over the six kernel crates, the declared tooling, and the R1
+crates `RUNTIME.md` section 3 declares — `R1_CRATES` in
+`xtask/src/boundary.rs`, empty today, reported as `r1 members N`:
 
 | Rule | What it refuses |
 | --- | --- |
@@ -96,9 +98,19 @@ enforces five rules:
 | `cycles` | a dependency cycle among kernel crates — including the dev-dependency cycles that Cargo itself allows |
 | `forbidden-dependency` | a renderer, windowing, engine, audio, networking, watcher, or hot-reload crate anywhere transitively reachable from a kernel crate |
 | `tooling-isolation` | `xtask` reaching a kernel crate |
+| `membership` (R1) | a workspace member that `RUNTIME.md` section 3 does not declare as an R1 crate; a declared R1 crate that has gone missing |
+| `permitted-edges` (R1) | an R1 crate depending on a workspace member that is neither a kernel crate nor another declared R1 crate; a kernel crate depending on an R1 crate is already refused by the row above |
+| `cycles` (R1) | a dependency cycle among the kernel and R1 crates, R1 to R1 included |
+
+`forbidden-dependency` stays scoped to what a kernel crate reaches: `RUNTIME.md`
+section 4, not this list, governs an R1 crate's third-party dependencies.
 
 `--manifest-path` points the check at a copy of the workspace, which is how the
 planted-violation receipt is produced without disturbing this one.
+`xtask/src/planted.rs` runs that pattern as tests: it copies the workspace to a
+temporary directory, plants `crates/nomos-render-plan` undeclared, declared,
+depended on by `nomos-sim`, and in a cycle with a second R1 crate, and asserts
+the rule each case must fail.
 
 ### What the checker cannot see
 

--- a/xtask/src/boundary.rs
+++ b/xtask/src/boundary.rs
@@ -5,15 +5,24 @@
 //! `Cargo.toml` files and hoping. This module reads `cargo metadata` and
 //! refuses:
 //!
-//! 1. a workspace member that is not a declared kernel crate or declared
-//!    tooling;
-//! 2. an edge between kernel crates that section 10 does not permit — including
+//! 1. a workspace member that is not a declared kernel crate, declared tooling,
+//!    or a declared R1 crate;
+//! 2. an edge between kernel crates that section 10 does not permit, or an edge
+//!    out of an R1 crate that `RUNTIME.md` section 3 does not permit — including
 //!    dev-dependency edges, because a dev-dependency also lets a crate name the
 //!    other's types;
-//! 3. a cycle among kernel crates;
+//! 3. a cycle among the kernel and R1 crates;
 //! 4. a forbidden dependency — renderer, windowing, audio, networking, watcher,
 //!    or hot-reload — anywhere reachable from a kernel crate, transitively;
 //! 5. tooling reaching into the kernel graph it checks.
+//!
+//! Rules 1 to 3 carry `RUNTIME.md` section 3 as well as section 10. An R1 crate
+//! may depend on any kernel crate and on another declared R1 crate; a kernel
+//! crate may not depend on an R1 crate, on `xtask`, or on `apps/`; and the
+//! declared list `R1_CRATES` is empty until a slice adds a member, so an
+//! undeclared member still fails rule 1. Rule 4 stays scoped to what a kernel
+//! crate reaches: R1's own third-party policy is `RUNTIME.md` section 4, not
+//! this list.
 //!
 //! Rule 5 is why the checker is a separate workspace member rather than a
 //! subcommand of `nomos-cli`. If it lived inside the kernel, its own JSON and
@@ -44,6 +53,13 @@ pub const KERNEL_CRATES: [&str; 6] = [
     "nomos-sim",
     "nomos-cli",
 ];
+
+/// The declared R1 members, mirroring the list in `RUNTIME.md` section 3.
+///
+/// Empty: no R1 crate exists yet. A crate joins this list in the change that
+/// creates it, and `RUNTIME.md` section 3 names the same members, or the
+/// `membership` rule refuses the workspace.
+pub const R1_CRATES: [&str; 0] = [];
 
 /// Workspace members that are tooling rather than kernel crates.
 pub const TOOLING_CRATES: [&str; 1] = ["xtask"];
@@ -264,21 +280,32 @@ impl Graph {
         seen.iter().map(|id| self.name_of(id)).collect()
     }
 
-    /// Runs every boundary rule, returning the violations found.
+    /// Runs every boundary rule against the declared lists, returning the
+    /// violations found.
     pub fn check(&self) -> Vec<Violation> {
+        self.check_with(&R1_CRATES)
+    }
+
+    /// Runs every boundary rule with an explicitly declared R1 member list.
+    ///
+    /// `check` passes `R1_CRATES`. The declaration is a parameter of the rules
+    /// so a planted-violation test can copy this workspace, plant a member, and
+    /// check it both undeclared and declared without a second copy of the rules.
+    pub fn check_with<'a>(&'a self, r1_crates: &[&'a str]) -> Vec<Violation> {
         let mut violations = Vec::new();
-        self.check_membership(&mut violations);
-        self.check_permitted_edges(&mut violations);
-        self.check_cycles(&mut violations);
+        self.check_membership(r1_crates, &mut violations);
+        self.check_permitted_edges(r1_crates, &mut violations);
+        self.check_cycles(r1_crates, &mut violations);
         self.check_forbidden(&mut violations);
         self.check_tooling_isolation(&mut violations);
         violations
     }
 
-    fn check_membership(&self, violations: &mut Vec<Violation>) {
+    fn check_membership(&self, r1_crates: &[&str], violations: &mut Vec<Violation>) {
         let declared: BTreeSet<&str> = KERNEL_CRATES
             .iter()
             .chain(TOOLING_CRATES.iter())
+            .chain(r1_crates.iter())
             .copied()
             .collect();
         for member in &self.members {
@@ -287,7 +314,7 @@ impl Graph {
                     "membership",
                     format!(
                         "workspace member `{member}` is neither a KERNEL.md section 10 kernel \
-                         crate nor declared tooling"
+                         crate, declared tooling, nor a RUNTIME.md section 3 declared R1 crate"
                     ),
                 ));
             }
@@ -300,9 +327,20 @@ impl Graph {
                 ));
             }
         }
+        for expected in r1_crates {
+            if !self.members.contains(*expected) {
+                violations.push(Violation::new(
+                    "membership",
+                    format!(
+                        "declared R1 crate `{expected}` is missing from the workspace; \
+                         RUNTIME.md section 3 declares a member that does not exist"
+                    ),
+                ));
+            }
+        }
     }
 
-    fn check_permitted_edges(&self, violations: &mut Vec<Violation>) {
+    fn check_permitted_edges(&self, r1_crates: &[&str], violations: &mut Vec<Violation>) {
         for (crate_name, permitted) in PERMITTED_EDGES {
             if !self.members.contains(crate_name) {
                 continue;
@@ -320,11 +358,39 @@ impl Graph {
                 }
             }
         }
+
+        // RUNTIME.md section 3: an R1 crate may depend on any kernel crate and
+        // on another declared R1 crate. Third-party edges are section 4's
+        // business, so only workspace members are judged here.
+        for crate_name in r1_crates {
+            if !self.members.contains(*crate_name) {
+                continue;
+            }
+            for dependency in self.direct_dependency_names(crate_name) {
+                if !self.members.contains(dependency)
+                    || KERNEL_CRATES.contains(&dependency)
+                    || r1_crates.contains(&dependency)
+                {
+                    continue;
+                }
+                violations.push(Violation::new(
+                    "permitted-edges",
+                    format!(
+                        "R1 crate `{crate_name}` depends on workspace member `{dependency}`, \
+                         which RUNTIME.md section 3 does not permit"
+                    ),
+                ));
+            }
+        }
     }
 
-    fn check_cycles(&self, violations: &mut Vec<Violation>) {
+    fn check_cycles<'a>(&'a self, r1_crates: &[&'a str], violations: &mut Vec<Violation>) {
         let mut state: BTreeMap<&str, u8> = BTreeMap::new();
-        for crate_name in KERNEL_CRATES {
+        for crate_name in KERNEL_CRATES
+            .iter()
+            .copied()
+            .chain(r1_crates.iter().copied())
+        {
             if self.members.contains(crate_name) {
                 self.visit(crate_name, &mut state, &mut Vec::new(), violations);
             }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,16 +4,19 @@
 //! cargo xtask boundary [--manifest-path <path/to/Cargo.toml>]
 //! ```
 //!
-//! `boundary` proves `KERNEL.md` section 10 (acceptance 15) against the
-//! resolved dependency graph. `--manifest-path` points the check at another
-//! workspace, which is how a planted-violation receipt is produced without
-//! disturbing this one.
+//! `boundary` proves `KERNEL.md` section 10 (acceptance 15) and the
+//! `RUNTIME.md` section 3 R1 workspace rules against the resolved dependency
+//! graph. `--manifest-path` points the check at another workspace, which is how
+//! a planted-violation receipt is produced without disturbing this one;
+//! `planted.rs` runs that pattern as tests.
 //!
 //! Exit codes follow `KERNEL.md` section 8: `0` clean, `1` violations found,
 //! `2` invalid usage, `3` the environment prevented the check.
 
 mod boundary;
 mod json;
+#[cfg(test)]
+mod planted;
 
 use std::process::{Command, ExitCode};
 
@@ -61,10 +64,11 @@ fn main() -> ExitCode {
 const HELP: &str = "\
 cargo xtask boundary [--manifest-path <path>]
 
-Proves the KERNEL.md section 10 dependency boundaries against the resolved
-cargo dependency graph: workspace membership, permitted edges, absence of
-cycles, forbidden renderer/windowing/audio/networking/watcher/hot-reload
-dependencies, and tooling isolation.
+Proves the KERNEL.md section 10 dependency boundaries and the RUNTIME.md
+section 3 R1 workspace rules against the resolved cargo dependency graph:
+workspace membership, permitted edges, absence of cycles, forbidden
+renderer/windowing/audio/networking/watcher/hot-reload dependencies, and
+tooling isolation.
 
 Exit codes: 0 clean, 1 violations, 2 invalid usage, 3 environment failure.";
 
@@ -73,7 +77,11 @@ fn usage(message: impl std::fmt::Display) -> ExitCode {
     ExitCode::from(2)
 }
 
-fn run_boundary(manifest_path: Option<&str>) -> ExitCode {
+/// Reads `cargo metadata` for a workspace and reduces it to a boundary graph.
+///
+/// The error is the operator-facing message for exit code 3: the environment
+/// prevented the check, rather than the check finding a violation.
+fn load_graph(manifest_path: Option<&str>) -> Result<Graph, String> {
     let mut command = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned()));
     command
         .arg("metadata")
@@ -86,33 +94,28 @@ fn run_boundary(manifest_path: Option<&str>) -> ExitCode {
         command.arg("--manifest-path").arg(path);
     }
 
-    let output = match command.output() {
-        Ok(output) => output,
-        Err(error) => {
-            eprintln!("error: could not run `cargo metadata`: {error}");
-            return ExitCode::from(3);
-        }
-    };
+    let output = command
+        .output()
+        .map_err(|error| format!("could not run `cargo metadata`: {error}"))?;
     if !output.status.success() {
-        eprintln!(
-            "error: `cargo metadata` failed:\n{}",
+        return Err(format!(
+            "`cargo metadata` failed:\n{}",
             String::from_utf8_lossy(&output.stderr)
-        );
-        return ExitCode::from(3);
+        ));
     }
 
     let text = String::from_utf8_lossy(&output.stdout);
-    let metadata = match json::parse(&text) {
-        Ok(value) => value,
-        Err(error) => {
-            eprintln!("error: could not read `cargo metadata` output: {error}");
-            return ExitCode::from(3);
-        }
-    };
-    let graph = match Graph::from_metadata(&metadata) {
+    let metadata = json::parse(&text)
+        .map_err(|error| format!("could not read `cargo metadata` output: {error}"))?;
+    Graph::from_metadata(&metadata)
+        .map_err(|error| format!("could not build the dependency graph: {error}"))
+}
+
+fn run_boundary(manifest_path: Option<&str>) -> ExitCode {
+    let graph = match load_graph(manifest_path) {
         Ok(graph) => graph,
         Err(error) => {
-            eprintln!("error: could not build the dependency graph: {error}");
+            eprintln!("error: {error}");
             return ExitCode::from(3);
         }
     };
@@ -128,6 +131,7 @@ fn run_boundary(manifest_path: Option<&str>) -> ExitCode {
             "  tooling crates     {}",
             boundary::TOOLING_CRATES.join(", ")
         );
+        println!("  r1 members         {}", boundary::R1_CRATES.len());
         println!(
             "  rules checked      membership, permitted-edges, cycles, \
              forbidden-dependency, tooling-isolation"
@@ -149,7 +153,10 @@ fn run_boundary(manifest_path: Option<&str>) -> ExitCode {
 
 #[cfg(test)]
 mod tests {
-    use crate::boundary::{FORBIDDEN_NAMES, KERNEL_CRATES, PERMITTED_EDGES, forbidden_category};
+    use crate::boundary::{
+        FORBIDDEN_NAMES, KERNEL_CRATES, PERMITTED_EDGES, R1_CRATES, TOOLING_CRATES,
+        forbidden_category,
+    };
 
     #[test]
     fn permitted_edges_cover_every_kernel_crate_exactly_once() {
@@ -187,6 +194,16 @@ mod tests {
                     "`{crate_name}` -> `{dependency}` would make the declared table cyclic"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn declared_r1_members_are_not_kernel_crates_or_tooling() {
+        // A name in two lists would make the rules disagree about which ones
+        // apply to it, so the declaration must partition the workspace.
+        for name in R1_CRATES {
+            assert!(!KERNEL_CRATES.contains(&name), "`{name}` is a kernel crate");
+            assert!(!TOOLING_CRATES.contains(&name), "`{name}` is tooling");
         }
     }
 

--- a/xtask/src/planted.rs
+++ b/xtask/src/planted.rs
@@ -1,0 +1,255 @@
+//! Planted workspace-boundary violations.
+//!
+//! `docs/workspace.md` records the receipt pattern: copy the workspace, plant
+//! the violation in the copy, and point `--manifest-path` at the copy, so the
+//! real workspace is never disturbed. These tests run that pattern in a
+//! temporary directory and read the violations directly, which is the same
+//! evidence the command prints, without a nested build.
+//!
+//! The planted cases are the ones `RUNTIME.md` section 3 turns into rules: an
+//! undeclared member, a declared member depending on a kernel crate, a kernel
+//! crate depending back, an R1 crate depending on an undeclared member, and a
+//! cycle between two R1 crates. Only the copy ever contains those crates; the
+//! accepted workspace declares none.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::boundary::{Graph, Violation};
+use crate::load_graph;
+
+/// The crate R1-2 will add for real (issue #139); planted here, never accepted.
+const RENDER_PLAN: &str = "nomos-render-plan";
+
+/// A second planted R1 member: a cycle needs two crates.
+const PRESENTATION: &str = "nomos-presentation";
+
+/// A copy of this workspace in a temporary directory, removed on drop.
+struct Planted {
+    root: PathBuf,
+}
+
+impl Planted {
+    /// Copies the manifests, the lock file, and the member trees — everything
+    /// `cargo metadata` reads — into a fresh temporary directory.
+    fn copy_of_the_workspace(label: &str) -> Self {
+        let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask is a member of the workspace it checks")
+            .to_owned();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("the clock is after the epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "nomos-boundary-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+
+        fs::create_dir_all(&root).expect("create the copy");
+        for file in ["Cargo.toml", "Cargo.lock"] {
+            fs::copy(source.join(file), root.join(file)).expect("copy a workspace file");
+        }
+        for tree in ["crates", "xtask"] {
+            copy_tree(&source.join(tree), &root.join(tree));
+        }
+        Self { root }
+    }
+
+    fn manifest(&self) -> PathBuf {
+        self.root.join("Cargo.toml")
+    }
+
+    /// Writes a new crate under `crates/` and adds it to the member list.
+    fn plant_crate(&self, name: &str, dependencies: &[&str], dev_dependencies: &[&str]) {
+        let directory = self.root.join("crates").join(name);
+        fs::create_dir_all(directory.join("src")).expect("create the planted crate");
+        let section = |names: &[&str]| {
+            names
+                .iter()
+                .map(|dependency| format!("{dependency} = {}\n", path_dependency(dependency)))
+                .collect::<String>()
+        };
+        let manifest = format!(
+            "[package]\n\
+             name = \"{name}\"\n\
+             version.workspace = true\n\
+             edition.workspace = true\n\
+             rust-version.workspace = true\n\
+             license.workspace = true\n\
+             repository.workspace = true\n\
+             publish.workspace = true\n\
+             \n\
+             [dependencies]\n{}\n[dev-dependencies]\n{}",
+            section(dependencies),
+            section(dev_dependencies),
+        );
+        fs::write(directory.join("Cargo.toml"), manifest).expect("write the planted manifest");
+        fs::write(
+            directory.join("src/lib.rs"),
+            "//! Planted by a boundary test. Never built.\n",
+        )
+        .expect("write the planted source");
+
+        let manifest = self.manifest();
+        let text = fs::read_to_string(&manifest).expect("read the copied workspace manifest");
+        let planted = text.replacen(
+            "    \"xtask\",\n",
+            &format!("    \"xtask\",\n    \"crates/{name}\",\n"),
+            1,
+        );
+        assert_ne!(
+            planted, text,
+            "the workspace manifest no longer lists `xtask` as a member"
+        );
+        fs::write(&manifest, planted).expect("write the copied workspace manifest");
+    }
+
+    /// Adds one dependency line to a member of the copy.
+    fn plant_dependency(&self, member: &str, dependency: &str) {
+        let manifest = self.root.join("crates").join(member).join("Cargo.toml");
+        let text = fs::read_to_string(&manifest).expect("read a member manifest");
+        let planted = text.replacen(
+            "[dependencies]\n",
+            &format!(
+                "[dependencies]\n{dependency} = {}\n",
+                path_dependency(dependency)
+            ),
+            1,
+        );
+        assert_ne!(
+            planted, text,
+            "`{member}` has no `[dependencies]` section to plant into"
+        );
+        fs::write(&manifest, planted).expect("write a member manifest");
+    }
+
+    fn graph(&self) -> Graph {
+        load_graph(Some(&self.manifest().to_string_lossy())).expect("read the planted metadata")
+    }
+}
+
+impl Drop for Planted {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+/// A path dependency on another crate of the copy, from a crate in `crates/`.
+fn path_dependency(name: &str) -> String {
+    format!("{{ path = \"../{name}\" }}")
+}
+
+fn copy_tree(from: &Path, to: &Path) {
+    fs::create_dir_all(to).expect("create a directory in the copy");
+    for entry in fs::read_dir(from).expect("read a directory of the workspace") {
+        let entry = entry.expect("read a directory entry");
+        // A build directory is not part of what `cargo metadata` reads.
+        if entry.file_name() == "target" {
+            continue;
+        }
+        let target = to.join(entry.file_name());
+        if entry.file_type().expect("read a file type").is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), &target).expect("copy a file");
+        }
+    }
+}
+
+/// Asserts one violation of `rule` and returns its detail, printed as a receipt.
+fn only_violation(violations: &[Violation], rule: &str) -> String {
+    assert_eq!(
+        violations.len(),
+        1,
+        "expected exactly one violation, found {violations:?}"
+    );
+    assert_eq!(violations[0].rule, rule, "{violations:?}");
+    println!("PLANTED [{}] {}", violations[0].rule, violations[0].detail);
+    violations[0].detail.clone()
+}
+
+#[test]
+fn an_undeclared_r1_member_fails_membership() {
+    let planted = Planted::copy_of_the_workspace("undeclared");
+    planted.plant_crate(RENDER_PLAN, &["nomos-sim"], &[]);
+
+    // `check` uses the shipped `R1_CRATES`, which declares nothing.
+    let detail = only_violation(&planted.graph().check(), "membership");
+    assert!(detail.contains(&format!("`{RENDER_PLAN}`")), "{detail}");
+}
+
+#[test]
+fn a_declared_r1_member_may_depend_on_a_kernel_crate() {
+    let planted = Planted::copy_of_the_workspace("declared");
+    planted.plant_crate(RENDER_PLAN, &["nomos-sim"], &[]);
+
+    let violations = planted.graph().check_with(&[RENDER_PLAN]);
+    println!(
+        "PLANTED [declared] {RENDER_PLAN} -> nomos-sim: {} violation(s)",
+        violations.len()
+    );
+    assert!(violations.is_empty(), "{violations:?}");
+}
+
+#[test]
+fn a_kernel_crate_depending_on_an_r1_member_fails_permitted_edges() {
+    let planted = Planted::copy_of_the_workspace("kernel-edge");
+    planted.plant_crate(RENDER_PLAN, &[], &[]);
+    planted.plant_dependency("nomos-sim", RENDER_PLAN);
+
+    let detail = only_violation(
+        &planted.graph().check_with(&[RENDER_PLAN]),
+        "permitted-edges",
+    );
+    assert!(
+        detail.contains(&format!("`nomos-sim` depends on `{RENDER_PLAN}`")),
+        "{detail}"
+    );
+}
+
+#[test]
+fn an_r1_member_depending_on_an_undeclared_member_fails_twice() {
+    // The only workspace members an R1 crate can reach that are neither kernel
+    // crates nor declared R1 crates are undeclared ones and, once R1-4 lands,
+    // `apps/`: Cargo drops a dependency on `xtask`, which has no lib target.
+    let planted = Planted::copy_of_the_workspace("undeclared-peer");
+    planted.plant_crate(RENDER_PLAN, &[PRESENTATION], &[]);
+    planted.plant_crate(PRESENTATION, &[], &[]);
+
+    let violations = planted.graph().check_with(&[RENDER_PLAN]);
+    for violation in &violations {
+        println!("PLANTED [{}] {}", violation.rule, violation.detail);
+    }
+    let rules: Vec<&str> = violations.iter().map(|violation| violation.rule).collect();
+    assert_eq!(rules, ["membership", "permitted-edges"], "{violations:?}");
+    assert!(
+        violations[0].detail.contains(PRESENTATION),
+        "{violations:?}"
+    );
+    assert!(
+        violations[1].detail.contains(&format!(
+            "R1 crate `{RENDER_PLAN}` depends on workspace member `{PRESENTATION}`"
+        )),
+        "{violations:?}"
+    );
+}
+
+#[test]
+fn a_cycle_between_two_r1_members_fails_cycles() {
+    let planted = Planted::copy_of_the_workspace("r1-cycle");
+    // Cargo refuses a cycle of normal dependencies outright, so the return edge
+    // is a dev-dependency — the kind Cargo allows and this rule still refuses.
+    planted.plant_crate(RENDER_PLAN, &[PRESENTATION], &[]);
+    planted.plant_crate(PRESENTATION, &[], &[RENDER_PLAN]);
+
+    let detail = only_violation(
+        &planted.graph().check_with(&[RENDER_PLAN, PRESENTATION]),
+        "cycles",
+    );
+    assert!(
+        detail.contains(&format!("{RENDER_PLAN} -> {PRESENTATION} -> {RENDER_PLAN}")),
+        "{detail}"
+    );
+}


### PR DESCRIPTION
Issue #137. `cargo xtask boundary` knew only the Gate K lists, so its
`membership` rule failed closed on any new workspace member. This slice teaches
it `RUNTIME.md` section 3 without loosening anything section 10 already refused.
No crate is added; nothing under `crates/` changes. **Unblocks #139.**

## What changed

`xtask/src/boundary.rs`

- `R1_CRATES: [&str; 0] = []` declared beside `KERNEL_CRATES`, mirrored by the
  new "Declared R1 members" list in `RUNTIME.md` section 3.
- `check()` calls `check_with(&R1_CRATES)`. The declared list is a parameter of
  the rules so a planted test can check one copied workspace both undeclared and
  declared, without a second copy of the rules.
- `membership` admits a declared R1 crate, and refuses a declared R1 crate that
  is missing from the workspace.
- `permitted-edges` keeps the kernel table byte-for-byte and adds an R1 pass: an
  R1 crate may depend on any kernel crate and any other declared R1 crate; every
  other workspace-member edge out of one is a violation. A kernel crate
  depending on an R1 crate, `xtask`, or `apps/` is still refused by the rule
  that already refused it. Dev-dependency edges count, as today.
- `cycles` roots the walk at the kernel crates *and* the declared R1 crates, so
  an R1↔R1 cycle that no kernel crate reaches is still found.
- `forbidden-dependency` and `tooling-isolation` are unchanged: an R1 crate's
  third-party policy is `RUNTIME.md` section 4, not the kernel's forbidden list.

`xtask/src/main.rs` — metadata loading split into `load_graph` so the planted
tests reuse the real path; report gains `r1 members N`; help text names the R1
rules.

`xtask/src/planted.rs` (new) — the receipt pattern `docs/workspace.md` records,
run as tests: copy the workspace to a temporary directory, plant the violation
in the copy, read the violations, delete the copy.

Docs — `RUNTIME.md` section 3 gains the "Declared R1 members" list (empty) and
the sentence that the checker enforces it; the stale "not a present claim"
paragraph is replaced by what is and is not enforced (viewer isolation is not:
no `apps/` member exists). `docs/workspace.md` gains the three R1 rule rows and
a pointer to the planted tests.

## Evidence

Planted cases, `cargo test -p xtask --locked -- --nocapture --test-threads=1 planted::`:

```console
running 5 tests
test planted::a_cycle_between_two_r1_members_fails_cycles ... PLANTED [cycles] dependency cycle: nomos-render-plan -> nomos-presentation -> nomos-render-plan
ok
test planted::a_declared_r1_member_may_depend_on_a_kernel_crate ... PLANTED [declared] nomos-render-plan -> nomos-sim: 0 violation(s)
ok
test planted::a_kernel_crate_depending_on_an_r1_member_fails_permitted_edges ... PLANTED [permitted-edges] `nomos-sim` depends on `nomos-render-plan`, which section 10 does not permit
ok
test planted::an_r1_member_depending_on_an_undeclared_member_fails_twice ... PLANTED [membership] workspace member `nomos-presentation` is neither a KERNEL.md section 10 kernel crate, declared tooling, nor a RUNTIME.md section 3 declared R1 crate
PLANTED [permitted-edges] R1 crate `nomos-render-plan` depends on workspace member `nomos-presentation`, which RUNTIME.md section 3 does not permit
ok
test planted::an_undeclared_r1_member_fails_membership ... PLANTED [membership] workspace member `nomos-render-plan` is neither a KERNEL.md section 10 kernel crate, declared tooling, nor a RUNTIME.md section 3 declared R1 crate
ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.19s
```

The acceptance's four cases are the first, second, third, and fifth. The fourth
is the only other way an R1 crate can reach a member that is neither a kernel
crate nor a declared R1 crate today: Cargo drops a dependency on `xtask`
outright — it has no lib target — so that edge cannot exist in the graph, and
`apps/` has no member yet.

Proof commands, from the worktree root, Linux x86_64:

```console
$ cargo fmt --all -- --check
EXIT=0

$ cargo clippy --workspace --all-targets --locked -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.51s
EXIT=0

$ cargo test --workspace --locked
total passed: 220  total failed: 0

$ cargo xtask boundary
boundary: clean
  kernel crates      nomos-core, nomos-schema, nomos-projection, nomos-compiler, nomos-sim, nomos-cli
  tooling crates     xtask
  r1 members         0
  rules checked      membership, permitted-edges, cycles, forbidden-dependency, tooling-isolation
  forbidden entries  64 exact names, 8 prefixes
EXIT=0
```

Determinism lane unchanged — no file under `crates/` is touched, and the frozen
canonicalization regression is byte-identical debug against release:

```console
HASH hash_domain_fixture 40a8cabed5fd8a036132acf952bdc0a0917199fca6c24e45e941e1227c0dfb12
HASH hash_domain_fixture_empty_object 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
HASH hash_domain_fixture_entities 34c3f09f03cac779162de81789d4d842866c5219b12a76dd28d7ed4f3cfc6613
$ diff -u debug.txt release.txt
EXIT=0
```

## Limits

- The declared list is empty, so `membership` still fails closed on every new
  member; #139 adds `crates/nomos-render-plan` to `R1_CRATES` and to
  `RUNTIME.md` section 3 in the change that creates it.
- Viewer isolation (`apps/`) is not enforced; there is no `apps/` member. It
  joins the checker with R1-4.
- The planted tests read the violations in-process rather than shelling out to
  the built binary; the command's own exit codes are unchanged and covered by
  the existing CLI exit-code test.
- Not green until a non-author rerun is recorded per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsZ5kuhqEodkjFWwdYu43F
