### PR TITLE
Let an author connect a new area from the packet alone

### DIFF
--- a/experiments/executable-gaol/AUTHORING.md
+++ b/experiments/executable-gaol/AUTHORING.md
@@ -129,3 +129,59 @@ movement disposition, cost, reasons, and light come from `nomos
 effective-facts` — so renaming an entity or a machine cannot change how it is
 drawn, and a primitive the compiler has no kind for is refused rather than
 drawn as a marker.
+
+## Connecting a new area
+
+Adding an area to the route is content, not code. The procedure:
+
+1. **Choose the predecessor.** Pick the existing area the new one will sit
+   behind, and edit that one field: its `presentation.json` `route.exit.to_area`,
+   from `null` (or another area's id) to the new area's id.
+2. **Write the new area.** Create `areas/<id>/` with `world.nomos` and
+   `presentation.json`, following the required-files list and the
+   `presentation.json` rules above. Give it its own `route.entry` — the cell a
+   player lands on arriving through the predecessor's gate — and set its own
+   `route.exit.to_area` to whatever the predecessor's old destination was (`null`
+   if the predecessor used to be the route's terminal).
+3. **Write five scenario scripts.** Copy `areas/north-gaol/scenarios/*.commands`
+   into `areas/<id>/scenarios/` and rename the entities each command names to
+   the new area's own gate and light. The five scripts stay in the same order —
+   baseline, ignite, unseal, extinguish, open — and each of scenarios 2–4 still
+   adds exactly one command to the one before it, because that ordering is what
+   lets the pipeline derive interactions between consecutive scenarios.
+4. **Produce the fixtures.**
+   ```sh
+   experiments/executable-gaol/gaol accept
+   ```
+   This compiles every area — including the new one — and copies what it
+   compiled over the committed examples: each area's
+   `target/executable-gaol/areas/<id>/rendering-plan.json` to that area's own
+   `areas/<id>/rendering-plan.example.json`, and
+   `target/executable-gaol/areas.json` to `area-collection.example.json`. It
+   prints every fixture it wrote.
+5. **Prove it.**
+   ```sh
+   experiments/executable-gaol/gaol verify
+   ```
+   `verify` never writes a fixture; it only compares. Green here is the proof
+   that the fixtures `accept` just wrote are what the pipeline actually
+   produces, not what an author typed by hand.
+
+**What a connected area legitimately changes.** The new area's own directory
+under `areas/<id>/`; the predecessor's `presentation.json` (the one
+`route.exit.to_area` edit) and its regenerated `rendering-plan.example.json`;
+and `area-collection.example.json`, which `gaol accept` also regenerates,
+because the route graph now has one more edge. Nothing under `src/`, `apps/`,
+or `crates/` changes. If a change to connect an area seems to require editing
+any of those, the area is not actually content — file it rather than route
+around it.
+
+**Where the vocabulary lives.** `world.nomos` is written in the source
+language the compiler reads; its full vocabulary — primitives, credentials,
+machines, commands — is `docs/authoring.md`, not this file. The scenario
+scripts under `scenarios/*.commands` are written in the command-script
+vocabulary the scenario files themselves demonstrate: `open`, `ignite`,
+`unseal`, `extinguish`, and `unlock ... with ...` are the commands this corpus
+uses, each one a command the compiled world already accepts or refuses on its
+own terms. This file governs only `presentation.json` and the shape of the
+five scenario scripts; it is not a second copy of either vocabulary.

--- a/experiments/executable-gaol/gaol
+++ b/experiments/executable-gaol/gaol
@@ -93,8 +93,19 @@ case "$mode" in
         "$output_dir/areas/$area_id/frames/contact-sheet.svg"
     done
     ;;
