### PR TITLE
Hotfix: Pages wasm build and Chrome profile cleanup

### DIFF
--- a/.github/workflows/executable-gaol-pages.yml
+++ b/.github/workflows/executable-gaol-pages.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Verify the study and publish its artifacts
         run: experiments/executable-gaol/gaol verify
 
+      # The authoritative runtime, before anything that stages or loads it —
+      # the same two steps as .github/workflows/nomos-viewer.yml. This workflow
+      # runs only on push to main, so a PR lane cannot catch their absence.
+      - name: Build the play runtime for the browser
+        run: crates/nomos-play/build-wasm.sh
+
+      - name: Build the native play runtime
+        run: cargo build --locked -p nomos-play
+
       - name: Viewer tests
         run: node --test apps/nomos-viewer/test/*.test.mjs
 
@@ -51,6 +60,7 @@ jobs:
         run: |
           node apps/nomos-viewer/build.mjs \
             --from target/executable-gaol \
+            --wasm target/wasm32-unknown-unknown/wasm/nomos_play.wasm \
             --out apps/nomos-viewer/dist
 
       - name: Browser smoke lane

--- a/apps/nomos-viewer/smoke/chrome.mjs
+++ b/apps/nomos-viewer/smoke/chrome.mjs
@@ -75,6 +75,27 @@ const versionOf = (binary) => {
 };
 
 /// The Chrome this machine offers, and where it came from.
+
+// Chrome's renderer and GPU children can outlive a SIGKILL on the main pid by
+// a few hundred milliseconds and keep writing into the profile, so a single
+// recursive removal can race them and fail with ENOTEMPTY. The directory is a
+// tmpdir the harness created; failing to remove it must never fail the lane.
+function removeUserDataDir(dir) {
+  const started = Date.now();
+  for (;;) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (Date.now() - started > 3_000) {
+        process.stderr.write(`chrome profile dir left behind: ${dir} (${error.code ?? error.message})\n`);
+        return;
+      }
+      const until = Date.now() + 100;
+      while (Date.now() < until) { /* bounded busy-wait; cleanup path only */ }
+    }
+  }
+}
 export function findChrome() {
   if (process.env.CHROME_BIN) {
     if (!executable(process.env.CHROME_BIN)) {
@@ -180,7 +201,7 @@ export async function launch({ binary, flags, timeout = 20_000 }) {
   }
   if (!port) {
     child.kill("SIGKILL");
-    rmSync(userDataDir, { recursive: true, force: true });
+    removeUserDataDir(userDataDir);
     throw new Error(`chrome wrote no DevToolsActivePort within ${timeout}ms: ${stderr.join("").slice(-500)}`);
   }
 
@@ -214,7 +235,7 @@ export async function launch({ binary, flags, timeout = 20_000 }) {
       child.stdout?.destroy();
       child.stderr?.destroy();
       child.unref();
-      rmSync(userDataDir, { recursive: true, force: true });
+      removeUserDataDir(userDataDir);
     },
   };
 }


### PR DESCRIPTION
Fixes the two main-branch failures after #156: the Pages workflow now builds the wasm and native play runtimes before staging (same steps as the viewer lane) and passes --wasm explicitly; smoke cleanup retries profile-dir removal for up to 3 s and never fails the lane.

Local: build + smoke x3 PASS, no cleanup warnings. The Pages workflow itself only runs on main; verified after merge by fetching nomos_play.wasm from the site.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsZ5kuhqEodkjFWwdYu43F