### PR TITLE
Add the entity-catalog projection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ AI-authored areas can share one coherent visual grammar.
   accepts. **R1-1, the kernel effective-facts projection (`nomos
   effective-facts`, PR #130), is the first accepted R1 slice**: it meets every
   `RUNTIME.md` §5 R1-1 criterion, and its identity `nomos.effective_facts@1` is
-  the first row of the R1 register `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`
+  the first row of the R1 register `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`.
+  `nomos entity-catalog <world/>` (issue #138) adds the register's second row,
+  `nomos.entity_catalog@1`: the read-only entity kind, capability set, binding,
+  machines, and resolver claims R1-2 needs in order to classify doors, water,
+  and lights from typed declarations instead of naming conventions
 - **Contract revision:** 7, owner-authorized in decision 0009
 - **Cold-agent protocol revision:** 6, owner-authorized in decision 0015;
   revision-6 packet, boundary, record, adjudication, and finalization tooling is

--- a/RUNTIME.md
+++ b/RUNTIME.md
@@ -91,6 +91,9 @@ command, artifact, hash, or diagnostic.
 | `nomos-sim` | `effective_facts.rs`, the `nomos.effective_facts@1` document builder over the existing resolvers | R1-1 |
 | `nomos-projection` | public canonical accessors on the resolved movement and light fact types | R1-1 |
 | `nomos-cli` | the `effective-facts` subcommand | R1-1 |
+| `nomos-compiler` | `entity_catalog.rs`, the `nomos.entity_catalog@1` document builder over the decoded stable World IR and the four verified plans | #138, an R1-2 input |
+| `nomos-cli` | the `entity-catalog` subcommand | #138, an R1-2 input |
+| `nomos-core` | `SourceSpan::to_canonical`, the one rendering of a source span; it replaces five byte-identical private copies in `nomos-core`, `nomos-schema`, `nomos-projection`, and `nomos-cli` | #138, an R1-2 input |
 
 The workspace layout under R1:
 

--- a/crates/nomos-cli/src/command.rs
+++ b/crates/nomos-cli/src/command.rs
@@ -17,7 +17,7 @@ use crate::{
     require_available_run_output, write_run_bundle,
 };
 
-const ROOT_HELP: &str = "Nomos Gate K semantic runtime\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos migrate <v1-world/> --to 2 --out <new-v2-world/>\n  nomos run <world/> --commands <commands> --out <new-run/>\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n  nomos replay <world/> --log <replay> --out <new-run/>\n  nomos explain-entity <world/> <entity>\n  nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n  nomos effective-facts <world/> --state <state.json>\n  nomos --help\n";
+const ROOT_HELP: &str = "Nomos Gate K semantic runtime\n\nUsage:\n  nomos validate <source.nomos>\n  nomos compile <source.nomos> --out <new.world/>\n  nomos inspect <world/>\n  nomos migrate <v1-world/> --to 2 --out <new-v2-world/>\n  nomos run <world/> --commands <commands> --out <new-run/>\n  nomos command <world/> --state <state.json> \"<command>\" --out <new-run/>\n  nomos replay <world/> --log <replay> --out <new-run/>\n  nomos explain-entity <world/> <entity>\n  nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n  nomos effective-facts <world/> --state <state.json>\n  nomos entity-catalog <world/>\n  nomos --help\n";
 const VALIDATE_HELP: &str = "Validate one Nomos source file without writing artifacts.\n\nUsage:\n  nomos validate <source.nomos>\n";
 const COMPILE_HELP: &str = "Compile one Nomos source file into a new immutable world package.\n\nUsage:\n  nomos compile <source.nomos> --out <new.world/>\n";
 const INSPECT_HELP: &str =
@@ -29,6 +29,7 @@ const REPLAY_HELP: &str = "Reproduce one strict replay log against a compiled wo
 const EXPLAIN_ENTITY_HELP: &str = "Explain one entity from a strictly verified compiled world.\n\nUsage:\n  nomos explain-entity <world/> <entity>\n";
 const EXPLAIN_TRANSITION_HELP: &str = "Explain one committed transition after strictly verifying its world and re-executing its run.\n\nUsage:\n  nomos explain-transition <run/> <entity> --tick <tick> --world <world/>\n";
 const EFFECTIVE_FACTS_HELP: &str = "Project every resolver subject's effective facts at one verified runtime state.\n\nUsage:\n  nomos effective-facts <world/> --state <state.json>\n";
+const ENTITY_CATALOG_HELP: &str = "Catalogue every entity of a strictly verified compiled world.\n\nUsage:\n  nomos entity-catalog <world/>\n";
 
 /// One completed command-line execution, including its exact stdout bytes.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -98,6 +99,9 @@ enum Command {
     EffectiveFacts {
         package: String,
         state: String,
+    },
+    EntityCatalog {
+        package: String,
     },
 }
 
@@ -252,6 +256,14 @@ fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Command, Diagnostic
                 state: state.clone(),
             }
         }
+        [name, help] if name == "entity-catalog" && help == "--help" => {
+            Command::Help(ENTITY_CATALOG_HELP)
+        }
+        [name, package] if name == "entity-catalog" && !is_option(package) => {
+            Command::EntityCatalog {
+                package: package.clone(),
+            }
+        }
         [name, help] if name == "command" && help == "--help" => Command::Help(COMMAND_HELP),
         [
             name,
@@ -329,6 +341,9 @@ fn execute_command(command: Command) -> Execution {
         } => explain_transition(&run, &entity, tick, &package).map(RuntimeOutcome::completed),
         Command::EffectiveFacts { package, state } => {
             effective_facts(&package, &state).map(RuntimeOutcome::completed)
+        }
+        Command::EntityCatalog { package } => {
+            entity_catalog(&package).map(RuntimeOutcome::completed)
         }
     };
     match result {
@@ -591,6 +606,12 @@ fn effective_facts(package: &str, state: &str) -> Result<CanonicalValue, Diagnos
         world.simulation(),
     )?;
     nomos_sim::effective_facts(world.simulation(), &state, world.package_digest())
