### PR TITLE
Unify the projected activation evaluator

### DIFF
--- a/RUNTIME.md
+++ b/RUNTIME.md
@@ -95,6 +95,7 @@ artifact, hash, or diagnostic.
 | `nomos-compiler` | `entity_catalog.rs`, the `nomos.entity_catalog@1` document builder over the decoded stable World IR and the four verified plans | #138, an R1-2 input | accepted with R1-2 |
 | `nomos-cli` | the `entity-catalog` subcommand | #138, an R1-2 input | accepted with R1-2 |
 | `nomos-core` | `SourceSpan::to_canonical`, the one rendering of a source span; it replaces five byte-identical private copies in `nomos-core`, `nomos-schema`, `nomos-projection`, and `nomos-cli` | #138, an R1-2 input | accepted with R1-2 |
+| `nomos-projection` | `activation_is_true`, the one evaluator of `ProjectedActivation`, taking the activation and a caller-supplied state lookup that owns its own diagnostic; it replaces the private copies in `nomos-compiler` and `nomos-sim`, which cannot share code as placed | #136 | proposed |
 
 The three R1-1 rows are accepted: `nomos.effective_facts@1` is registered in
 `docs/evaluation/R1_SCHEMA_OWNERSHIP.md`, its comparison harness reports

--- a/crates/nomos-cli/tests/activation_evaluator.rs
+++ b/crates/nomos-cli/tests/activation_evaluator.rs
@@ -1,0 +1,129 @@
+//! Acceptance proof for the unified projected-activation evaluator (issue #136).
+//!
+//! `nomos-compiler` and `nomos-sim` each carried a private evaluator of
+//! `ProjectedActivation`. `RUNTIME.md` section 1 adoption criterion 2 — no
+//! shadow resolver survives — applies inside the kernel too, so the evaluator
+//! now lives once in `nomos-projection` and both callers pass it their own
+//! state lookup. The design record is `docs/review/activation-evaluator.md`.
+//!
+//! The two crates cannot see each other (`KERNEL.md` section 10 permits
+//! `nomos-compiler` -> core/schema/projection and `nomos-sim` ->
+//! core/projection, and no edge between them), so this test lives in the one
+//! crate that depends on both. It is the equivalence nothing proved before:
+//! the compile-time initial movement recorded in stable World IR must equal
+//! what `resolve_movement` resolves at the initial simulation state, subject by
+//! subject, for the fixture and every committed gaol area.
+
+use nomos_core::SourcePath;
+use nomos_projection::MovementDisposition;
+use nomos_sim::{SimulationState, resolve_movement};
+
+/// The fixture plus the four committed gaol areas, which the acceptance
+/// criterion names explicitly.
+const WORLDS: [(&str, &str); 5] = [
+    (
+        "fixtures/gaol.nomos",
+        include_str!("../../../fixtures/gaol.nomos"),
+    ),
+    (
+        "experiments/executable-gaol/areas/cistern-walk/world.nomos",
+        include_str!("../../../experiments/executable-gaol/areas/cistern-walk/world.nomos"),
+    ),
+    (
+        "experiments/executable-gaol/areas/ember-vault/world.nomos",
+        include_str!("../../../experiments/executable-gaol/areas/ember-vault/world.nomos"),
+    ),
+    (
+        "experiments/executable-gaol/areas/north-gaol/world.nomos",
+        include_str!("../../../experiments/executable-gaol/areas/north-gaol/world.nomos"),
+    ),
+    (
+        "experiments/executable-gaol/areas/ossuary-reach/world.nomos",
+        include_str!("../../../experiments/executable-gaol/areas/ossuary-reach/world.nomos"),
+    ),
+];
+
+#[test]
+fn compile_time_initial_movement_equals_the_resolver_at_the_initial_state() {
+    let mut subjects_compared = 0_usize;
+    for (path, source) in WORLDS {
+        let stable = nomos_compiler::compile_world(source, SourcePath::new(path).unwrap()).unwrap();
+        let plan = nomos_compiler::compile_simulation_plan(&stable).unwrap();
+        let initial = SimulationState::initialize(&plan).unwrap();
+        let resolved = resolve_movement(&plan, &initial).unwrap();
+
+        assert_eq!(
+            stable.movement_v2().len(),
+            resolved.facts().len(),
+            "{path}: compile-time and runtime subject counts differ"
+        );
+        for row in stable.movement_v2() {
+            let entity = row.entity();
+            let compiled = row.movement_disposition_ground();
+            let runtime = resolved
+                .get(entity)
+                .unwrap_or_else(|| panic!("{path}: `{entity}` is absent from resolved facts"));
+            match runtime {
+                MovementDisposition::Blocked { reasons } => {
+                    assert!(
+                        compiled.is_blocked(),
+                        "{path}: `{entity}` is blocked at runtime but not at compile time"
+                    );
+                    assert_eq!(
+                        compiled.cost(),
+                        None,
+                        "{path}: `{entity}` blocked disposition carries a cost"
+                    );
+                    assert_eq!(
+                        compiled.reasons(),
+                        reasons.as_slice(),
+                        "{path}: `{entity}` blocking reasons differ"
+                    );
+                }
+                MovementDisposition::Traversable { cost, reasons } => {
+                    assert!(
+                        !compiled.is_blocked(),
+                        "{path}: `{entity}` is traversable at runtime but blocked at compile time"
+                    );
+                    assert_eq!(
+                        compiled.cost(),
+                        Some(*cost),
+                        "{path}: `{entity}` effective cost differs"
+                    );
+                    assert_eq!(
+                        compiled.reasons(),
+                        reasons.as_slice(),
+                        "{path}: `{entity}` cost reasons differ"
+                    );
+                }
+            }
+            subjects_compared += 1;
+        }
+    }
+    assert!(
+        subjects_compared > 0,
+        "the equivalence must compare at least one movement subject"
+    );
+}
+
+#[test]
+fn every_world_carries_a_state_dependent_activation_for_the_evaluator_to_decide() {
+    // Without this the equivalence above could pass on worlds whose every claim
+    // is `always`, which would exercise no state lookup at all.
+    for (path, source) in WORLDS {
+        let stable = nomos_compiler::compile_world(source, SourcePath::new(path).unwrap()).unwrap();
+        let plan = nomos_compiler::compile_simulation_plan(&stable).unwrap();
+        let mut state_predicates = 0_usize;
+        for subject in plan.movement_resolver().subjects() {
+            for claim in subject.claims() {
+                claim
+                    .activation()
+                    .visit_state_equals(&mut |_, _| state_predicates += 1);
+            }
+        }
+        assert!(
+            state_predicates > 0,
+            "{path}: no movement claim depends on machine state"
+        );
+    }
+}