+  accept)
+    build
+    for area_dir in "$areas_dir"/*; do
+      [[ -d $area_dir ]] || continue
+      area_id=$(basename "$area_dir")
+      cp "$output_dir/areas/$area_id/rendering-plan.json" "$area_dir/rendering-plan.example.json"
+      printf 'wrote %s\n' "${area_dir#"$repo_root/"}/rendering-plan.example.json"
+    done
+    cp "$output_dir/areas.json" "$experiment_dir/area-collection.example.json"
+    printf 'wrote %s\n' "${experiment_dir#"$repo_root/"}/area-collection.example.json"
+    ;;
   *)
-    printf 'usage: %s [capture|verify]\n' "$0" >&2
+    printf 'usage: %s [capture|verify|accept]\n' "$0" >&2
     exit 64
     ;;
 esac

--- a/experiments/executable-gaol/src/area-collection.test.mjs
+++ b/experiments/executable-gaol/src/area-collection.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   ACTOR_ASSEMBLIES,
   ARCHITECTURE_ASSEMBLIES,
@@ -13,18 +14,28 @@ import {
   cellsOf,
 } from "./renderer-catalog.mjs";
 
-const readPlan = (id) => JSON.parse(readFileSync(new URL(`../areas/${id}/rendering-plan.example.json`, import.meta.url)));
-const north = readPlan("north-gaol");
-const cistern = readPlan("cistern-walk");
-const ember = readPlan("ember-vault");
-const ossuary = readPlan("ossuary-reach");
+// The corpus is discovered, not named. Every directory under `areas/` is one
+// area; adding a fifth (or a fifteenth) changes nothing below this line.
+const areasDir = fileURLToPath(new URL("../areas/", import.meta.url));
+const areaIds = readdirSync(areasDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
 
-// The area collection itself is not read here any more. `nomos.area_collection@2`
-// is emitted by `crates/nomos-render-plan/src/collection.rs`, its route-graph and
+const readPlan = (id) => JSON.parse(readFileSync(new URL(`../areas/${id}/rendering-plan.example.json`, import.meta.url)));
+const readSource = (id) => readFileSync(new URL(`../areas/${id}/presentation.json`, import.meta.url), "utf8");
+
+const plans = areaIds.map(readPlan);
+const byId = new Map(plans.map((plan) => [plan.area.id, plan]));
+
+// The area collection itself is not read here. `nomos.area_collection@2` is
+// emitted by `crates/nomos-render-plan/src/collection.rs`, its route-graph and
 // visual-grammar refusals are proved by `crates/nomos-render-plan/tests/collection.rs`,
 // and the committed `area-collection.example.json` is compared byte for byte by
-// `verify.mjs --collection`, which also re-derives every plan digest it publishes.
-// What is left in this file is what it was always about: the four committed plans.
+// `verify.mjs --collection`, which also re-derives every plan digest it
+// publishes. What is left in this file is what it was always about: every
+// committed plan, and the route graph each plan's own `route` already carries
+// — discovered from `areas/*/` rather than named here.
 
 const grammar = (plan) => ({
   architectureStyle: plan.architecture.style,
@@ -33,15 +44,16 @@ const grammar = (plan) => ({
   effects: [...new Set(plan.effects.map((effect) => effect.assembly))].sort(),
 });
 
-test("independent areas retain one exact visual grammar", () => {
-  assert.notEqual(north.area.id, cistern.area.id);
-  assert.deepEqual(grammar(cistern), grammar(north));
-  assert.deepEqual(grammar(ember), grammar(north));
-  assert.deepEqual(grammar(ossuary), grammar(north));
+test("every area retains one exact visual grammar", () => {
+  const [reference, ...rest] = plans;
+  for (const plan of rest) {
+    assert.notEqual(plan.area.id, reference.area.id);
+    assert.deepEqual(grammar(plan), grammar(reference));
+  }
 });
 
 test("every area exposes one exact compiled-door objective", () => {
-  for (const plan of [cistern, ember, ossuary, north]) {
+  for (const plan of plans) {
     // The objective is derived from the one authored `route.exit.gate`, so
     // there is no `target` to agree with a `primaryGate` any more: the triple
     // the ownership audit recorded is one field.
@@ -52,17 +64,16 @@ test("every area exposes one exact compiled-door objective", () => {
 });
 
 test("no plan or source carries a decimal, a camera, a palette, or ui anchors", () => {
-  for (const plan of [cistern, ember, ossuary, north]) {
+  for (const plan of plans) {
     for (const gone of ["camera", "palette", "uiAnchors", "ui_anchors", "deterministic", "presentation"]) {
       assert.equal(plan[gone], undefined, `${plan.area.id} still carries ${gone}`);
     }
     const withoutStrings = JSON.stringify(plan).replaceAll(/"[^"]*"/g, '""');
     assert.doesNotMatch(withoutStrings, /[-\d]\.\d/, `${plan.area.id} carries a decimal literal`);
   }
-  for (const area of ["cistern-walk", "ember-vault", "north-gaol", "ossuary-reach"]) {
-    const text = readFileSync(new URL(`../areas/${area}/presentation.json`, import.meta.url), "utf8");
-    const withoutStrings = text.replaceAll(/"[^"]*"/g, '""');
-    assert.doesNotMatch(withoutStrings, /[-\d]\.\d/, `${area} source carries a decimal literal`);
+  for (const id of areaIds) {
+    const withoutStrings = readSource(id).replaceAll(/"[^"]*"/g, '""');
+    assert.doesNotMatch(withoutStrings, /[-\d]\.\d/, `${id} source carries a decimal literal`);
   }
 });
 
@@ -77,16 +88,24 @@ test("vertical steps convert by division, reproducing every replaced decimal", (
   for (const [steps, cells] of expected) {
     assert.equal(cellsOf(steps), cells, `${steps} steps is not ${cells} cells`);
   }
-  assert.equal(cellsOf(north.architecture.wall_height_steps), 4.5);
-  assert.equal(cellsOf(ember.architecture.wall_height_steps), 5);
-  assert.equal(cellsOf(ossuary.architecture.wall_height_steps), 4.8);
-  assert.deepEqual(ossuary.architecture.masses.map((mass) => cellsOf(mass.height_steps)), [0.7, 0.7, 2.4]);
+});
+
+test("architecture heights are declared in bounds, as integer steps", () => {
+  // AUTHORING.md: walls are 1..=50 steps and masonry masses 1..=40.
+  for (const plan of plans) {
+    const wall = plan.architecture.wall_height_steps;
+    assert.ok(Number.isInteger(wall) && wall >= 1 && wall <= 50, `${plan.area.id} wall height ${wall} is out of bounds`);
+    for (const mass of plan.architecture.masses) {
+      const height = mass.height_steps;
+      assert.ok(Number.isInteger(height) && height >= 1 && height <= 40, `${plan.area.id} mass ${mass.id} height ${height} is out of bounds`);
+    }
+  }
 });
 
 test("content selects from the renderer catalog's closed sets", () => {
   // The catalog defines what is legal; the presentation source selects one
   // member. The Rust decoder checks the grammar, this checks the membership.
-  for (const plan of [cistern, ember, ossuary, north]) {
+  for (const plan of plans) {
     assert.ok(ARCHITECTURE_ASSEMBLIES.includes(plan.architecture.style.assembly));
     assert.ok(MATERIAL_FAMILIES.includes(plan.architecture.style.material_family));
     assert.ok(TRIM_FAMILIES.includes(plan.architecture.style.trim_family));
@@ -100,10 +119,11 @@ test("content selects from the renderer catalog's closed sets", () => {
 });
 
 test("every actor declares a role and no plan entity names an assembly", () => {
-  for (const plan of [cistern, ember, ossuary, north]) {
+  for (const plan of plans) {
     assert.equal(plan.schema, "nomos.rendering_plan@3");
-    const roles = plan.actors.map((actor) => actor.role).sort();
-    assert.deepEqual(roles, ["player", "pursuer"]);
+    const roles = plan.actors.map((actor) => actor.role);
+    assert.equal(roles.filter((role) => role === "player").length, 1, `${plan.area.id} declares exactly one player`);
+    assert.ok(roles.filter((role) => role === "pursuer").length <= 1, `${plan.area.id} declares at most one pursuer`);
     for (const entity of plan.entities) {
       assert.equal(entity.visual_assembly, undefined);
       assert.equal(entity.material_family, undefined);
@@ -113,7 +133,7 @@ test("every actor declares a role and no plan entity names an assembly", () => {
 });
 
 test("effects attach by socket and carry no coordinate", () => {
-  for (const plan of [cistern, ember, ossuary, north]) {
+  for (const plan of plans) {
     for (const effect of plan.effects) {
       assert.deepEqual(Object.keys(effect.anchor).sort(), ["entity", "socket"]);
       assert.equal(effect.anchor.socket, "ward");
@@ -122,39 +142,72 @@ test("effects attach by socket and carry no coordinate", () => {
   }
 });
 
-test("each area declares its own arrival cell, and only the start area declares none", () => {
-  assert.equal(cistern.area.start, true);
-  assert.equal(cistern.route.entry, undefined);
-  assert.deepEqual(ember.route.entry, { x: 7, y: 5, z: 0 });
-  assert.deepEqual(ossuary.route.entry, { x: 1, y: 5, z: 0 });
-  assert.deepEqual(north.route.entry, { x: 2, y: 4, z: 0 });
-  assert.equal(north.route.to_area, null);
+test("exactly one area is the start", () => {
+  assert.equal(plans.filter((plan) => plan.area.start).length, 1);
 });
 
-test("every added area is a distinct composition", () => {
-  const anchors = (plan) => plan.entities.map((entity) => entity.anchor);
-  assert.notDeepEqual(anchors(cistern), anchors(north));
-  assert.deepEqual(cistern.actors.find((actor) => actor.role === "player").cell, { x: 7, y: 4, z: 0 });
-  assert.equal(cistern.entities.find((entity) => entity.kind === "water").id, "runoff_channel");
-  assert.notDeepEqual(anchors(ember), anchors(north));
-  assert.equal(ember.architecture.masses.length, 2);
-  assert.equal(ember.architecture.wall_height_steps, 50);
-  assert.notDeepEqual(anchors(ossuary), anchors(north));
-  assert.equal(ossuary.entities.find((entity) => entity.kind === "water").id, "burial_channel");
-  assert.deepEqual(ossuary.entities.find((entity) => entity.kind === "water").anchor, {
-    kind: "region",
-    min: { x: 3, y: 1, z: 0 },
-    max: { x: 5, y: 4, z: 0 },
-  });
-  assert.deepEqual(ossuary.architecture.masses.map((mass) => mass.id), [
-    "west_tomb_bank", "east_tomb_bank", "reliquary_pier",
-  ]);
+test("every non-start area's arrival cell lies inside its own bounds; the start declares none", () => {
+  for (const plan of plans) {
+    if (plan.area.start) {
+      assert.equal(plan.route.entry, undefined, `${plan.area.id} is the start and declares an entry`);
+      continue;
+    }
+    assert.ok(plan.route.entry, `${plan.area.id} is not the start and declares no entry`);
+    const { x, y, z } = plan.route.entry;
+    assert.ok(x >= 0 && x < plan.architecture.bounds.width, `${plan.area.id} entry x is out of bounds`);
+    assert.ok(y >= 0 && y < plan.architecture.bounds.height, `${plan.area.id} entry y is out of bounds`);
+    assert.equal(z, 0, `${plan.area.id} entry is not at z 0`);
+  }
 });
 
+test("every declared to_area names an enumerated area", () => {
+  for (const plan of plans) {
+    if (plan.route.to_area === null) continue;
+    assert.ok(byId.has(plan.route.to_area), `${plan.area.id} names undeclared area ${plan.route.to_area}`);
+  }
+});
 
-// The six tests that drove `play-state.mjs` over these four areas are gone with
-// it. What they asserted - that each committed area is winnable and that one run
-// crosses every declared connection - is now proved end to end by
+test("the route chain from the start visits every area exactly once and ends at the one null exit", () => {
+  const terminal = plans.filter((plan) => plan.route.to_area === null);
+  assert.equal(terminal.length, 1, "exactly one area declares no to_area");
+  const start = plans.find((plan) => plan.area.start);
+  const chain = [];
+  let current = start.area.id;
+  while (current !== null) {
+    assert.ok(!chain.includes(current), `the route cycles at ${current}`);
+    const plan = byId.get(current);
+    assert.ok(plan, `the route names undeclared area ${current}`);
+    chain.push(current);
+    current = plan.route.to_area;
+  }
+  assert.equal(chain.length, plans.length, `the route visits ${chain.length} of ${plans.length} areas`);
+  assert.equal(chain[chain.length - 1], terminal[0].area.id);
+});
+
+test("every area's pursuit light and exit gate are compiled entities of the right kind", () => {
+  for (const plan of plans) {
+    const light = plan.entities.find((entity) => entity.id === plan.pursuit.light);
+    assert.ok(light, `${plan.area.id} pursuit light ${plan.pursuit.light} is not a compiled entity`);
+    assert.equal(light.kind, "light");
+    const gate = plan.entities.find((entity) => entity.id === plan.objective.gate);
+    assert.ok(gate, `${plan.area.id} exit gate ${plan.objective.gate} is not a compiled entity`);
+    assert.equal(gate.kind, "door");
+  }
+});
+
+test("every area is a distinct composition", () => {
+  const anchorsOf = (plan) => JSON.stringify(plan.entities.map((entity) => entity.anchor).sort());
+  const seen = new Map();
+  for (const plan of plans) {
+    const key = anchorsOf(plan);
+    assert.ok(!seen.has(key), `${plan.area.id} and ${seen.get(key)} share an identical entity layout`);
+    seen.set(key, plan.area.id);
+  }
+});
+
+// The six tests that drove `play-state.mjs` over these areas are gone with
+// it. What they asserted - that each committed area is winnable and that one
+// run crosses every declared connection - is now proved end to end by
 // `apps/nomos-viewer/smoke/`, which plays the same corpus in a browser and
 // checks the cumulative counters against a walk solved from these artifacts.
 // RUNTIME.md section 2: the study is the specification, and this is what it


### PR DESCRIPTION
## Summary

- Add `gaol accept`, which runs `capture` and copies every compiled
  `target/executable-gaol/areas/<id>/rendering-plan.json` over that area's
  committed `rendering-plan.example.json`, and
  `target/executable-gaol/areas.json` over `area-collection.example.json`,
  printing what it wrote. `gaol verify` is unchanged in strictness — it only
  ever compares (`cmp` per area, byte-equality for the collection).
- Rewrite `src/area-collection.test.mjs` to enumerate `areas/*/` instead of
  naming the four areas in half a dozen literal arrays. The generic
  invariants: exactly one `start` area; every non-start area's `route.entry`
  lies inside its own bounds; every non-null `to_area` names an enumerated
  area; the route chain from the start visits every area exactly once and
  ends at the one null exit; every area's `pursuit.light` and exit gate
  resolve to compiled entities of the right kind. Corpus-independent grammar
  and unit-conversion checks are kept; nothing in the file names a specific
  area any more.
- Add a "Connecting a new area" section to `AUTHORING.md`: edit the
  predecessor's one `route.exit.to_area` field, write the new area's own
  `world.nomos`/`presentation.json`/five scenario scripts, run `gaol accept`
  to produce fixtures, run `gaol verify` to prove them — plus the closed list
  of files a connected area legitimately changes, and where the source- and
  command-script vocabularies are documented.

Closes #163.

## Proof

**`gaol verify` green on the four committed areas:**

```
✔ every area retains one exact visual grammar
✔ every area exposes one exact compiled-door objective
✔ no plan or source carries a decimal, a camera, a palette, or ui anchors
✔ vertical steps convert by division, reproducing every replaced decimal
✔ architecture heights are declared in bounds, as integer steps
✔ content selects from the renderer catalog's closed sets
✔ every actor declares a role and no plan entity names an assembly
✔ effects attach by socket and carry no coordinate
✔ exactly one area is the start
✔ every non-start area's arrival cell lies inside its own bounds; the start declares none
✔ every declared to_area names an enumerated area
✔ the route chain from the start visits every area exactly once and ends at the one null exit
✔ every area's pursuit light and exit gate are compiled entities of the right kind
✔ every area is a distinct composition
ℹ tests 14  pass 14  fail 0
AREA_COLLECTION_VERIFY PASS areas=4 grammar=fe9879cb68cb128545b85001b229bc6f15da3e64820c491aa35ff1fc962c554c collection=60f748681e0ea9247a9e86759a49378b1c19971de1011f5d7c898c7f425aed1f
EXECUTABLE_GAOL_VERIFY PASS plan=7bf15645b64641600bc5116ed150c5138e6d992f1627560f46dd40d959cd324e ...
EXECUTABLE_GAOL_VERIFY PASS plan=9a071e61f104b10982abb8670df9ed9dd5e9b1562cfce7a7de6833f2ef4ab19f ...
EXECUTABLE_GAOL_VERIFY PASS plan=92e50eaef2e45f0ffd6b10ece82fe55fdb71c7d52894209cc2602bc1ad2fccda ...
EXECUTABLE_GAOL_VERIFY PASS plan=a6bc83711a726cc38a03976eed1b285bd05a6dd0678e42859a3ecedcda5db7d5 ...
```

**`gaol accept` output** (re-run against the unchanged four-area corpus; byte-identical fixtures, so `git status` reports nothing):

```
wrote experiments/executable-gaol/areas/cistern-walk/rendering-plan.example.json
wrote experiments/executable-gaol/areas/ember-vault/rendering-plan.example.json
wrote experiments/executable-gaol/areas/north-gaol/rendering-plan.example.json
wrote experiments/executable-gaol/areas/ossuary-reach/rendering-plan.example.json
wrote experiments/executable-gaol/area-collection.example.json
```

**Fifth-area proof**, in a throwaway copy (not this worktree, discarded after): applied only
`origin/scratch/issue-148-area-proof`'s `areas/warden-stair/` directory and the
one-line `north-gaol/presentation.json` `route.exit.to_area` edit — not that
branch's `src/area-collection.test.mjs` edit, since the rewritten test needs
none. (That branch forked before the presentation-source `@2`/`role` schema
landed on `main`, so `warden-stair/presentation.json`'s schema and actor
`role` fields were brought forward to match; nothing else in its content
changed.) Then ran `gaol accept` followed by `gaol verify`:

```
wrote experiments/executable-gaol/areas/cistern-walk/rendering-plan.example.json
wrote experiments/executable-gaol/areas/ember-vault/rendering-plan.example.json
wrote experiments/executable-gaol/areas/north-gaol/rendering-plan.example.json
wrote experiments/executable-gaol/areas/ossuary-reach/rendering-plan.example.json
wrote experiments/executable-gaol/areas/warden-stair/rendering-plan.example.json
wrote experiments/executable-gaol/area-collection.example.json

ℹ tests 14  pass 14  fail 0
AREA_COLLECTION_VERIFY PASS areas=5 grammar=fe9879cb68cb128545b85001b229bc6f15da3e64820c491aa35ff1fc962c554c collection=61da5d4fb8a5fe2f6e4755ebd6775db1909d40e96869e55aebbbacaec42790c7
EXECUTABLE_GAOL_VERIFY PASS plan=7bf15645b64641600bc5116ed150c5138e6d992f1627560f46dd40d959cd324e ...   (cistern-walk)
EXECUTABLE_GAOL_VERIFY PASS plan=9a071e61f104b10982abb8670df9ed9dd5e9b1562cfce7a7de6833f2ef4ab19f ...   (ember-vault)
EXECUTABLE_GAOL_VERIFY PASS plan=9b48a0b1319e57cfdee2466209556fc6194383f1e8105cf0a43aab9ae214b1dc ...   (north-gaol, plan digest changed: it now points to warden-stair)
EXECUTABLE_GAOL_VERIFY PASS plan=a6bc83711a726cc38a03976eed1b285bd05a6dd0678e42859a3ecedcda5db7d5 ...   (ossuary-reach)
EXECUTABLE_GAOL_VERIFY PASS plan=2ee3f3d7729c0dc945977fdbed5b2c7d36bd7fd7d0dce385edd0fc68fd8bb407 ...   (warden-stair)
```

`diff -rq` between the throwaway and the pre-connection tree confirmed the only
files that differed were `areas/north-gaol/presentation.json` (the one
`to_area` edit), `areas/north-gaol/rendering-plan.example.json` (regenerated),
the new `areas/warden-stair/` directory, and `area-collection.example.json`
(regenerated) — `src/`, `apps/`, and `crates/` were byte-identical
(`diff -rq` exit 0, i.e. no changes) between the throwaway and the base
worktree. The throwaway copy was discarded afterward.

**Viewer suite**, unaffected by this change but run per the task:

```
node --test apps/nomos-viewer/test/*.test.mjs
ℹ tests 102  pass 97  fail 0  skipped 5
```

## Test plan

- [x] `experiments/executable-gaol/gaol verify` — green, 4 areas
- [x] `experiments/executable-gaol/gaol accept` — deterministic, `git status` clean after
- [x] Fifth area (`warden-stair`, from the scratch branch) connects via `gaol accept` + `gaol verify` alone, with no edit under `src/`
- [x] `node --test apps/nomos-viewer/test/*.test.mjs` — 97 pass, 5 skipped, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsZ5kuhqEodkjFWwdYu43F