+}
+
+fn entity_catalog(package: &str) -> Result<CanonicalValue, Diagnostic> {
+    let package_path = relative_filesystem_path(package)?;
+    let world = open_compiled_world(&package_path)?;
+    nomos_compiler::entity_catalog(&world)
 }
 
 fn publish_execution(

--- a/crates/nomos-cli/src/explanation.rs
+++ b/crates/nomos-cli/src/explanation.rs
@@ -155,9 +155,6 @@ pub(crate) fn transition_report(
         .difference(&after)
         .map(StableId::to_canonical)
         .collect();
-    let span = entity_record.source_span();
-    let (byte_start, byte_end) = span.byte_range();
-    let (line, column) = span.position();
 
     Ok(CanonicalValue::object_declared([
         ("claims_added", CanonicalValue::Array(claims_added)),
@@ -175,16 +172,7 @@ pub(crate) fn transition_report(
             "run_result_digest",
             CanonicalValue::text(run.result_digest().to_hex()),
         ),
-        (
-            "source_mapping",
-            CanonicalValue::object_declared([
-                ("byte_end", CanonicalValue::Uint(u64::from(byte_end))),
-                ("byte_start", CanonicalValue::Uint(u64::from(byte_start))),
-                ("column", CanonicalValue::Uint(u64::from(column))),
-                ("line", CanonicalValue::Uint(u64::from(line))),
-                ("path", CanonicalValue::text(span.path().as_str())),
-            ]),
-        ),
+        ("source_mapping", entity_record.source_span().to_canonical()),
         ("status", CanonicalValue::text("completed")),
         ("tick", CanonicalValue::Uint(tick)),
     ]))

--- a/crates/nomos-cli/tests/entity_catalog.rs
+++ b/crates/nomos-cli/tests/entity_catalog.rs
@@ -1,0 +1,523 @@
+//! Acceptance proof for the read-only entity-catalog projection (issue #138).
+//!
+//! The design record is `docs/review/entity-catalog.md`, which maps each
+//! acceptance bullet to the test below that proves it.
+//!
+//! The point of the command is that no downstream tool has to infer an entity's
+//! kind from a naming convention — `build-plan.mjs:25` classifies doors by
+//! `machine.endsWith(".access")` only because no kernel command says what an
+//! entity *is*. These tests hold the catalog to the two facts that removes:
+//! every entity's `primitive` is its source declaration, and its `capabilities`
+//! are World IR's `expansion.capabilities`. The source is read *here*, to know
+//! what to expect; the command itself never opens it, which
+//! `the_catalog_reads_no_source` proves by deleting it.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use nomos_core::canonical::read::parse_canonical;
+use nomos_core::{CanonicalValue, FieldName};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+const GAOL: &str = include_str!("../../../fixtures/gaol.nomos");
+const COMMANDS: &[u8] = include_bytes!("../../../fixtures/gaol.commands");
+
+/// The fixture plus the four committed gaol areas, which the acceptance
+/// criterion names explicitly.
+const WORLDS: [(&str, &str); 5] = [
+    ("fixtures/gaol.nomos", GAOL),
+    (
+        "experiments/executable-gaol/areas/cistern-walk/world.nomos",
+        include_str!("../../../experiments/executable-gaol/areas/cistern-walk/world.nomos"),
+    ),
+    (
+        "experiments/executable-gaol/areas/ember-vault/world.nomos",
+        include_str!("../../../experiments/executable-gaol/areas/ember-vault/world.nomos"),
+    ),
+    (
+        "experiments/executable-gaol/areas/north-gaol/world.nomos",
+        include_str!("../../../experiments/executable-gaol/areas/north-gaol/world.nomos"),
+    ),
+    (
+        "experiments/executable-gaol/areas/ossuary-reach/world.nomos",
+        include_str!("../../../experiments/executable-gaol/areas/ossuary-reach/world.nomos"),
+    ),
+];
+
+fn fresh_workspace(label: &str) -> PathBuf {
+    let index = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+        .join("entity-catalog")
+        .join(format!("{}-{nonce}-{label}-{index}", std::process::id()));
+    fs::create_dir_all(&root).unwrap();
+    root
+}
+
+fn run<I, S>(cwd: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new(env!("CARGO_BIN_EXE_nomos"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap()
+}
+
+fn assert_exit(output: &Output, expected: i32) {
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(output.stderr.is_empty());
+}
+
+fn canonical_stdout(output: &Output) -> CanonicalValue {
+    assert_eq!(output.stdout.last(), Some(&b'\n'));
+    parse_canonical(&output.stdout[..output.stdout.len() - 1]).unwrap()
+}
+
+fn object(value: &CanonicalValue) -> &BTreeMap<FieldName, CanonicalValue> {
+    let CanonicalValue::Object(fields) = value else {
+        panic!("expected canonical object")
+    };
+    fields
+}
+
+fn field<'a>(value: &'a CanonicalValue, name: &'static str) -> &'a CanonicalValue {
+    object(value)
+        .get(&FieldName::declared(name))
+        .unwrap_or_else(|| panic!("missing field `{name}`"))
+}
+
+fn array(value: &CanonicalValue) -> &[CanonicalValue] {
+    let CanonicalValue::Array(items) = value else {
+        panic!("expected canonical array")
+    };
+    items
+}
+
+fn text(value: &CanonicalValue) -> &str {
+    let CanonicalValue::Text(inner) = value else {
+        panic!("expected canonical text")
+    };
+    inner.as_str()
+}
+
+fn text_set(value: &CanonicalValue) -> BTreeSet<&str> {
+    array(value).iter().map(text).collect()
+}
+
+fn json(value: &CanonicalValue) -> String {
+    String::from_utf8(value.to_canonical_bytes()).unwrap()
+}
+
+fn listing(dir: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut entries: Vec<(PathBuf, Vec<u8>)> = fs::read_dir(dir)
+        .unwrap()
+        .map(|entry| {
+            let path = entry.unwrap().path();
+            let bytes = fs::read(&path).unwrap();
+            (path, bytes)
+        })
+        .collect();
+    entries.sort();
+    entries
+}
+
+fn diagnostic_code(output: &Output) -> String {
+    let value = canonical_stdout(output);
+    let diagnostic = &array(field(&value, "diagnostics"))[0];
+    let CanonicalValue::Text(code) = field(diagnostic, "code") else {
+        panic!("diagnostic code must be text")
+    };
+    code.clone()
+}
+
+/// Writes one source and compiles it into `world/` under a fresh workspace.
+fn compiled(label: &str, source: &str) -> PathBuf {
+    let root = fresh_workspace(label);
+    fs::write(root.join("world.nomos"), source).unwrap();
+    assert_exit(&run(&root, ["compile", "world.nomos", "--out", "world"]), 0);
+    root
+}
+
+fn catalog(root: &Path) -> CanonicalValue {
+    let output = run(root, ["entity-catalog", "world"]);
+    assert_exit(&output, 0);
+    canonical_stdout(&output)
+}
+
+/// The `entity <id> <primitive/kind>` declarations of a `.nomos` source.
+///
+/// This is the *test's* reading of the source, which is the whole point: the
+/// expected value comes from the declaration a human wrote, not from anything
+/// the command computed.
+fn declared_primitives(source: &str) -> BTreeMap<&str, &str> {
+    source
+        .lines()
+        .filter_map(|line| {
+            let mut words = line.split_whitespace();
+            match (words.next(), words.next(), words.next(), words.next()) {
+                (Some("entity"), Some(id), Some(primitive), None) => Some((id, primitive)),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+/// `entities[].expansion.capabilities` from the package's World IR member.
+fn world_ir_capabilities(root: &Path) -> BTreeMap<String, BTreeSet<String>> {
+    let ir = parse_canonical(&fs::read(root.join("world/world-ir.json")).unwrap()).unwrap();
+    array(field(&ir, "entities"))
+        .iter()
+        .map(|entity| {
+            let capabilities = text_set(field(field(entity, "expansion"), "capabilities"))
+                .into_iter()
+                .map(str::to_owned)
+                .collect();
+            (text(field(entity, "id")).to_owned(), capabilities)
+        })
+        .collect()
+}
+
+#[test]
+fn the_catalog_names_its_schema_and_the_world_it_catalogued() {
+    let root = compiled("identity", GAOL);
+    let document = catalog(&root);
+
+    assert_eq!(text(field(&document, "command")), "entity-catalog");
+    assert_eq!(text(field(&document, "status")), "completed");
+    assert_eq!(text(field(&document, "schema")), "nomos.entity_catalog@1");
+
+    // The document binds the exact package it was built from, so a consumer
+    // cannot silently pair a catalog with a different world.
+    let world = field(&document, "world");
+    assert_eq!(text(field(world, "world_ir_schema")), "nomos.world_ir@2");
+    let inspect = run(&root, ["inspect", "world"]);
+    assert_exit(&inspect, 0);
+    assert_eq!(
+        text(field(world, "manifest_digest")),
+        text(field(&canonical_stdout(&inspect), "manifest_digest"))
+    );
+}
+
+#[test]
+fn every_entity_carries_its_declared_primitive_and_world_ir_capabilities() {
+    for (path, source) in WORLDS {
+        let root = compiled("primitives", source);
+        let document = catalog(&root);
+        let entities = array(field(&document, "entities"));
+
+        let declared = declared_primitives(source);
+        assert!(
+            !declared.is_empty(),
+            "`{path}` declares no entity; the assertion below would be vacuous"
+        );
+        assert_eq!(
+            entities.len(),
+            declared.len(),
+            "`{path}`: catalog and source disagree about how many entities exist"
+        );
+
+        let capabilities = world_ir_capabilities(&root);
+        let mut previous: Option<&str> = None;
+        for entity in entities {
+            let id = text(field(entity, "id"));
+            assert!(
+                previous.is_none_or(|earlier| earlier < id),
+                "`{path}`: catalog entities are not in strict entity order"
+            );
+            previous = Some(id);
+
+            // The acceptance criterion: the kind is the one declared in source.
+            assert_eq!(
+                text(field(entity, "primitive")),
+                declared[id],
+                "`{path}`: entity `{id}` is not catalogued as its declared primitive"
+            );
+            // ... and the capability set is World IR's, verbatim as a set. The
+            // catalog sorts arrays by wire spelling; World IR emits the same
+            // members in `CapabilityKind` declaration order.
+            assert_eq!(
+                text_set(field(entity, "capabilities"))
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect::<BTreeSet<_>>(),
+                capabilities[id],
+                "`{path}`: entity `{id}` does not carry World IR's expansion.capabilities"
+            );
+            assert!(
+                !capabilities[id].is_empty(),
+                "`{path}`: entity `{id}` has no capabilities; the assertion above is vacuous"
+            );
+        }
+    }
+}
+
+#[test]
+fn resolver_subjects_claims_and_machines_come_from_the_plans() {
+    let root = compiled("subjects", GAOL);
+    let document = catalog(&root);
+    let entities: BTreeMap<&str, &CanonicalValue> = array(field(&document, "entities"))
+        .iter()
+        .map(|entity| (text(field(entity, "id")), entity))
+        .collect();
+    assert_eq!(
+        entities.keys().copied().collect::<Vec<_>>(),
+        ["brazier_02", "flooded_section", "north_gate"]
+    );
+
+    // The door is a movement subject with two blocking claims, four machines,
+    // and a face binding; it emits no light.
+    let gate = entities["north_gate"];
+    assert_eq!(json(field(gate, "movement_subject")), "true");
+    assert_eq!(json(field(gate, "light_subject")), "false");
+    assert_eq!(
+        json(field(gate, "binding")),
+        r#"{"cell":{"x":5,"y":0,"z":0},"direction":"north","kind":"face"}"#
+    );
+    assert_eq!(
+        json(field(gate, "machines")),
+        concat!(
+            r#"[{"initial":"locked","namespace":"north_gate.access","#,
+            r#""states":["closed","locked","open"]},"#,
+            r#"{"initial":"cold","namespace":"north_gate.combustion","#,
+            r#""states":["burning","cold","spent"]},"#,
+            r#"{"initial":"intact","namespace":"north_gate.integrity","#,
+            r#""states":["damaged","destroyed","intact"]},"#,
+            r#"{"initial":"sealed","namespace":"north_gate.ward","#,
+            r#""states":["sealed","unsealed"]}]"#,
+        )
+    );
+    let claims = array(field(gate, "claims"));
+    assert_eq!(claims.len(), 2);
+    for claim in claims {
+        assert_eq!(text(field(claim, "resolver")), "movement");
+        assert_eq!(text(field(claim, "capability")), "blocks_ground");
+        // The span is the entity declaration's, verbatim from the resolver
+        // plan: catalog claims are compiler expansions of a sealed primitive
+        // and have no source text of their own.
+        assert_eq!(
+            json(field(claim, "source")),
+            concat!(
+                r#"{"byte_end":162,"byte_start":53,"column":1,"line":4,"#,
+                r#""path":"world.nomos"}"#,
+            )
+        );
+    }
+    assert_eq!(
+        array(field(gate, "claims"))
+            .iter()
+            .map(|claim| text(field(claim, "id")))
+            .collect::<Vec<_>>(),
+        [
+            "north_gate.portal#blocks_ground",
+            "north_gate.ward#blocks_ground"
+        ]
+    );
+
+    // The water region is a movement subject with a cost claim and no machine.
+    let water = entities["flooded_section"];
+    assert_eq!(json(field(water, "movement_subject")), "true");
+    assert_eq!(json(field(water, "light_subject")), "false");
+    assert_eq!(json(field(water, "machines")), "[]");
+    assert_eq!(
+        text(field(&array(field(water, "claims"))[0], "capability")),
+        "traversal_cost_ground"
+    );
+
+    // The brazier is a light subject and not a movement subject.
+    let brazier = entities["brazier_02"];
+    assert_eq!(json(field(brazier, "movement_subject")), "false");
+    assert_eq!(json(field(brazier, "light_subject")), "true");
+    assert_eq!(
+        json(field(brazier, "claims")),
+        concat!(
+            r#"[{"capability":"emits_light","id":"brazier_02.emission#emits_light","#,
+            r#""resolver":"light","source":{"byte_end":323,"byte_start":251,"#,
+            r#""column":1,"line":13,"path":"world.nomos"}}]"#,
+        )
+    );
+}
+
+#[test]
+fn the_catalog_reads_no_source() {
+    let root = compiled("no-source", GAOL);
+    let before = catalog(&root);
+
+    // The command is a projection over the compiled package. Removing the
+    // source it was compiled from must change nothing at all.
+    fs::remove_file(root.join("world.nomos")).unwrap();
+    let after = catalog(&root);
+    assert_eq!(json(&after), json(&before));
+    assert!(json(&after).contains("nomos.entity_catalog@1"));
+}
+
+#[test]
+fn the_catalog_mutates_no_input() {
+    let root = compiled("immutable", GAOL);
+    fs::write(root.join("gaol.commands"), COMMANDS).unwrap();
+    assert_exit(
+        &run(
+            &root,
+            [
+                "run",
+                "world",
+                "--commands",
+                "gaol.commands",
+                "--out",
+                "runs/gaol",
+            ],
+        ),
+        0,
+    );
+
+    let package_before = listing(&root.join("world"));
+    // A run bundle is a closed six-file set whose strict reopener fails closed
+    // on an extra entry; the catalog must never add a seventh.
+    let bundle_before = listing(&root.join("runs/gaol"));
+    assert_eq!(bundle_before.len(), 6, "run bundle is not the six-file set");
+    let mut workspace_before: Vec<PathBuf> = fs::read_dir(&root)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    workspace_before.sort();
+
+    let _ = catalog(&root);
+
+    assert_eq!(listing(&root.join("world")), package_before);
+    assert_eq!(listing(&root.join("runs/gaol")), bundle_before);
+    let mut workspace_after: Vec<PathBuf> = fs::read_dir(&root)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    workspace_after.sort();
+    assert_eq!(
+        workspace_after, workspace_before,
+        "the catalog wrote an artifact"
+    );
+}
+
+#[test]
+fn the_argument_grammar_is_exact() {
+    let root = compiled("grammar", GAOL);
+
+    let help = run(&root, ["entity-catalog", "--help"]);
+    assert_exit(&help, 0);
+    assert!(String::from_utf8_lossy(&help.stdout).contains("nomos entity-catalog <world/>"));
+    assert!(
+        String::from_utf8_lossy(&run(&root, ["--help"]).stdout).contains("nomos entity-catalog")
+    );
+
+    // A missing argument, an option in the package position, and any extra
+    // argument are usage errors rather than partial work.
+    for args in [
+        vec!["entity-catalog"],
+        vec!["entity-catalog", "--world", "world"],
+        vec!["entity-catalog", "world", "extra"],
+        vec![
+            "entity-catalog",
+            "world",
+            "--state",
+            "runs/gaol/final-state.json",
+        ],
+    ] {
+        assert_exit(&run(&root, args), 2);
+    }
+
+    // An absolute or escaping path is refused before any filesystem access.
+    let escaping = run(&root, ["entity-catalog", "../world"]);
+    assert_exit(&escaping, 1);
+    assert_eq!(diagnostic_code(&escaping), "EK0002");
+
+    // A world that is not there is a rejected world, exactly as `inspect` and
+    // `explain-entity` report it.
+    let absent = run(&root, ["entity-catalog", "absent.world"]);
+    assert_exit(&absent, 1);
+    assert_eq!(diagnostic_code(&absent), "EK0405");
+}
+
+#[test]
+fn the_same_world_produces_byte_identical_output() {
+    let root = compiled("determinism", GAOL);
+
+    // Ten invocations against one package must agree on every byte of stdout,
+    // not merely on the facts they encode.
+    let mut outputs = Vec::new();
+    for _ in 0..10 {
+        let output = run(&root, ["entity-catalog", "world"]);
+        assert_exit(&output, 0);
+        outputs.push(output.stdout);
+    }
+
+    // Guard against a vacuous pass: ten empty stdouts are also "identical".
+    let first = &outputs[0];
+    assert!(
+        first.len() > 1024,
+        "stdout is implausibly short: {}",
+        first.len()
+    );
+    assert_eq!(first.last(), Some(&b'\n'));
+    assert!(
+        String::from_utf8_lossy(first).contains(r#""schema":"nomos.entity_catalog@1""#),
+        "stdout does not carry the catalog: {}",
+        String::from_utf8_lossy(first)
+    );
+
+    for (index, output) in outputs.iter().enumerate().skip(1) {
+        assert_eq!(
+            String::from_utf8_lossy(output),
+            String::from_utf8_lossy(first),
+            "run {index} diverged from the first run"
+        );
+    }
+
+    // A second compilation of the same source at the same path must produce the
+    // same bytes, so nothing about the package's location on disk reaches
+    // canonical output. The source path itself is inside the document, in claim
+    // source spans, so "the same source" means the same bytes at the same path.
+    assert_exit(
+        &run(&root, ["compile", "world.nomos", "--out", "copy.world"]),
+        0,
+    );
+    let copy = run(&root, ["entity-catalog", "copy.world"]);
+    assert_exit(&copy, 0);
+    assert_eq!(
+        String::from_utf8_lossy(&copy.stdout),
+        String::from_utf8_lossy(first),
+        "a second compilation of the same source produced different bytes"
+    );
+
+    // The same bytes compiled from a different path are a different world, and
+    // the catalog says so rather than quietly reporting the first world's spans.
+    fs::create_dir_all(root.join("nested")).unwrap();
+    fs::copy(root.join("world.nomos"), root.join("nested/world.nomos")).unwrap();
+    assert_exit(
+        &run(
+            &root,
+            ["compile", "nested/world.nomos", "--out", "nested.world"],
+        ),
+        0,
+    );
+    let moved = run(&root, ["entity-catalog", "nested.world"]);
+    assert_exit(&moved, 0);
+    assert_ne!(
+        String::from_utf8_lossy(&moved.stdout),
+        String::from_utf8_lossy(first),
+        "the source path appears in claim spans and must reach the document"
+    );
+}

--- a/crates/nomos-compiler/src/entity_catalog.rs
+++ b/crates/nomos-compiler/src/entity_catalog.rs
@@ -1,0 +1,286 @@
+//! The typed entity catalog of one strictly verified compiled world.
+//!
+//! The four persisted projections deliberately carry no entity kind: a
+//! `simulation.json` entity is `{id, binding, machines}`, so a downstream tool
+//! that needs to know a door from a water region has to guess — which is why
+//! `experiments/executable-gaol/src/build-plan.mjs:25` classifies by
+//! `machine.endsWith(".access")`. The kind and the typed capability set already
+//! exist, in the stable World IR entity record; nothing in the tree exposes
+//! them next to the projected binding, machines, and resolver claims.
+//!
+//! This module joins what the kernel already knows into one read-only
+//! entity-sorted document. It classifies nothing, resolves nothing, and reads
+//! no source: every field is copied from typed evidence the package opener has
+//! already verified.
+
+use std::collections::BTreeMap;
+
+use nomos_core::canonical::keyed_array;
+use nomos_core::id::{SchemaId, StableId};
+use nomos_core::{
+    CanonicalValue, ClaimRef, Diagnostic, EntityId, NamespaceId, RepairClass, SourceSpan,
+};
+use nomos_projection::{
+    LightSubject, MachineDefinition, MovementClaim, MovementSubject, ProjectedEntity,
+};
+use nomos_schema::{CapabilityKind, IrEntity};
+
+use crate::OpenedCompiledWorld;
+
+/// The resolver a projected claim belongs to.
+const MOVEMENT: &str = "movement";
+/// The resolver a projected light claim belongs to.
+const LIGHT: &str = "light";
+
+/// One entity-sorted catalog of every entity in a verified compiled world.
+///
+/// Each record carries the World IR primitive kind and capability set beside
+/// the simulation projection's binding and machines and the movement and light
+/// resolver claims whose subject the entity is. The document is derived: it is
+/// written to stdout, never into a package or a run bundle, and is outside the
+/// state-hash domain.
+///
+/// # Errors
+///
+/// Returns `EK0413` when the verified package's World IR and simulation
+/// projection disagree about an entity or a machine namespace — evidence that
+/// cannot be assembled truthfully is refused rather than filled in.
+pub fn entity_catalog(world: &OpenedCompiledWorld) -> Result<CanonicalValue, Diagnostic> {
+    let construction = world.stable_ir().construction();
+    let simulation = world.simulation();
+
+    let projected: BTreeMap<&EntityId, &ProjectedEntity> = simulation
+        .entities()
+        .iter()
+        .map(|entity| (entity.id(), entity))
+        .collect();
+    let machines: BTreeMap<&NamespaceId, &MachineDefinition> = simulation
+        .machines()
+        .iter()
+        .map(|machine| (machine.namespace(), machine))
+        .collect();
+    // The movement resolver plan is shared: `validate_member_integrity` proves
+    // the simulation and navigation projections carry byte-identical
+    // `movement_resolver` values before this function can be reached.
+    let movement: BTreeMap<&EntityId, &MovementSubject> = world
+        .navigation()
+        .movement_resolver()
+        .subjects()
+        .iter()
+        .map(|subject| (subject.entity(), subject))
+        .collect();
+    let light: BTreeMap<&EntityId, &LightSubject> = simulation
+        .light_resolver()
+        .subjects()
+        .iter()
+        .map(|subject| (subject.entity(), subject))
+        .collect();
+
+    let records = construction
+        .entities()
+        .iter()
+        .map(|entity| {
+            let record = entity_record(entity, &projected, &machines, &movement, &light)?;
+            Ok((entity.id().clone(), record))
+        })
+        .collect::<Result<Vec<_>, Diagnostic>>()?;
+
+    Ok(CanonicalValue::object_declared([
+        ("command", CanonicalValue::text("entity-catalog")),
+        ("entities", keyed_array(records)?),
+        (
+            "schema",
+            CanonicalValue::text(entity_catalog_schema().to_string()),
+        ),
+        ("status", CanonicalValue::text("completed")),
+        (
+            "world",
+            CanonicalValue::object_declared([
+                (
+                    "manifest_digest",
+                    CanonicalValue::text(world.package_digest().to_hex()),
+                ),
+                (
+                    "world_ir_schema",
+                    CanonicalValue::text(world.stable_ir().schema().to_string()),
+                ),
+            ]),
+        ),
+    ]))
+}
+
+fn entity_record(
+    entity: &IrEntity,
+    projected: &BTreeMap<&EntityId, &ProjectedEntity>,
+    machines: &BTreeMap<&NamespaceId, &MachineDefinition>,
+    movement: &BTreeMap<&EntityId, &MovementSubject>,
+    light: &BTreeMap<&EntityId, &LightSubject>,
+) -> Result<CanonicalValue, Diagnostic> {
+    let id = entity.id();
+    let projected = projected.get(id).ok_or_else(|| {
+        inconsistent(format!(
+            "World IR entity `{id}` has no simulation projection record"
+        ))
+    })?;
+
+    Ok(CanonicalValue::object_declared([
+        ("binding", projected.binding().to_canonical()),
+        ("capabilities", capabilities(entity)),
+        ("claims", claims(id, movement, light)?),
+        ("id", id.to_canonical()),
+        (
+            "light_subject",
+            CanonicalValue::Bool(light.contains_key(id)),
+        ),
+        ("machines", entity_machines(projected, machines)?),
+        (
+            "movement_subject",
+            CanonicalValue::Bool(movement.contains_key(id)),
+        ),
+        ("primitive", entity.primitive().to_canonical()),
+    ]))
+}
+
+/// The World IR capability set, sorted by its wire spelling.
+///
+/// The World IR itself emits these in `CapabilityKind` declaration order; the
+/// catalog sorts every array by the identity a consumer sees, so the members
+/// are the same set in lexicographic order.
+fn capabilities(entity: &IrEntity) -> CanonicalValue {
+    let mut spellings: Vec<&'static str> = entity
+        .expansion()
+        .capabilities()
+        .iter()
+        .map(|capability| capability.as_str())
+        .collect();
+    spellings.sort_unstable();
+    CanonicalValue::Array(spellings.into_iter().map(CanonicalValue::text).collect())
+}
+
+fn entity_machines(
+    projected: &ProjectedEntity,
+    machines: &BTreeMap<&NamespaceId, &MachineDefinition>,
+) -> Result<CanonicalValue, Diagnostic> {
+    let rows = projected
+        .machines()
+        .iter()
+        .map(|namespace| {
+            let definition = machines.get(namespace).ok_or_else(|| {
+                inconsistent(format!(
+                    "projected entity `{}` names machine `{namespace}`, which the simulation projection does not define",
+                    projected.id()
+                ))
+            })?;
+            let states = definition
+                .states()
+                .iter()
+                .map(|state| CanonicalValue::text(state.as_str()))
+                .collect();
+            Ok((
+                namespace.clone(),
+                CanonicalValue::object_declared([
+                    ("initial", CanonicalValue::text(definition.initial().as_str())),
+                    ("namespace", namespace.to_canonical()),
+                    ("states", CanonicalValue::Array(states)),
+                ]),
+            ))
+        })
+        .collect::<Result<Vec<_>, Diagnostic>>()?;
+    keyed_array(rows)
+}
+
+fn claims(
+    id: &EntityId,
+    movement: &BTreeMap<&EntityId, &MovementSubject>,
+    light: &BTreeMap<&EntityId, &LightSubject>,
+) -> Result<CanonicalValue, Diagnostic> {
+    let mut rows = Vec::new();
+    if let Some(subject) = movement.get(id) {
+        for claim in subject.claims() {
+            let capability = match claim {
+                MovementClaim::Blocker { .. } => CapabilityKind::BlocksGround,
+                MovementClaim::TraversalCost { .. } => CapabilityKind::TraversalCostGround,
+            };
+            rows.push(claim_row(claim.id(), capability, MOVEMENT, claim.source()));
+        }
+    }
+    if let Some(subject) = light.get(id) {
+        for claim in subject.claims() {
+            rows.push(claim_row(
+                claim.id(),
+                CapabilityKind::EmitsLight,
+                LIGHT,
+                claim.source(),
+            ));
+        }
+    }
+    keyed_array(rows)
+}
+
+fn claim_row(
+    id: &ClaimRef,
+    capability: CapabilityKind,
+    resolver: &'static str,
+    source: &SourceSpan,
+) -> ((String, &'static str), CanonicalValue) {
+    (
+        (id.canonical_string(), resolver),
+        CanonicalValue::object_declared([
+            ("capability", CanonicalValue::text(capability.as_str())),
+            ("id", id.to_canonical()),
+            ("resolver", CanonicalValue::text(resolver)),
+            ("source", source.to_canonical()),
+        ]),
+    )
+}
+
+fn inconsistent(message: String) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::PACKAGE_MEMBER_INCONSISTENT,
+        message,
+    )
+    .with_repair(RepairClass::RebuildFromSource)
+}
+
+/// Canonical schema for the read-only entity catalog.
+///
+/// Like `nomos.effective_facts@1` this document exists to be consumed by a
+/// downstream compiler rather than read by a human, so it carries a versioned
+/// identity to bind against. It is declared here, in the crate that owns World
+/// IR decoding and projection generation and is therefore the only kernel crate
+/// that can see both halves of the join.
+///
+/// # Panics
+///
+/// Panics if the built-in literal is not a valid schema id, which this crate's
+/// tests rule out.
+#[must_use]
+pub fn entity_catalog_schema() -> SchemaId {
+    SchemaId::new("nomos.entity_catalog", 1)
+        .expect("the entity-catalog schema id is a valid literal")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::entity_catalog_schema;
+    use crate::{consumed_schemas, produced_schemas};
+
+    #[test]
+    fn the_catalog_identity_is_versioned_and_is_not_a_package_artifact() {
+        assert_eq!(
+            entity_catalog_schema().to_string(),
+            "nomos.entity_catalog@1"
+        );
+        // The catalog is derived stdout, never a package member, so its name
+        // must not collide with an artifact this compiler reads or writes and
+        // it must not enter the registry that binds the compiled members.
+        assert!(!produced_schemas().contains(&entity_catalog_schema()));
+        for schema in produced_schemas().iter().chain(consumed_schemas().iter()) {
+            assert_ne!(
+                schema.name(),
+                entity_catalog_schema().name(),
+                "the entity catalog versions independently of every compiled artifact"
+            );
+        }
+    }
+}

--- a/crates/nomos-compiler/src/lib.rs
+++ b/crates/nomos-compiler/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod catalog;
 pub mod diagnostics;
+mod entity_catalog;
 mod inspect;
 mod linker;
 mod opened;
@@ -25,6 +26,7 @@ use nomos_core::{Diagnostic, SchemaId, SourcePath};
 pub use nomos_projection::{DiagnosticsPlan, NavigationPlan, PersistencePlan, SimulationPlan};
 use nomos_schema::{LegacyStableWorldIrV1, SourceDocument, StableWorldIr, WorldIr};
 
+pub use entity_catalog::{entity_catalog, entity_catalog_schema};
 pub use inspect::inspect_compiled_package;
 pub use opened::{OpenedCompiledWorld, open_compiled_package, validate_compiled_package};
 pub use package::{

--- a/crates/nomos-core/src/diagnostic.rs
+++ b/crates/nomos-core/src/diagnostic.rs
@@ -258,6 +258,27 @@ impl SourceSpan {
     pub fn position(&self) -> (u32, u32) {
         (self.line, self.column)
     }
+
+    /// The span as the canonical `byte_end`/`byte_start`/`column`/`line`/`path`
+    /// object every artifact and report already spells.
+    ///
+    /// This crate owns [`SourceSpan`], so it owns the one rendering of it.
+    /// Before this accessor the same five fields were written out separately in
+    /// `nomos-core`, `nomos-schema`, `nomos-projection` (twice), and
+    /// `nomos-cli`; each of those now calls here and the bytes are unchanged.
+    #[must_use]
+    pub fn to_canonical(&self) -> CanonicalValue {
+        CanonicalValue::object_declared([
+            ("byte_end", CanonicalValue::Uint(u64::from(self.byte_end))),
+            (
+                "byte_start",
+                CanonicalValue::Uint(u64::from(self.byte_start)),
+            ),
+            ("column", CanonicalValue::Uint(u64::from(self.column))),
+            ("line", CanonicalValue::Uint(u64::from(self.line))),
+            ("path", CanonicalValue::text(self.path.as_str())),
+        ])
+    }
 }
 
 impl fmt::Display for SourceSpan {
@@ -355,16 +376,7 @@ impl Diagnostic {
             ),
         ];
         if let Some(span) = &self.span {
-            let (byte_start, byte_end) = span.byte_range();
-            let (line, column) = span.position();
-            let span_value = CanonicalValue::object_declared([
-                ("byte_end", CanonicalValue::Uint(u64::from(byte_end))),
-                ("byte_start", CanonicalValue::Uint(u64::from(byte_start))),
-                ("column", CanonicalValue::Uint(u64::from(column))),
-                ("line", CanonicalValue::Uint(u64::from(line))),
-                ("path", CanonicalValue::text(span.path().as_str())),
-            ]);
-            fields.push((FieldName::declared("span"), span_value));
+            fields.push((FieldName::declared("span"), span.to_canonical()));
         }
         CanonicalValue::object(fields)
             .expect("diagnostic construction supplies each canonical field once")

--- a/crates/nomos-projection/src/light.rs
+++ b/crates/nomos-projection/src/light.rs
@@ -99,7 +99,7 @@ impl LightClaim {
             ("activation", self.activation.to_canonical()),
             ("capability", CanonicalValue::text("emits_light")),
             ("id", self.id.to_canonical()),
-            ("source", span_to_canonical(&self.source)),
+            ("source", self.source.to_canonical()),
             ("value", CanonicalValue::Bool(self.value)),
         ])
     }
@@ -400,16 +400,4 @@ fn duplicate(identity: &str) -> Diagnostic {
         format!("{identity} occurs more than once"),
     )
     .with_repair(RepairClass::RemoveDuplicateDeclaration)
-}
-
-fn span_to_canonical(span: &SourceSpan) -> CanonicalValue {
-    let (byte_start, byte_end) = span.byte_range();
-    let (line, column) = span.position();
-    CanonicalValue::object_declared([
-        ("byte_end", CanonicalValue::Uint(u64::from(byte_end))),
-        ("byte_start", CanonicalValue::Uint(u64::from(byte_start))),
-        ("column", CanonicalValue::Uint(u64::from(column))),
-        ("line", CanonicalValue::Uint(u64::from(line))),
-        ("path", CanonicalValue::text(span.path().as_str())),
-    ])
 }

--- a/crates/nomos-projection/src/movement.rs
+++ b/crates/nomos-projection/src/movement.rs
@@ -263,7 +263,7 @@ impl MovementClaim {
                 ("activation", activation.to_canonical()),
                 ("capability", CanonicalValue::text("blocks_ground")),
                 ("id", id.to_canonical()),
-                ("source", span_to_canonical(source)),
+                ("source", source.to_canonical()),
                 ("value", CanonicalValue::Bool(*value)),
             ]),
             Self::TraversalCost {
@@ -275,7 +275,7 @@ impl MovementClaim {
                 ("activation", activation.to_canonical()),
                 ("capability", CanonicalValue::text("traversal_cost_ground")),
                 ("id", id.to_canonical()),
-                ("source", span_to_canonical(source)),
+                ("source", source.to_canonical()),
                 ("value", CanonicalValue::Uint(u64::from(*cost))),
             ]),
         }
@@ -742,16 +742,4 @@ fn duplicate(identity: &str) -> Diagnostic {
         format!("{identity} occurs more than once"),
     )
     .with_repair(RepairClass::RemoveDuplicateDeclaration)
-}
-
-fn span_to_canonical(span: &SourceSpan) -> CanonicalValue {
-    let (byte_start, byte_end) = span.byte_range();
-    let (line, column) = span.position();
-    CanonicalValue::object_declared([
-        ("byte_end", CanonicalValue::Uint(u64::from(byte_end))),
-        ("byte_start", CanonicalValue::Uint(u64::from(byte_start))),
-        ("column", CanonicalValue::Uint(u64::from(column))),
-        ("line", CanonicalValue::Uint(u64::from(line))),
-        ("path", CanonicalValue::text(span.path().as_str())),
-    ])
 }

--- a/crates/nomos-schema/src/ir.rs
+++ b/crates/nomos-schema/src/ir.rs
@@ -463,7 +463,7 @@ impl IrEntity {
             ("expansion", self.expansion.to_canonical()),
             ("id", self.id.to_canonical()),
             ("primitive", self.primitive.to_canonical()),
-            ("source", span_to_canonical(&self.source_span)),
+            ("source", self.source_span.to_canonical()),
         ])
     }
 }