--- a/crates/nomos-compiler/src/projection.rs
+++ b/crates/nomos-compiler/src/projection.rs
@@ -9,7 +9,7 @@ use nomos_projection::{
     LightResolverPlan as ProjectedLightResolverPlan, LightSubject, MachineDefinition,
     MovementClaim, MovementConnectivity, MovementResolverPlan as ProjectedMovementResolverPlan,
     MovementSubject, NavigationPlan, PersistencePlan, Phase, ProjectedActivation,
-    ProjectedDirection, ProjectedEntity, RuntimeBinding, SimulationPlan,
+    ProjectedDirection, ProjectedEntity, RuntimeBinding, SimulationPlan, activation_is_true,
     validate_light_projection_agreement,
 };
 use nomos_schema::{
@@ -111,18 +111,14 @@ pub(crate) fn validate_all_light_projections(ir: &WorldIr) -> Result<(), Diagnos
 
 pub(crate) fn initial_movement_v1(ir: &WorldIr) -> Result<Vec<StableGroundMovementV1>, Diagnostic> {
     let projected = movement_plan(ir)?;
-    let initial_states: BTreeMap<NamespaceId, Ident> = ir
-        .entities()
-        .iter()
-        .flat_map(|entity| entity.expansion().machines())
-        .map(|machine| (machine.namespace().clone(), machine.initial().clone()))
-        .collect();
+    let initial_states = initial_machine_states(ir);
+    let state_equals = initial_state_lookup(&initial_states);
     let mut rows = Vec::new();
     for subject in projected.subjects() {
         let mut blocked = false;
         let mut maximum_cost = None;
         for claim in subject.claims() {
-            if !projected_activation_is_true(claim.activation(), &initial_states)? {
+            if !activation_is_true(claim.activation(), &state_equals)? {
                 continue;
             }
             match claim {
@@ -149,12 +145,8 @@ pub(crate) fn initial_movement_v1(ir: &WorldIr) -> Result<Vec<StableGroundMoveme
 
 pub(crate) fn initial_movement_v2(ir: &WorldIr) -> Result<Vec<StableGroundMovementV2>, Diagnostic> {
     let projected = movement_plan(ir)?;
-    let initial_states: BTreeMap<NamespaceId, Ident> = ir
-        .entities()
-        .iter()
-        .flat_map(|entity| entity.expansion().machines())
-        .map(|machine| (machine.namespace().clone(), machine.initial().clone()))
-        .collect();
+    let initial_states = initial_machine_states(ir);
+    let state_equals = initial_state_lookup(&initial_states);
     projected
         .subjects()
         .iter()
@@ -162,7 +154,7 @@ pub(crate) fn initial_movement_v2(ir: &WorldIr) -> Result<Vec<StableGroundMoveme
             let mut blockers = Vec::new();
             let mut costs = Vec::new();
             for claim in subject.claims() {
-                if !projected_activation_is_true(claim.activation(), &initial_states)? {
+                if !activation_is_true(claim.activation(), &state_equals)? {
                     continue;
                 }
                 match claim {
@@ -617,13 +609,26 @@ fn project_activation(activation: &ClaimActivation) -> ProjectedActivation {
     }
 }
 
-fn projected_activation_is_true(
-    activation: &ProjectedActivation,
+/// Every machine's authored initial state, keyed by namespace.
+fn initial_machine_states(ir: &WorldIr) -> BTreeMap<NamespaceId, Ident> {
+    ir.entities()
+        .iter()
+        .flat_map(|entity| entity.expansion().machines())
+        .map(|machine| (machine.namespace().clone(), machine.initial().clone()))
+        .collect()
+}
+
+/// The compile-time state lookup `nomos_projection::activation_is_true` consumes.
+///
+/// It owns the diagnostic the initial-movement shape has always emitted for a
+/// namespace the world does not declare. Issue #136 moved the evaluator, not
+/// this message: the runtime resolver reports a different code and wording for
+/// its own two lookups, and unifying them would change accepted diagnostics.
+fn initial_state_lookup(
     states: &BTreeMap<NamespaceId, Ident>,
-) -> Result<bool, Diagnostic> {
-    match activation {
-        ProjectedActivation::Always => Ok(true),
-        ProjectedActivation::StateEquals { namespace, state } => states
+) -> impl Fn(&NamespaceId, &Ident) -> Result<bool, Diagnostic> + '_ {
+    move |namespace, state| {
+        states
             .get(namespace)
             .map(|current| current == state)
             .ok_or_else(|| {
@@ -631,22 +636,7 @@ fn projected_activation_is_true(
                     nomos_core::diagnostic::codes::RESOLVER_ACTIVATION_NAMESPACE_MISSING,
                     format!("initial movement activation namespace `{namespace}` does not exist"),
                 )
-            }),
-        ProjectedActivation::Any(children) => {
-            let mut result = false;
-            for child in children {
-                result |= projected_activation_is_true(child, states)?;
-            }
-            Ok(result)
-        }
-        ProjectedActivation::All(children) => {
-            let mut result = true;
-            for child in children {
-                result &= projected_activation_is_true(child, states)?;
-            }
-            Ok(result)
-        }
-        ProjectedActivation::Not(child) => Ok(!projected_activation_is_true(child, states)?),
+            })
     }
 }
 

--- a/crates/nomos-projection/src/lib.rs
+++ b/crates/nomos-projection/src/lib.rs
@@ -49,6 +49,7 @@ pub use light::{
 pub use movement::{
     LatticeCell, MovementClaim, MovementConnectivity, MovementDisposition, MovementResolverPlan,
     MovementSubject, NavigationPlan, ProjectedActivation, ResolvedMovement, ResolvedMovementFacts,
+    activation_is_true,
 };
 pub use simulation::{
     CausalEdge, Command, CommandArgument, CommandRequirement, CommandTransition, EventHandler,

--- a/crates/nomos-projection/src/movement.rs
+++ b/crates/nomos-projection/src/movement.rs
@@ -159,6 +159,72 @@ fn activation_group(kind: &'static str, children: &[ProjectedActivation]) -> Can
     ])
 }
 
+/// Evaluates one projected activation against a caller-supplied state lookup.
+///
+/// This is the only evaluator of [`ProjectedActivation`] in the workspace. It
+/// lived twice — `nomos_sim`'s runtime resolver and `nomos_compiler`'s
+/// compile-time initial-movement shape each carried a private copy that nothing
+/// proved equal (issue #136). Neither crate may depend on the other, so the one
+/// function lives beside the type both already consume.
+///
+/// `state_equals` answers exactly one question — is `namespace` currently in
+/// `state`? — and owns the diagnostic for a namespace or state it cannot answer
+/// for. That is deliberate: the runtime resolver checks the simulation plan and
+/// the live state and reports which of the two is missing, while the compiler
+/// checks the world's initial states, and the two emit different stable codes
+/// and messages. Unifying the text would change accepted diagnostics; supplying
+/// it does not.
+///
+/// This evaluates one activation node. It composes no movement disposition and
+/// no light fact, so it is not a second resolver: effective facts still come
+/// from `nomos_sim::resolve_movement` and `nomos_sim::resolve_light`, which
+/// keep the projected-law flags in the path.
+///
+/// # Errors
+///
+/// Propagates whatever diagnostic `state_equals` returns, and returns `EK0907`
+/// for an empty `any` or `all` group, which no validly projected plan contains.
+pub fn activation_is_true<L>(
+    activation: &ProjectedActivation,
+    state_equals: &L,
+) -> Result<bool, Diagnostic>
+where
+    L: Fn(&NamespaceId, &Ident) -> Result<bool, Diagnostic>,
+{
+    match activation {
+        ProjectedActivation::Always => Ok(true),
+        ProjectedActivation::StateEquals { namespace, state } => state_equals(namespace, state),
+        ProjectedActivation::Any(children) => {
+            if children.is_empty() {
+                return Err(empty_activation_group("any"));
+            }
+            let mut result = false;
+            for child in children {
+                result |= activation_is_true(child, state_equals)?;
+            }
+            Ok(result)
+        }
+        ProjectedActivation::All(children) => {
+            if children.is_empty() {
+                return Err(empty_activation_group("all"));
+            }
+            let mut result = true;
+            for child in children {
+                result &= activation_is_true(child, state_equals)?;
+            }
+            Ok(result)
+        }
+        ProjectedActivation::Not(child) => Ok(!activation_is_true(child, state_equals)?),
+    }
+}
+
+fn empty_activation_group(kind: &str) -> Diagnostic {
+    Diagnostic::new(
+        nomos_core::diagnostic::codes::RESOLVER_PLAN_INVALID,
+        format!("runtime received an empty `{kind}` activation group"),
+    )
+}
+
 /// One typed movement claim projected from the compiler-owned catalog.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum MovementClaim {

--- a/crates/nomos-sim/src/resolver.rs
+++ b/crates/nomos-sim/src/resolver.rs
@@ -2,11 +2,11 @@
 
 use std::collections::BTreeSet;
 
-use nomos_core::{Diagnostic, NamespaceId};
+use nomos_core::{Diagnostic, Ident, NamespaceId};
 use nomos_projection::{
     LightProjectionConsumer, MachineDefinition, MovementClaim, MovementConnectivity,
-    MovementDisposition, ProjectedActivation, ResolvedLight, ResolvedLightFacts, ResolvedMovement,
-    ResolvedMovementFacts, SimulationPlan,
+    MovementDisposition, ResolvedLight, ResolvedLightFacts, ResolvedMovement,
+    ResolvedMovementFacts, SimulationPlan, activation_is_true,
 };
 
 use crate::SimulationState;
@@ -36,13 +36,14 @@ pub fn resolve_movement(
         ));
     }
 
+    let state_equals = machine_state_lookup(plan, state);
     let mut facts = Vec::new();
     for subject in resolver.subjects() {
         validate_connectivity(subject.connectivity())?;
         let mut blockers = Vec::new();
         let mut active_costs = Vec::new();
         for claim in subject.claims() {
-            if !activation_is_true(claim.activation(), plan, state)? {
+            if !activation_is_true(claim.activation(), &state_equals)? {
                 continue;
             }
             match claim {
@@ -105,6 +106,7 @@ pub fn resolve_light(
         ));
     }
 
+    let state_equals = machine_state_lookup(plan, state);
     let mut facts = Vec::new();
     for subject in resolver.subjects() {
         let mut reasons = Vec::new();
@@ -118,7 +120,7 @@ pub fn resolve_light(
                     ),
                 ));
             }
-            if activation_is_true(claim.activation(), plan, state)? {
+            if activation_is_true(claim.activation(), &state_equals)? {
                 reasons.push(claim.id().clone());
             }
         }
@@ -152,55 +154,33 @@ fn validate_connectivity(connectivity: &MovementConnectivity) -> Result<(), Diag
     }
 }
 
-fn activation_is_true(
-    activation: &ProjectedActivation,
-    plan: &SimulationPlan,
-    state: &SimulationState,
-) -> Result<bool, Diagnostic> {
-    match activation {
-        ProjectedActivation::Always => Ok(true),
-        ProjectedActivation::StateEquals {
-            namespace,
-            state: required,
-        } => {
-            let machine = find_machine(plan, namespace).ok_or_else(|| {
-                missing_reference(format!(
-                    "claim activation namespace `{namespace}` is absent from the simulation plan"
-                ))
-            })?;
-            if !machine.states().contains(required) {
-                return Err(missing_reference(format!(
-                    "claim activation state `{required}` is absent from `{namespace}`"
-                )));
-            }
-            let current = state.machine(namespace).ok_or_else(|| {
-                missing_reference(format!(
-                    "claim activation namespace `{namespace}` is absent from current state"
-                ))
-            })?;
-            Ok(current == required)
+/// The runtime state lookup `nomos_projection::activation_is_true` consumes.
+///
+/// It owns the three diagnostics the runtime resolver has always emitted for a
+/// projection that names something it does not carry: a namespace absent from
+/// the plan, a state absent from that machine, and a namespace absent from the
+/// current state. Issue #136 moved the evaluator, not these messages.
+fn machine_state_lookup<'a>(
+    plan: &'a SimulationPlan,
+    state: &'a SimulationState,
+) -> impl Fn(&NamespaceId, &Ident) -> Result<bool, Diagnostic> + 'a {
+    move |namespace, required| {
+        let machine = find_machine(plan, namespace).ok_or_else(|| {
+            missing_reference(format!(
+                "claim activation namespace `{namespace}` is absent from the simulation plan"
+            ))
+        })?;
+        if !machine.states().contains(required) {
+            return Err(missing_reference(format!(
+                "claim activation state `{required}` is absent from `{namespace}`"
+            )));
         }
-        ProjectedActivation::Any(children) => {
-            if children.is_empty() {
-                return Err(invalid_group("any"));
-            }
-            let mut result = false;
-            for child in children {
-                result |= activation_is_true(child, plan, state)?;
-            }
-            Ok(result)
-        }
-        ProjectedActivation::All(children) => {
-            if children.is_empty() {
-                return Err(invalid_group("all"));
-            }
-            let mut result = true;
-            for child in children {
-                result &= activation_is_true(child, plan, state)?;
-            }
-            Ok(result)
-        }
-        ProjectedActivation::Not(child) => Ok(!activation_is_true(child, plan, state)?),
+        let current = state.machine(namespace).ok_or_else(|| {
+            missing_reference(format!(
+                "claim activation namespace `{namespace}` is absent from current state"
+            ))
+        })?;
+        Ok(current == required)
     }
 }
 
@@ -218,12 +198,5 @@ fn missing_reference(message: String) -> Diagnostic {
     Diagnostic::new(
         nomos_core::diagnostic::codes::RESOLVER_RUNTIME_REFERENCE_MISSING,
         message,
-    )
-}
-
-fn invalid_group(kind: &str) -> Diagnostic {
-    Diagnostic::new(
-        nomos_core::diagnostic::codes::RESOLVER_PLAN_INVALID,
-        format!("runtime received an empty `{kind}` activation group"),
     )
 }

--- a/docs/review/activation-evaluator.md
+++ b/docs/review/activation-evaluator.md
@@ -1,0 +1,129 @@
+---
+title: One projected-activation evaluator — record
+status: R1 slice record; acceptance disposition with the owner
+date: 2026-08-25
+issue: 136
+branch: r1/issue-136-activation-evaluator
+accepts_against: issue #136 acceptance; RUNTIME.md §3 (revision 1, option (a))
+registers: nothing; no new canonical schema identity
+applies_to: RUNTIME.md §3
+---
+
+# One projected-activation evaluator
+
+## What moved
+
+`ProjectedActivation` had two private evaluators that nothing proved equal:
+
+- `crates/nomos-sim/src/resolver.rs:155` `activation_is_true`, reached by
+  `resolve_movement` and `resolve_light`;
+- `crates/nomos-compiler/src/projection.rs:620` `projected_activation_is_true`,
+  called from `initial_movement_v1` and `initial_movement_v2` at lines 125 and
+  165.
+
+`KERNEL.md` §10 permits `nomos-compiler` → core/schema/projection and
+`nomos-sim` → core/projection and no edge between them, so the one evaluator now
+lives in `nomos-projection` beside the type both crates already consume, at
+`crates/nomos-projection/src/movement.rs`. Both private copies are deleted.
+
+## The signature
+
+```rust
+pub fn activation_is_true<L>(
+    activation: &ProjectedActivation,
+    state_equals: &L,
+) -> Result<bool, Diagnostic>
+where
+    L: Fn(&NamespaceId, &Ident) -> Result<bool, Diagnostic>;
+```
+
+The state lookup is a closure, not a `&BTreeMap<NamespaceId, Ident>`, because
+the two callers do not look up the same thing. The compiler holds exactly such a
+map — every machine's authored initial state — and its closure captures it by
+reference. The runtime resolver has no map: it reads the machine table of the
+`SimulationPlan` *and* the live `SimulationState`, and reports which of the two
+is missing. Handing it a `&BTreeMap` would mean materialising one per
+`resolve_movement` and `resolve_light` call, which is allocation churn on the
+runtime path for no gain; a closure over the two borrows it already holds costs
+nothing. The compiler's lookup allocates nothing either — it is a `get` on the
+map it already builds.
+
+The lookup owns its diagnostic, which is the second reason for this shape. The
+two callers report a missing namespace differently and both spellings are
+accepted diagnostics:
+
+| Caller | Code | Message |
+| --- | --- | --- |
+| `nomos-compiler` | `EK0903` `RESOLVER_ACTIVATION_NAMESPACE_MISSING` | ``initial movement activation namespace `{namespace}` does not exist`` |
+| `nomos-sim` | `EK0908` `RESOLVER_RUNTIME_REFERENCE_MISSING` | ``claim activation namespace `{namespace}` is absent from the simulation plan`` |
+| `nomos-sim` | `EK0908` `RESOLVER_RUNTIME_REFERENCE_MISSING` | ``claim activation state `{state}` is absent from `{namespace}` `` |
+| `nomos-sim` | `EK0908` `RESOLVER_RUNTIME_REFERENCE_MISSING` | ``claim activation namespace `{namespace}` is absent from current state`` |
+
+Unifying that text would change accepted diagnostics, which `RUNTIME.md` §3
+option (a) forbids. Each message stays with its caller, byte for byte:
+`machine_state_lookup` in `crates/nomos-sim/src/resolver.rs` and
+`initial_state_lookup` in `crates/nomos-compiler/src/projection.rs`.
+
+## Where the two evaluators actually differed
+
+They were not byte-identical, and the difference is recorded rather than papered
+over. On an empty `any` or `all` group the runtime copy returned `EK0907`
+`RESOLVER_PLAN_INVALID`, ``runtime received an empty `{kind}` activation
+group``; the compiler copy returned vacuous truth — `false` for empty `any`,
+`true` for empty `all`. The shared function keeps the strict runtime behaviour,
+message included.
+
+That is unreachable in the compiler and therefore changes no compiler
+diagnostic. `initial_movement_v1` and `initial_movement_v2` obtain their plan
+from `movement_plan`, which calls `validate_activation`
+(`crates/nomos-compiler/src/projection.rs`) on every claim before
+`project_activation` builds a `ProjectedActivation`; that validation refuses an
+empty group with `EK0907`, "claim activation groups must not be empty". No
+compiled world can carry one. The runtime copy checks it anyway because a
+package on disk is not necessarily one this compiler produced.
+
+The runtime lookup also verifies that the required state exists in the named
+machine before comparing, which the compiler copy never did. That check moved
+into `machine_state_lookup` unchanged, so it still applies on the runtime path
+and still does not apply on the compile-time path.
+
+## The equivalence test
+
+`crates/nomos-cli/tests/activation_evaluator.rs`, in the one crate that depends
+on both compiler and runtime:
+`compile_time_initial_movement_equals_the_resolver_at_the_initial_state`
+compiles `fixtures/gaol.nomos` and all four `experiments/executable-gaol/areas/*/world.nomos`,
+and asserts that every stable-v2 initial movement row equals what
+`nomos_sim::resolve_movement` resolves against `SimulationState::initialize` —
+same subjects, same blocked/traversable disposition, same effective cost, same
+ordered reasons. A second test proves the comparison is not vacuous: every one
+of the five worlds carries at least one `state_equals` predicate, so the state
+lookup is actually exercised. Inverting the compiler lookup's comparison fails
+the first test on `north_gate`.
+
+## Gate K visibility
+
+Nothing Gate K-visible changed. The frozen hash-domain regression in
+`crates/nomos-core/tests/determinism.rs` and the golden fixtures run under
+`cargo test --workspace --locked`, and every artifact and command output for the
+five worlds — 63 files across `validate`, `compile`, `inspect`,
+`entity-catalog`, `run`, `explain-entity`, and `effective-facts` — is
+byte-identical to the same files produced by the binary built at `origin/main`
+(`52296dc`). No canonical schema identity is added, so
+`docs/evaluation/R1_SCHEMA_OWNERSHIP.md` is untouched and
+`docs/evaluation/r1-schema-ownership.sh` still passes.
+
+## Open point for the owner
+
+`RUNTIME.md` §5 R1-1 is an accepted criterion and it names this function:
+"`activation_is_true` (`resolver.rs:155`) staying private so the projected law
+flags stay in the path." That line reference no longer resolves, and the
+function is now `pub` in `nomos-projection`. Issue #136 dispositions the move
+explicitly and calls it a separate slice, so this change follows the issue and
+does not edit the accepted §5 text; repairing that wording is an owner decision
+under `RUNTIME.md` §8. The criterion's substance is unaffected: the shared
+function evaluates one activation node and composes no movement disposition and
+no light fact, so effective facts still come only from `resolve_movement` and
+`resolve_light`, with the projected-law flags in the path, and R1-1's "must not
+add a second implementation of activation evaluation" is strengthened by this
+change, not weakened.


### PR DESCRIPTION
Closes #136. Draft: no non-author rerun yet.

`ProjectedActivation` had two private evaluators that nothing proved equal —
`nomos-sim`'s runtime resolver and `nomos-compiler`'s compile-time
initial-movement shape. `KERNEL.md` §10 permits no edge between those crates, so
the one evaluator now lives in `nomos-projection` beside the type both already
consume. This is R1 surface in a kernel crate under `RUNTIME.md` §3 option (a);
no Gate K command, artifact, hash, or diagnostic changes.

## Acceptance mapping

| Issue #136 acceptance | Where |
| --- | --- |
| Exactly one function in `crates/` evaluates `ProjectedActivation`; the grep matches only the projection crate and the compiler's constructor | `nomos_projection::activation_is_true` (`crates/nomos-projection/src/movement.rs`); both private copies deleted; grep output below |
| A test asserts compile-time initial-movement facts equal `resolve_movement` at the initial state for `fixtures/gaol.nomos` and all four gaol areas | `crates/nomos-cli/tests/activation_evaluator.rs::compile_time_initial_movement_equals_the_resolver_at_the_initial_state` |
| Four proof commands pass; determinism matrix unchanged | proof results below; 63 artifact and command-output hashes byte-identical to `origin/main` |
| `R1_SCHEMA_OWNERSHIP.md` unchanged (no new identity) | untouched; `docs/evaluation/r1-schema-ownership.sh` passes |
| Listed in `RUNTIME.md` §3 "R1 surface added to kernel crates" | new `nomos-projection` row, slice `#136` |
| Non-author rerun recorded | **not done** — this PR is a draft pending it |

## The signature, and why

```rust
pub fn activation_is_true<L>(
    activation: &ProjectedActivation,
    state_equals: &L,
) -> Result<bool, Diagnostic>
where
    L: Fn(&NamespaceId, &Ident) -> Result<bool, Diagnostic>;
```

A closure, not a `&BTreeMap<NamespaceId, Ident>`. The compiler holds exactly such
a map — every machine's authored initial state — and its closure captures it by
reference. The runtime resolver has no map: it reads the `SimulationPlan`'s
machine table *and* the live `SimulationState`, and reports which of the two is
missing. A `&BTreeMap` parameter would force it to materialise one per
`resolve_movement` / `resolve_light` call — allocation churn on the runtime path
for nothing. Both callers supply the closure from borrows they already hold.

The lookup also owns its caller's diagnostic, so no message is unified:

| Caller | Code | Message |
| --- | --- | --- |
| `nomos-compiler` | `EK0903` | ``initial movement activation namespace `{namespace}` does not exist`` |
| `nomos-sim` | `EK0908` | ``claim activation namespace `{namespace}` is absent from the simulation plan`` |
| `nomos-sim` | `EK0908` | ``claim activation state `{state}` is absent from `{namespace}` `` |
| `nomos-sim` | `EK0908` | ``claim activation namespace `{namespace}` is absent from current state`` |

## Where the two evaluators actually differed

They were **not** equivalent, and this is recorded rather than smoothed over.

1. **Empty `any` / `all` group.** The runtime copy returned `EK0907`
   `RESOLVER_PLAN_INVALID`, ``runtime received an empty `{kind}` activation
   group``. The compiler copy returned vacuous truth — `false` for empty `any`,
   `true` for empty `all`. The shared function keeps the strict runtime
   behaviour, message included. It is unreachable in the compiler:
   `initial_movement_v1` / `_v2` get their plan from `movement_plan`, which runs
   `validate_activation` on every claim before `project_activation`, and that
   refuses an empty group with `EK0907` "claim activation groups must not be
   empty". No compiled world can carry one; a package on disk is not necessarily
   one this compiler produced, which is why the runtime check stays.
2. **Required-state existence.** The runtime copy verified that the required
   state exists in the named machine before comparing (`EK0908` "claim
   activation state ... is absent from ..."); the compiler copy never did. That
   check moved into the runtime lookup unchanged, so it still applies on the
   runtime path and still does not apply on the compile-time path.

Neither difference changes an emitted diagnostic. `docs/review/activation-evaluator.md`
carries the same record.

## Grep acceptance

```console
$ grep -rn 'ProjectedActivation::StateEquals' crates/*/src
crates/nomos-compiler/src/projection.rs:596:        ClaimActivation::StateEquals { namespace, state } => ProjectedActivation::StateEquals {
crates/nomos-projection/src/movement.rs:196:        ProjectedActivation::StateEquals { namespace, state } => state_equals(namespace, state),
```

The projection crate's evaluator and the compiler's constructor, and nothing
else.

## Diff summary

```text
 RUNTIME.md                                  |   1 +
 crates/nomos-cli/tests/activation_evaluator.rs | 129 ++++++++++++++++++++++
 crates/nomos-compiler/src/projection.rs     |  64 +++++------
 crates/nomos-projection/src/lib.rs          |   1 +
 crates/nomos-projection/src/movement.rs     |  66 +++++++++++
 crates/nomos-sim/src/resolver.rs            |  93 ++++++----------
 docs/review/activation-evaluator.md         | 128 +++++++++++++++++++++
 7 files changed, 386 insertions(+), 97 deletions(-)
```

No file touched is near the ~1,000-line decomposition threshold: `projection.rs`
838, `movement.rs` 811, `resolver.rs` 202.

## Proof

```console
$ cargo fmt --all -- --check
(exit 0, no output)

$ cargo clippy --workspace --all-targets --locked -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo test --workspace --locked
57 test binaries, 296 tests passed, 0 failed

$ cargo xtask boundary
boundary: clean
  kernel crates      nomos-core, nomos-schema, nomos-projection, nomos-compiler, nomos-sim, nomos-cli
  tooling crates     xtask
  r1 members         1
  rules checked      membership, permitted-edges, cycles, forbidden-dependency, tooling-isolation
  forbidden entries  64 exact names, 8 prefixes

$ docs/evaluation/r1-schema-ownership.sh
R1_SCHEMA_OWNERSHIP PASS
schema_identities_gate_k 20
schema_identities_r1 4
```

Nothing Gate K-visible changed, two ways. The frozen hash-domain regression in
`crates/nomos-core/tests/determinism.rs` and the golden fixtures run inside
`cargo test --workspace --locked` above. Separately, every artifact and command
output for the five worlds — `validate`, `compile`, `inspect`, `entity-catalog`,
`run`, `explain-entity`, `effective-facts`, 63 files — was produced by the
binary built at `origin/main` (`52296dc`) and by the binary built at this branch,
and the two sha256 listings diff clean.

The equivalence test is not vacuous: a second test asserts every one of the five
worlds carries at least one `state_equals` predicate, and inverting the
compiler's lookup comparison fails the first test on `north_gate`
(`fixtures/gaol.nomos: `north_gate` is blocked at runtime but not at compile
time`).

## One point for the owner

`RUNTIME.md` §5 R1-1 is accepted text and names this function: "`activation_is_true`
(`resolver.rs:155`) staying private so the projected law flags stay in the path."
That line reference no longer resolves and the function is now `pub` in
`nomos-projection`. Issue #136 dispositions the move explicitly and calls it a
separate slice, so this branch follows the issue and does not edit accepted §5
text; repairing that wording is an owner decision under `RUNTIME.md` §8. The
criterion's substance is unaffected: the shared function evaluates one activation
node and composes no movement disposition and no light fact, so effective facts
still come only from `resolve_movement` and `resolve_light` with the
projected-law flags in the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsZ5kuhqEodkjFWwdYu43F