@@ -511,7 +511,7 @@ impl IrRelation {
         CanonicalValue::object_declared([
             ("kind", CanonicalValue::text(self.kind.as_str())),
             ("object", self.object.to_canonical()),
-            ("source", span_to_canonical(&self.source_span)),
+            ("source", self.source_span.to_canonical()),
             ("subject", self.subject.to_canonical()),
         ])
     }
@@ -743,16 +743,4 @@ fn require_unique_with_code<T: Ord>(
         }
     }
     Ok(())
-}
-
-pub(crate) fn span_to_canonical(span: &SourceSpan) -> CanonicalValue {
-    let (byte_start, byte_end) = span.byte_range();
-    let (line, column) = span.position();
-    CanonicalValue::object_declared([
-        ("byte_end", CanonicalValue::Uint(u64::from(byte_end))),
-        ("byte_start", CanonicalValue::Uint(u64::from(byte_start))),
-        ("column", CanonicalValue::Uint(u64::from(column))),
-        ("line", CanonicalValue::Uint(u64::from(line))),
-        ("path", CanonicalValue::text(span.path().as_str())),
-    ])
 }

--- a/crates/nomos-schema/src/provenance.rs
+++ b/crates/nomos-schema/src/provenance.rs
@@ -11,7 +11,6 @@ use nomos_core::{
 };
 
 use crate::Binding;
-use crate::ir::span_to_canonical;
 
 /// Canonical owner of a fact class.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -524,7 +523,7 @@ impl FactOwnershipReceipt {
                         .collect(),
                 ),
             ),
-            ("declared_at", span_to_canonical(&self.declared_at)),
+            ("declared_at", self.declared_at.to_canonical()),
             (
                 "derivation",
                 CanonicalValue::Array(

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -50,6 +50,14 @@ projection: given a strictly verified package and a runtime state it emits
 reasons, and effective light for every resolver subject, resolved entirely by
 the existing `resolve_movement` and `resolve_light` rather than by new logic.
 
+`nomos entity-catalog <world/>` adds the read-only catalog of what a compiled
+world *contains*: for every entity it emits `nomos.entity_catalog@1`, carrying
+the World IR primitive kind and `expansion.capabilities` beside the simulation
+projection's binding and machines and the movement and light resolver claims
+with their source spans. It classifies nothing and reads no `.nomos` source, so
+a downstream compiler no longer has to infer an entity's kind from a naming
+convention.
+
 The executable study provides:
 
 - Cistern Walk, Ember Vault, Ossuary Reach, and North Gaol as separately

--- a/docs/evaluation/R1_SCHEMA_OWNERSHIP.md
+++ b/docs/evaluation/R1_SCHEMA_OWNERSHIP.md
@@ -36,15 +36,29 @@ relative.
 | Canonical identity | Owner | Owner file | Authoritative type set | Encoder | Strict reader / verifier | Persisted boundary | Primary consumers | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `nomos.effective_facts@1` | `nomos-sim` | `crates/nomos-sim/src/effective_facts.rs` | the `effective_facts()` document, embedding the `ResolvedMovementFacts` and `ResolvedLightFacts` renderings it composes | `nomos_sim::effective_facts` composes the `CanonicalValue`; canonical entity-sorted bytes written to stdout by `nomos effective-facts` | none in-tree: derived read-only output, never re-read by the kernel and with no strict package reader; its first consumer binds identity and version | none: stdout only, never written into a run bundle or package, and outside the state-hash domain because it is derived | R1-2 Rust rendering-plan compilation; today `experiments/executable-gaol/compare-effective-facts.sh` | active R1-1 |
+| `nomos.entity_catalog@1` | `nomos-compiler` | `crates/nomos-compiler/src/entity_catalog.rs` | the `entity_catalog()` document, joining the stable World IR `IrEntity` records with the `ProjectedEntity`, `MachineDefinition`, `MovementSubject`, and `LightSubject` values of the verified plans | `nomos_compiler::entity_catalog` composes the `CanonicalValue`; canonical entity-sorted bytes written to stdout by `nomos entity-catalog` | none in-tree: derived read-only output, never re-read by the kernel and with no strict package reader; its first consumer binds identity and version | none: stdout only, never written into a package or a run bundle, and outside the state-hash domain because it is derived | R1-2 Rust rendering-plan compilation, which needs the entity kind and capability set the four projections do not carry | active R1-2 input |
 
-One R1 identity has entered the accepted tree. `nomos.effective_facts@1` is the
-read-only effective-fact projection accepted as R1-1 under `RUNTIME.md` §5
+Two R1 identities have entered the accepted tree. `nomos.effective_facts@1` is
+the read-only effective-fact projection accepted as R1-1 under `RUNTIME.md` §5
 (issue #126, PR #130): given a strictly verified world package and a runtime
 state it composes, for every resolver subject, the effective movement
 disposition, cost, ordered reason claim IDs, and effective light. It resolves
 nothing itself — `nomos_sim::resolve_movement` and `nomos_sim::resolve_light`
 do that — and it is derived output, so it is persisted nowhere and enters no
 hash domain.
+
+`nomos.entity_catalog@1` is the read-only entity catalog added under issue #138:
+given a strictly verified world package it emits, for every entity, the World IR
+primitive kind and `expansion.capabilities` beside the simulation projection's
+binding and machines and the movement and light resolver claims whose subject
+that entity is. It classifies nothing and resolves nothing; every field is
+copied from typed evidence the package opener has already verified, so that no
+downstream compiler has to infer an entity's kind from a naming convention. It
+is declared in `nomos-compiler` because that crate owns World IR decoding and
+projection generation and is the only kernel crate that can see both halves of
+the join: `nomos-sim` has no edge to `nomos-schema` and therefore cannot name an
+entity's primitive kind at all. Like the effective-fact projection it is derived
+output, persisted nowhere, and outside every hash domain.
 
 ## How a row is added
 

--- a/docs/review/entity-catalog.md
+++ b/docs/review/entity-catalog.md
@@ -1,0 +1,370 @@
+---
+title: Kernel entity-catalog projection — design record
+status: R1 slice design record; an R1-2 input, acceptance disposition with the owner
+date: 2026-08-25
+issue: 138
+branch: r1/issue-138-entity-catalog
+accepts_against: issue #138 acceptance; RUNTIME.md §3 (revision 1, option (a))
+registers: docs/evaluation/R1_SCHEMA_OWNERSHIP.md (nomos.entity_catalog@1)
+applies_to: RUNTIME.md §3, §5 R1-2, §6; docs/evaluation/R1_SCHEMA_OWNERSHIP.md
+unblocks: issue #139 (R1-2 Rust rendering-plan compilation)
+---
+
+# Kernel entity-catalog projection
+
+## Problem
+
+`RUNTIME.md` §5 R1-2 requires doors, water, and lights to be classified from
+typed declarations, and forbids the plan compiler from reading `.nomos` source,
+World IR, or compiler receipts. Nothing in the four package projections lets it
+obey both at once. A `simulation.json` entity is `{id, binding, machines}`; the
+entity kind (`primitive/iron_barred_door`) and the typed capability set
+(`expansion.capabilities`) exist only in World IR, which R1-2 may not open. That
+gap is why `experiments/executable-gaol/src/build-plan.mjs:25` classifies doors
+by `machine.endsWith(".access")` — a convention, not a declaration.
+
+This is the same shape as R1-1: a read-only kernel command exposing what the
+kernel already knows, so no downstream code has to infer it. R1-1 removed a
+shadow *resolver*; this removes a shadow *taxonomy*.
+
+## Owner crate, and why
+
+The builder is `crates/nomos-compiler/src/entity_catalog.rs`, and the schema
+identity literal `SchemaId::new("nomos.entity_catalog", 1)` is declared there.
+
+`nomos-compiler` is not merely the recommended home — under `KERNEL.md`
+section 10's permitted edges it is the **only** kernel crate that can build this
+document at all. The catalog is a join of two things:
+
+| Half | Lives in | Reachable from |
+| --- | --- | --- |
+| `primitive`, `expansion.capabilities` | `nomos_schema::IrEntity` via `StableWorldIr::construction()` | `nomos-compiler` only |
+| `binding`, `machines`, resolver claims and spans | `nomos_projection` plan types | `nomos-compiler`, `nomos-sim`, `nomos-cli` |
+
+`nomos-sim`, which owns R1-1's document, has no edge to `nomos-schema` and
+therefore cannot name an entity's primitive kind; `nomos-projection` is denied
+`nomos-schema` by an explicit `compile_fail` doctest at
+`crates/nomos-projection/src/lib.rs:27`, on the stated ground that a projection
+type able to name Canonical World IR would invite a runtime subsystem to reach
+the IR through it. `nomos-cli` can see both but owns "command-line surface and
+artifact orchestration", not document semantics. `nomos-compiler` owns World IR
+decoding and projection generation, already crosses that boundary in
+`inspect.rs`, and is the crate `KERNEL.md` names as *the only crossing between
+IR and projections*.
+
+## Rust entry points reused
+
+Nothing new decodes, classifies, or resolves anything. The whole builder is a
+join and a canonical rendering over values the package opener has already
+verified.
+
+| Entry point | File | What it supplies |
+| --- | --- | --- |
+| `nomos_cli::open_compiled_world` → `nomos_compiler::open_compiled_package` | `crates/nomos-compiler/src/opened.rs:136` | strict package verification, as used by `inspect`/`explain-entity`/`effective-facts` |
+| `StableWorldIr::construction().entities()` | `crates/nomos-schema/src/ir.rs:637` | `IrEntity::primitive()`, `IrEntity::expansion().capabilities()` |
+| `SimulationPlan::entities()` | `crates/nomos-projection/src/simulation.rs:501` | `ProjectedEntity::binding()`, `ProjectedEntity::machines()` |
+| `SimulationPlan::machines()` | `crates/nomos-projection/src/simulation.rs:507` | `MachineDefinition::states()`, `MachineDefinition::initial()` |
+| `NavigationPlan::movement_resolver().subjects()` | `crates/nomos-projection/src/movement.rs:466` | `MovementSubject::claims()` with each claim's `id()` and `source()` |
+| `SimulationPlan::light_resolver().subjects()` | `crates/nomos-projection/src/light.rs:228` | `LightSubject::claims()` with each claim's `id()` and `source()` |
+| `CapabilityKind::as_str` | `crates/nomos-schema/src/ir.rs:45` | the one wire spelling of every capability, including a claim's |
+
+Two consequences worth stating, because they are what keep this from being a
+second implementation of anything:
+
+- **The capability spelling has one owner.** A claim's `capability` is not a
+  string literal in the new file; it is `CapabilityKind::BlocksGround`,
+  `TraversalCostGround`, or `EmitsLight` rendered through `as_str`, the same
+  function World IR renders `expansion.capabilities` through. A renamed
+  capability changes both together or neither.
+- **The movement plan is read once.** `validate_member_integrity`
+  (`crates/nomos-compiler/src/package.rs:414`) proves the simulation and
+  navigation projections carry byte-identical `movement_resolver` values before
+  the package can open, so reading it from the navigation plan and light from
+  the simulation plan is a choice of spelling, not of source.
+
+### Disclosed refactor: one owner for the source-span rendering
+
+The claim `source` object is the `byte_end`/`byte_start`/`column`/`line`/`path`
+shape every artifact already writes. Before this change that shape was written
+out **five** separate times, byte-identically, in `nomos-core`
+(`Diagnostic::to_canonical`), `nomos-schema` (`ir::span_to_canonical`, used by
+`IrEntity`, `IrRelation`, and `FactOwnershipReceipt`), `nomos-projection`
+(`movement::span_to_canonical` and `light::span_to_canonical`), and `nomos-cli`
+(`explanation.rs`'s `source_mapping`). Adding a sixth copy for the catalog was
+the obvious wrong answer, so this change adds `SourceSpan::to_canonical` in
+`nomos-core` — the crate that owns the type — and deletes all five copies.
+
+The rendering is unchanged field for field, so no artifact byte moves; the 222
+workspace tests, which include byte assertions on every compiled package member
+and on the committed run-bundle evidence, are the proof.
+
+## Chosen CLI shape
+
+```text
+nomos entity-catalog <world/>
+```
+
+Read-only: it opens and strictly verifies the package exactly as `inspect` and
+`explain-entity` do, writes canonical entity-sorted bytes to stdout, and touches
+nothing. It writes no artifact, adds no file to a run bundle — whose strict
+reopener fails closed on a seventh entry — and is outside the state-hash domain
+because it is derived. The argument grammar matches `effective-facts` in
+strictness: one exact arity, no optional arguments, `--help`, and a usage error
+for anything else.
+
+No `--state` argument exists, and that is deliberate. Everything in this
+document is a compile-time fact: the entity kind, its capabilities, its binding,
+its machine *definitions*, and the claims declared against it. What a machine's
+state happens to be right now, and what the claims therefore compose to, is
+exactly what `nomos effective-facts <world/> --state <state.json>` already
+answers. The two documents partition cleanly — this one is the world's shape,
+that one is the world's condition — and a consumer joins them on `id`.
+
+## The document
+
+Verbatim stdout for `experiments/executable-gaol/areas/north-gaol/world.nomos`,
+compiled at `world.nomos`, abbreviated to two of its four entities; the full
+document is in the pull request.
+
+```json
+{
+  "command": "entity-catalog",
+  "entities": [
+    {
+      "binding": {"cell": {"x": 3, "y": 1, "z": 0}, "kind": "cell"},
+      "capabilities": ["authority", "emits_light", "interactable", "machine", "persisted"],
+      "claims": [
+        {
+          "capability": "emits_light",
+          "id": "brazier_02.emission#emits_light",
+          "resolver": "light",
+          "source": {"byte_end": 437, "byte_start": 365, "column": 1, "line": 18, "path": "world.nomos"}
+        }
+      ],
+      "id": "brazier_02",
+      "light_subject": true,
+      "machines": [
+        {"initial": "lit", "namespace": "brazier_02.emission", "states": ["extinguished", "lit"]}
+      ],
+      "movement_subject": false,
+      "primitive": "primitive/extinguishable_light"
+    },
+    {
+      "binding": {"cell": {"x": 5, "y": 0, "z": 0}, "direction": "north", "kind": "face"},
+      "capabilities": ["authority", "blocks_ground", "boundary", "interactable", "machine", "persisted", "portal"],
+      "claims": [
+        {
+          "capability": "blocks_ground",
+          "id": "north_gate.portal#blocks_ground",
+          "resolver": "movement",
+          "source": {"byte_end": 162, "byte_start": 53, "column": 1, "line": 4, "path": "world.nomos"}
+        },
+        {
+          "capability": "blocks_ground",
+          "id": "north_gate.ward#blocks_ground",
+          "resolver": "movement",
+          "source": {"byte_end": 162, "byte_start": 53, "column": 1, "line": 4, "path": "world.nomos"}
+        }
+      ],
+      "id": "north_gate",
+      "light_subject": false,
+      "machines": [
+        {"initial": "locked", "namespace": "north_gate.access", "states": ["closed", "locked", "open"]},
+        {"initial": "cold", "namespace": "north_gate.combustion", "states": ["burning", "cold", "spent"]},
+        {"initial": "intact", "namespace": "north_gate.integrity", "states": ["damaged", "destroyed", "intact"]},
+        {"initial": "sealed", "namespace": "north_gate.ward", "states": ["sealed", "unsealed"]}
+      ],
+      "movement_subject": true,
+      "primitive": "primitive/iron_barred_door"
+    }
+  ],
+  "schema": "nomos.entity_catalog@1",
+  "status": "completed",
+  "world": {
+    "manifest_digest": "fabc8398300df90a6bb28b445cc36f2cc4507bbf2a7cc332f575729d4bca0977",
+    "world_ir_schema": "nomos.world_ir@2"
+  }
+}
+```
+
+Every field name is issue #138's, unchanged. Every array is sorted: entities by
+`id`, machines by namespace, claims by `(id, resolver)`, capabilities and
+machine states by their wire spelling. There is no floating point anywhere in
+the document — the only numbers are lattice coordinates, byte offsets, and line
+and column positions, all integers.
+
+### Four notes on faithfulness
+
+1. **`command` and `status` are additions.** Issue #138's sketch shows
+   `schema`, `world`, and `entities`. Every other `nomos` stdout document
+   carries `command` and `status`, and a rejection is
+   `{"diagnostics": [...], "status": "rejected"}` — so a consumer that cannot
+   read `status` cannot tell a catalog from a refusal. They are added for that
+   reason. Nothing #139 codes against is renamed, moved, or retyped; the
+   contract shape is a subset of what is emitted.
+2. **`capabilities` is sorted, and World IR's is not.** World IR emits the set
+   in `CapabilityKind` declaration order (`["machine", "interactable",
+   "emits_light", "authority", "persisted"]`). Issue #138 asks for sorted
+   arrays and its own example is lexicographic, so the catalog sorts. The
+   members are identical, which is what the acceptance criterion asserts and
+   what the test compares — as sets, in both directions.
+3. **A claim's `source` is its entity's declaration span.** Every claim in the
+   gaol corpus is a compiler expansion of a sealed catalog primitive, so it has
+   no source text of its own; the projected claim carries the entity
+   declaration's span, and the catalog copies it verbatim rather than inventing
+   a narrower one. Two claims on the same door therefore share a span. This is
+   the plan's own data, unmodified.
+4. **`machines` carries definitions, not states.** `states` is the machine's
+   legal state set and `initial` its initial state, both from the simulation
+   plan. The current state of a machine is runtime data and is not in this
+   document; `nomos effective-facts --state` is where it lives.
+
+Nothing in issue #138's shape could not be populated truthfully. No field was
+dropped, and none was invented.
+
+## Acceptance mapping
+
+Test names are in `crates/nomos-cli/tests/entity_catalog.rs` unless stated.
+
+| Issue #138 criterion | Proved by | State |
+| --- | --- | --- |
+| Command shape and strict verification | `the_argument_grammar_is_exact` — `--help`, root-help listing, four usage rejections, `EK0002` on an escaping path, `EK0405` on an absent world | ✅ |
+| Read-only, stdout only; no input mutation | `the_catalog_mutates_no_input` — byte comparison of every package member and of the workspace's top-level entries before and after | ✅ |
+| No run-bundle file | Same test — asserts the run bundle is the six-file set before, and byte-identical after | ✅ |
+| Never reads `.nomos` source | `the_catalog_reads_no_source` — deletes the source the package was compiled from and asserts byte-identical output | ✅ |
+| `primitive` matches the source declaration, for the fixture and all four areas | `every_entity_carries_its_declared_primitive_and_world_ir_capabilities` — the *test* parses each `entity <id> <primitive/kind>` line; five worlds, with an anti-vacuous count assertion | ✅ |
+| `capabilities` equal World IR's `expansion.capabilities` | Same test — reads `world/world-ir.json` from the compiled package and compares sets per entity, with an anti-vacuous non-empty assertion | ✅ |
+| `binding`, `machines`, `claims`, resolver flags come from the plans | `resolver_subjects_claims_and_machines_come_from_the_plans` — exact canonical byte strings for the door's binding, four machines, and both claims; the water region's cost claim; the brazier's light claim | ✅ |
+| Byte-identical across ten runs for the same package | `the_same_world_produces_byte_identical_output` — ten invocations, three anti-vacuous guards, plus a second compilation of the same source at the same path | ✅ |
+| Arrays sorted; no floating point | Same test's byte assertions plus `resolver_subjects_...`; the document contains no `CanonicalValue::Float`, which the canonical encoder does not offer | ✅ |
+| Schema identity `nomos.entity_catalog@1` declared in the owner crate | `the_catalog_identity_is_versioned_and_is_not_a_package_artifact` in `crates/nomos-compiler/src/entity_catalog.rs`; it also asserts the identity never enters `produced_schemas()` and so cannot reach a package member | ✅ |
+| Identity registered; `r1-schema-ownership.sh` → `schema_identities_r1 2` | [Proof commands](#proof-commands) | ✅ |
+| `RUNTIME.md` §3 table row added | Three rows: `nomos-compiler`, `nomos-cli`, `nomos-core` | ✅ |
+| Four proof commands pass | [Proof commands](#proof-commands) | ✅ |
+| No Gate K command, artifact, hash, or diagnostic changes | 222 workspace tests pass with every pre-existing suite unchanged and no assertion edited; no diagnostic code added; `produced_schemas()` and the package registry are untouched | ✅ |
+| Non-author rerun recorded | Owner's, on the pull request | ⏳ |
+
+Must-nots:
+
+| Must not | Evidence | State |
+| --- | --- | --- |
+| Classify by string convention | The builder contains no `ends_with`, no substring test, and no entity or namespace literal; `primitive` is copied from `IrEntity::primitive()` | ✅ |
+| Add a second decoder for `.nomos`, World IR, or receipts | The command opens a package through the one existing strict opener and decodes nothing itself | ✅ |
+| Add a third-party dependency to a kernel crate | `Cargo.lock` unchanged versus `origin/main`; `cargo xtask boundary` clean | ✅ |
+| Add a new dependency edge | None; `nomos-compiler → nomos-schema` and `nomos-cli → nomos-compiler` both already exist | ✅ |
+| Edit `KERNEL.md`, `THESIS.md`, or the frozen `SCHEMA_OWNERSHIP.md` | `git diff origin/main HEAD` over all three is empty | ✅ |
+| Write a seventh file into a run bundle | `the_catalog_mutates_no_input` | ✅ |
+| Leave a file over ~1,000 lines | Largest touched file is `crates/nomos-cli/src/command.rs` at 833 lines | ✅ |
+
+### Disclosed finding, filed rather than folded in: issue #141
+
+`docs/evaluation/test-gate-k-eval-tooling.sh`, a step in the `verify` lane,
+fails locally on this branch — and equally on a pristine `origin/main` checkout.
+`tree_sha` at `docs/evaluation/gate-k-eval-packet.sh:164` sorts paths with
+`sort -z` and pins no collation, so its digest depends on the caller's locale:
+under `LC_ALL=C` it reproduces the frozen `artifactsTreeSha256` receipt exactly,
+and under `en_US.UTF-8` it does not. That is the same latent defect issue #134
+records in the Gate K schema-ownership script, and the reason
+`docs/evaluation/r1-schema-ownership.sh` already sets `export LC_ALL=C`.
+
+It is pre-existing, unrelated to this slice — the branch touches no file under
+`docs/evaluation/runs/` — and lives in frozen Gate K evaluation tooling rather
+than in R1 surface, so it is filed as **issue #141** with its evidence rather
+than repaired here.
+
+## Proof commands
+
+All five pass on this branch. Run from the worktree root, Linux x86_64,
+toolchain 1.98.0.
+
+```console
+$ cargo fmt --all -- --check
+EXIT=0
+
+$ cargo clippy --workspace --all-targets --locked -- -D warnings
+    Checking nomos-core v0.0.0 (.../crates/nomos-core)
+    Checking xtask v0.0.0 (.../xtask)
+    Checking nomos-projection v0.0.0 (.../crates/nomos-projection)
+    Checking nomos-schema v0.0.0 (.../crates/nomos-schema)
+    Checking nomos-sim v0.0.0 (.../crates/nomos-sim)
+    Checking nomos-compiler v0.0.0 (.../crates/nomos-compiler)
+    Checking nomos-cli v0.0.0 (.../crates/nomos-cli)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.60s
+
+$ cargo test --workspace --locked
+total passed: 222  total failed: 0
+
+$ cargo xtask boundary
+boundary: clean
+  kernel crates      nomos-core, nomos-schema, nomos-projection, nomos-compiler, nomos-sim, nomos-cli
+  tooling crates     xtask
+  rules checked      membership, permitted-edges, cycles, forbidden-dependency, tooling-isolation
+  forbidden entries  64 exact names, 8 prefixes
+EXIT=0
+
+$ docs/evaluation/r1-schema-ownership.sh
+R1_SCHEMA_OWNERSHIP PASS
+schema_identities_gate_k 20
+schema_identities_r1 2
+```
+
+The seven tests in `crates/nomos-cli/tests/entity_catalog.rs`:
+
+```console
+running 7 tests
+test the_argument_grammar_is_exact ... ok
+test the_catalog_reads_no_source ... ok
+test resolver_subjects_claims_and_machines_come_from_the_plans ... ok
+test the_catalog_names_its_schema_and_the_world_it_catalogued ... ok
+test the_catalog_mutates_no_input ... ok
+test the_same_world_produces_byte_identical_output ... ok
+test every_entity_carries_its_declared_primitive_and_world_ir_capabilities ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s
+```
+
+Three are load-bearing.
+
+`every_entity_carries_its_declared_primitive_and_world_ir_capabilities` is the
+acceptance criterion itself, over all five committed worlds. Its expected values
+come from two places the command cannot reach: the `.nomos` source text, parsed
+in the test, and the package's `world-ir.json` member. If the catalog ever
+starts deriving a kind instead of copying one, this fails.
+
+`the_catalog_reads_no_source` deletes the source file and demands byte-identical
+output. It is the mechanical form of R1-2's "never reads `.nomos` source" for
+the command R1-2 will consume.
+
+`the_same_world_produces_byte_identical_output` covers the ten-run criterion and
+was mutation-checked: recompiling the identical bytes from a *different* source
+path produces a different document, which the test asserts, because the source
+path appears in every claim span. Byte identity is a property of a fixed
+(source bytes, source path) pair, not of source bytes alone — the same bound
+R1-1 recorded.
+
+## What this unblocks
+
+Issue #139 (R1-2) can now classify from declarations. The three convention-based
+classifications in `experiments/executable-gaol/src/build-plan.mjs` lines 17–29
+have a typed replacement:
+
+| `build-plan.mjs` | Convention | Replaced by |
+| --- | --- | --- |
+| line 25 | `machine.endsWith(".access")` means "door" | `primitive == "primitive/iron_barred_door"`, or the capability set `{boundary, portal, blocks_ground}` |
+| lines 17–24, `classify` | subject presence in the movement table means "water" | `primitive == "primitive/shallow_water_region"`, or `traversal_cost_ground` in `capabilities` |
+| lines 26–29, `lightEntities` | presence in the light table means "light" | `light_subject`, or `emits_light` in `capabilities` |
+
+Two of those are exactly R1-2's "a test renames a machine and an entity
+identifier and the classification is unchanged": neither the primitive kind nor
+the capability set moves when an identifier does.
+
+## Disposition
+
+This is a small, boundary-clean, read-only slice that adds one command, one
+schema identity, and one canonical accessor, and deletes five duplicated
+renderings. It resolves nothing, classifies nothing, and reads no source. It is
+an input to R1-2 rather than an R1 target in its own right, so `RUNTIME.md` §5
+gains no new subsection; its acceptance is issue #138's list above.
+
+Merge and acceptance disposition are the owner's, and nothing here is green
+until a non-author reruns the five proof commands.


### PR DESCRIPTION
Closes #138. **Unblocks #139.**

`nomos entity-catalog <world/>` is a read-only kernel projection: given a
strictly verified compiled world it emits, for every entity, the World IR
primitive kind and `expansion.capabilities` beside the simulation projection's
binding and machines and the movement and light resolver claims whose subject
that entity is. It classifies nothing, resolves nothing, and reads no `.nomos`
source — every field is copied from typed evidence the package opener has
already verified.

Design record: `docs/review/entity-catalog.md`.

## Owner crate, and why

`crates/nomos-compiler/src/entity_catalog.rs` declares
`SchemaId::new("nomos.entity_catalog", 1)`.

`nomos-compiler` is not merely the recommended home — under `KERNEL.md`
section 10's permitted edges it is the **only** kernel crate that can build this
document. The catalog joins `nomos_schema::IrEntity` (`primitive`,
`expansion.capabilities`), reachable only from `nomos-compiler`, with
`nomos_projection` plan types (`binding`, `machines`, claims, spans).
`nomos-sim`, which owns R1-1's `nomos.effective_facts@1`, has no edge to
`nomos-schema` and therefore cannot name an entity's primitive kind at all;
`nomos-projection` is denied `nomos-schema` by an explicit `compile_fail`
doctest at `crates/nomos-projection/src/lib.rs:27`; `nomos-cli` owns
orchestration, not document semantics. `nomos-compiler` owns World IR decoding
and projection generation and is the crate `KERNEL.md` names as the only
crossing between IR and projections.

## Example: north-gaol, verbatim stdout

`experiments/executable-gaol/areas/north-gaol/world.nomos` compiled at
`world.nomos`, pretty-printed here only for readability; the command writes one
canonical line plus a newline.

```json
{
  "command": "entity-catalog",
  "entities": [
    {
      "binding": {"cell": {"x": 3, "y": 1, "z": 0}, "kind": "cell"},
      "capabilities": ["authority", "emits_light", "interactable", "machine", "persisted"],
      "claims": [
        {"capability": "emits_light", "id": "brazier_02.emission#emits_light", "resolver": "light",
         "source": {"byte_end": 437, "byte_start": 365, "column": 1, "line": 18, "path": "world.nomos"}}
      ],
      "id": "brazier_02",
      "light_subject": true,
      "machines": [{"initial": "lit", "namespace": "brazier_02.emission", "states": ["extinguished", "lit"]}],
      "movement_subject": false,
      "primitive": "primitive/extinguishable_light"
    },
    {
      "binding": {"kind": "region", "max": {"x": 4, "y": 3, "z": 0}, "min": {"x": 2, "y": 2, "z": 0}},
      "capabilities": ["authority", "persisted", "region", "traversal_cost_ground"],
      "claims": [
        {"capability": "traversal_cost_ground", "id": "flooded_section.region#traversal_cost_ground",
         "resolver": "movement",
         "source": {"byte_end": 363, "byte_start": 278, "column": 1, "line": 14, "path": "world.nomos"}}
      ],
      "id": "flooded_section",
      "light_subject": false,
      "machines": [],
      "movement_subject": true,
      "primitive": "primitive/shallow_water_region"
    },
    {
      "binding": {"cell": {"x": 5, "y": 0, "z": 0}, "direction": "north", "kind": "face"},
      "capabilities": ["authority", "blocks_ground", "boundary", "interactable", "machine", "persisted", "portal"],
      "claims": [
        {"capability": "blocks_ground", "id": "north_gate.portal#blocks_ground", "resolver": "movement",
         "source": {"byte_end": 162, "byte_start": 53, "column": 1, "line": 4, "path": "world.nomos"}},
        {"capability": "blocks_ground", "id": "north_gate.ward#blocks_ground", "resolver": "movement",
         "source": {"byte_end": 162, "byte_start": 53, "column": 1, "line": 4, "path": "world.nomos"}}
      ],
      "id": "north_gate",
      "light_subject": false,
      "machines": [
        {"initial": "locked", "namespace": "north_gate.access", "states": ["closed", "locked", "open"]},
        {"initial": "cold", "namespace": "north_gate.combustion", "states": ["burning", "cold", "spent"]},
        {"initial": "intact", "namespace": "north_gate.integrity", "states": ["damaged", "destroyed", "intact"]},
        {"initial": "sealed", "namespace": "north_gate.ward", "states": ["sealed", "unsealed"]}
      ],
      "movement_subject": true,
      "primitive": "primitive/iron_barred_door"
    },
    {
      "binding": {"cell": {"x": 7, "y": 0, "z": 0}, "direction": "north", "kind": "face"},
      "capabilities": ["authority", "blocks_ground", "boundary", "interactable", "machine", "persisted", "portal"],
      "claims": [
        {"capability": "blocks_ground", "id": "north_gate_02.portal#blocks_ground", "resolver": "movement",
         "source": {"byte_end": 276, "byte_start": 164, "column": 1, "line": 9, "path": "world.nomos"}},
        {"capability": "blocks_ground", "id": "north_gate_02.ward#blocks_ground", "resolver": "movement",
         "source": {"byte_end": 276, "byte_start": 164, "column": 1, "line": 9, "path": "world.nomos"}}
      ],
      "id": "north_gate_02",
      "light_subject": false,
      "machines": [
        {"initial": "locked", "namespace": "north_gate_02.access", "states": ["closed", "locked", "open"]},
        {"initial": "cold", "namespace": "north_gate_02.combustion", "states": ["burning", "cold", "spent"]},
        {"initial": "intact", "namespace": "north_gate_02.integrity", "states": ["damaged", "destroyed", "intact"]},
        {"initial": "sealed", "namespace": "north_gate_02.ward", "states": ["sealed", "unsealed"]}
      ],
      "movement_subject": true,
      "primitive": "primitive/iron_barred_door"
    }
  ],
  "schema": "nomos.entity_catalog@1",
  "status": "completed",
  "world": {
    "manifest_digest": "fabc8398300df90a6bb28b445cc36f2cc4507bbf2a7cc332f575729d4bca0977",
    "world_ir_schema": "nomos.world_ir@2"
  }
}
```

## Where the shape departs from #138, and why

Every field name in the issue's sketch is present and unchanged. Four things a
reviewer should judge:

1. **`command` and `status` are added.** The sketch shows `schema`, `world`,
   `entities`. Every other `nomos` stdout document carries `command` and
   `status`, and a rejection is `{"diagnostics": [...], "status": "rejected"}` —
   a consumer that cannot read `status` cannot tell a catalog from a refusal.
   Nothing #139 codes against is renamed, moved, or retyped; the contract shape
   is a strict subset of what is emitted.
2. **`capabilities` is sorted; World IR's is not.** World IR emits the set in
   `CapabilityKind` declaration order (`["machine", "interactable",
   "emits_light", "authority", "persisted"]`). #138 asks for sorted arrays and
   its own example is lexicographic, so the catalog sorts. The members are
   identical, which is exactly what the acceptance criterion asserts and what
   the test compares, in both directions.
3. **A claim's `source` is its entity's declaration span.** Every claim in the
   gaol corpus is a compiler expansion of a sealed catalog primitive and has no
   source text of its own, so the projected claim carries the entity
   declaration's span. Two claims on the same door therefore share a span. This
   is the plan's own data, copied verbatim — not a narrower span invented here.
4. **`machines` carries definitions, not current states.** `states` is the legal
   state set, `initial` the initial state. Runtime state is what
   `nomos effective-facts <world/> --state <state.json>` already answers; the
   two documents partition cleanly and join on `id`.

**Nothing in the issue's shape could not be populated truthfully.** No field was
dropped and none was invented.

## Acceptance mapping

Test names are in `crates/nomos-cli/tests/entity_catalog.rs` unless stated.

| Issue #138 criterion | Proved by | State |
| --- | --- | --- |
| Command shape and strict verification | `the_argument_grammar_is_exact` — `--help`, root-help listing, four usage rejections (exit 2), `EK0002` on an escaping path, `EK0405` on an absent world | ✅ |
| Read-only, stdout only; no input mutation | `the_catalog_mutates_no_input` — byte comparison of every package member and of the workspace's top-level entries before and after | ✅ |
| No run-bundle file | Same test — asserts the run bundle is the six-file set before, and byte-identical after | ✅ |
| Never reads `.nomos` source | `the_catalog_reads_no_source` — deletes the source the package was compiled from and asserts byte-identical output | ✅ |
| `primitive` matches the source declaration, for `fixtures/gaol.nomos` and all four areas | `every_entity_carries_its_declared_primitive_and_world_ir_capabilities` — the *test* parses each `entity <id> <primitive/kind>` line; five worlds, with an anti-vacuous count assertion | ✅ |
| `capabilities` equal World IR's `expansion.capabilities` | Same test — reads `world/world-ir.json` from the compiled package, compares sets per entity, with an anti-vacuous non-empty assertion | ✅ |
| `binding`, `machines`, `claims`, resolver flags come from the plans | `resolver_subjects_claims_and_machines_come_from_the_plans` — exact canonical byte strings for the door's binding, four machines, and both claims; the water region's cost claim; the brazier's light claim | ✅ |
| Byte-identical across ten runs for the same package | `the_same_world_produces_byte_identical_output` — ten invocations, three anti-vacuous guards, plus a second compilation of the same source at the same path | ✅ |
| Arrays sorted; no floating point | The byte assertions above; `CanonicalValue` has no float variant | ✅ |
| Identity declared in the owner crate | `the_catalog_identity_is_versioned_and_is_not_a_package_artifact` in `crates/nomos-compiler/src/entity_catalog.rs`; it also asserts the identity never enters `produced_schemas()` and so cannot reach a package member | ✅ |
| Identity registered; `r1-schema-ownership.sh` → `schema_identities_r1 2` | Proof commands below | ✅ |
| `RUNTIME.md` §3 table row added | Three rows: `nomos-compiler`, `nomos-cli`, `nomos-core` | ✅ |
| Four proof commands pass | Proof commands below | ✅ |
| No Gate K command, artifact, hash, or diagnostic changes | 222 workspace tests pass (214 → 222, +8), every pre-existing suite unchanged and no assertion edited; the frozen canonical hash-domain regression is unchanged; no diagnostic code added; `produced_schemas()` and the package registry untouched; `Cargo.lock` unchanged | ✅ |
| Non-author rerun recorded | Owner's | ⏳ |

Must-nots:

| Must not | Evidence | State |
| --- | --- | --- |
| Classify by string convention | The builder contains no `ends_with`, no substring test, and no entity or namespace literal | ✅ |
| Add a second decoder for `.nomos`, World IR, or receipts | The command opens a package through the one existing strict opener and decodes nothing itself | ✅ |
| Add a third-party dependency or a new dependency edge | `Cargo.lock` unchanged; `nomos-compiler → nomos-schema` and `nomos-cli → nomos-compiler` already exist; `cargo xtask boundary` clean | ✅ |
| Edit `KERNEL.md`, `THESIS.md`, or the frozen `SCHEMA_OWNERSHIP.md` | `git diff origin/main HEAD` over all three is empty | ✅ |
| Leave a file over ~1,000 lines | Largest touched file is `crates/nomos-cli/src/command.rs` at 833 lines | ✅ |

## Disclosed refactor: one owner for the source-span rendering

The claim `source` object is the `byte_end`/`byte_start`/`column`/`line`/`path`
shape written out **five** times, byte-identically, across `nomos-core`
(`Diagnostic::to_canonical`), `nomos-schema` (`ir::span_to_canonical`),
`nomos-projection` (`movement::span_to_canonical`, `light::span_to_canonical`),
and `nomos-cli` (`explanation.rs`). Rather than add a sixth copy, this adds
`SourceSpan::to_canonical` in `nomos-core` — the crate that owns the type — and
deletes all five. Field for field the rendering is unchanged, so no artifact
byte moves; the 222 workspace tests, which include byte assertions on every
compiled package member and on committed run-bundle evidence, are the proof.

## Disclosed finding, filed not folded in: #141

`docs/evaluation/test-gate-k-eval-tooling.sh` fails locally under a UTF-8
locale, on this branch and equally on a pristine `origin/main` checkout:
`tree_sha` at `docs/evaluation/gate-k-eval-packet.sh:164` sorts paths with
`sort -z` and pins no collation, so its digest is locale-dependent. Under
`LC_ALL=C` it reproduces the frozen `artifactsTreeSha256` receipt exactly. Same
class of defect as #134. Pre-existing and unrelated to this slice — the branch
touches no file under `docs/evaluation/runs/` — so it is filed as **#141** with
evidence rather than repaired here.
`LC_ALL=C docs/evaluation/test-gate-k-eval-tooling.sh` exits 0 on this branch.

## Proof commands

Worktree root, Linux x86_64, toolchain 1.98.0.

```console
$ cargo fmt --all -- --check
EXIT=0

$ cargo clippy --workspace --all-targets --locked -- -D warnings
    Checking nomos-core v0.0.0 (.../crates/nomos-core)
    Checking xtask v0.0.0 (.../xtask)
    Checking nomos-projection v0.0.0 (.../crates/nomos-projection)
    Checking nomos-schema v0.0.0 (.../crates/nomos-schema)
    Checking nomos-sim v0.0.0 (.../crates/nomos-sim)
    Checking nomos-compiler v0.0.0 (.../crates/nomos-compiler)
    Checking nomos-cli v0.0.0 (.../crates/nomos-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.60s

$ cargo test --workspace --locked
total passed: 222  total failed: 0

$ cargo xtask boundary
boundary: clean
  kernel crates      nomos-core, nomos-schema, nomos-projection, nomos-compiler, nomos-sim, nomos-cli
  tooling crates     xtask
  rules checked      membership, permitted-edges, cycles, forbidden-dependency, tooling-isolation
  forbidden entries  64 exact names, 8 prefixes
EXIT=0

$ docs/evaluation/r1-schema-ownership.sh
R1_SCHEMA_OWNERSHIP PASS
schema_identities_gate_k 20
schema_identities_r1 2
```

```console
running 7 tests
test the_argument_grammar_is_exact ... ok
test the_catalog_reads_no_source ... ok
test resolver_subjects_claims_and_machines_come_from_the_plans ... ok
test the_catalog_names_its_schema_and_the_world_it_catalogued ... ok
test the_catalog_mutates_no_input ... ok
test the_same_world_produces_byte_identical_output ... ok
test every_entity_carries_its_declared_primitive_and_world_ir_capabilities ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s
```

## What #139 gets

| `build-plan.mjs` | Convention | Replaced by |
| --- | --- | --- |
| line 25 | `machine.endsWith(".access")` means "door" | `primitive == "primitive/iron_barred_door"`, or `{boundary, portal, blocks_ground}` in `capabilities` |
| lines 17-24 `classify` | movement-table presence means "water" | `primitive == "primitive/shallow_water_region"`, or `traversal_cost_ground` in `capabilities` |
| lines 26-29 `lightEntities` | light-table presence means "light" | `light_subject`, or `emits_light` in `capabilities` |

Two of those are exactly R1-2's "a test renames a machine and an entity
identifier and the classification is unchanged": neither the primitive kind nor
the capability set moves when an identifier does.

Draft: merge and acceptance disposition are the owner's, and nothing here is
green until a non-author reruns the five proof commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsZ5kuhqEodkjFWwdYu43F
