### PR TITLE
Bind each area arrival to its player actor

### DIFF
--- a/crates/nomos-render-plan/src/source.rs
+++ b/crates/nomos-render-plan/src/source.rs
@@ -31,7 +31,8 @@
 //! - **`route.entry` is this area's own arrival cell.** `area.json` had the
 //!   exiting area author a cell inside its *destination*; that cross-area
 //!   authority is gone. Every non-start area declares the cell a player arrives
-//!   on, and it is validated here against *that area's* bounds and masses.
+//!   on, and it is validated here against *that area's* bounds and masses and
+//!   against the starting cell of its sole player-role actor.
 //!
 //! The bounded-area invariants `experiments/executable-gaol/src/build-plan.mjs:73-84`
 //! enforced as compiler magic numbers — the 9x6 lattice, the wall-height bound,
@@ -301,6 +302,7 @@ fn decode(
     let route = decode_route(field(document, "route")?, &area, &architecture, entity_kind)?;
     let pursuit = decode_pursuit(field(document, "pursuit")?, entity_kind)?;
     let actors = decode_actors(field(document, "actors")?, &architecture)?;
+    validate_arrival(&route, &actors)?;
     let effects = decode_effects(field(document, "effects")?, entity_kind)?;
 
     Ok(PresentationSource {
@@ -311,6 +313,23 @@ fn decode(
         actors,
         effects,
     })
+}
+
+fn validate_arrival(route: &Route, actors: &[Actor]) -> PlanResult<()> {
+    let Some(entry) = route.entry else {
+        return Ok(());
+    };
+    let player = actors
+        .iter()
+        .find(|actor| actor.role == "player")
+        .expect("decode_actors guarantees exactly one player-role actor");
+    if entry != player.cell {
+        return Err(invalid(format!(
+            "`route.entry` ({}, {}, {}) does not equal player-role actor `{}`'s cell ({}, {}, {})",
+            entry.x, entry.y, entry.z, player.id, player.cell.x, player.cell.y, player.cell.z
+        )));
+    }
+    Ok(())
 }
 
 /// Binds the declared identity.

--- a/crates/nomos-render-plan/tests/source.rs
+++ b/crates/nomos-render-plan/tests/source.rs
@@ -388,6 +388,22 @@ fn a_non_start_area_without_an_entry_is_refused() {
 }
 
 #[test]
+fn a_route_entry_different_from_the_player_cell_is_refused() {
+    let (code, message) = refusal("entry-player-mismatch", |text| {
+        text.replace("\"start\": true", "\"start\": false").replace(
+            "\"exit\": { \"gate\": \"north_gate\", \"to_area\": null }",
+            "\"exit\": { \"gate\": \"north_gate\", \"to_area\": null },\n    \
+             \"entry\": { \"x\": 1, \"y\": 1, \"z\": 0 }",
+        )
+    });
+    assert_eq!(code, "RP0202");
+    assert!(
+        message.contains("does not equal player-role actor `player`'s cell"),
+        "{message}"
+    );
+}
+
+#[test]
 fn a_gate_that_is_not_a_compiled_door_is_refused() {
     let (code, message) = refusal("gate-not-a-door", |text| {
         text.replace("\"gate\": \"north_gate\"", "\"gate\": \"watch_brazier\"")

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -142,9 +142,9 @@ iterations inside the quarantined executable study until concrete evidence
 justifies a separate decision to promote a boundary into a post-Gate-K runtime
 epoch.
 
-The cold-author area-five experiment leaves one open packet gap (issue #165,
-`route.entry` duplicating the player actor's `cell`) and an owner visual
-verdict still pending on `docs/review/cold-author-area-five.md`.
+The cold-author area-five experiment's owner visual verdict is compelling.
+Issue #165 closes its packet gap by making `route.entry` equal the player-role
+actor's `cell` as both an authored rule and an `RP0202` decoder invariant.
 
 That separate decision is now owner-authorized:
 `docs/decisions/0017-post-gate-k-runtime-epoch.md` opens the R1 epoch under

--- a/docs/review/cold-author-area-five.md
+++ b/docs/review/cold-author-area-five.md
@@ -83,6 +83,8 @@ the session lead committed its unedited output under a Codex author identity.
   convention rather than risk diverging from it, though nothing in `gaol
   verify` checks the relationship directly. Filed as issue #165,
   "Presentation source: route.entry duplicates the player actor's cell."
+  Issue #165 makes the equality an authored rule and an `RP0202` decoder
+  invariant, so a later author cannot make the two spellings diverge.
 - **The read boundary hid three of five comparison axes from Codex.** Its
   note records that the permitted presentations exposed the other areas'
   masonry masses but not their gate columns, water regions, or brazier

--- a/experiments/executable-gaol/AUTHORING.md
+++ b/experiments/executable-gaol/AUTHORING.md
@@ -85,7 +85,8 @@ steps and masonry masses `1..=40`. The renderer divides by ten.
 **Positions are lattice cells.** `0 ≤ x < bounds.width`, `0 ≤ y < bounds.height`,
 `z == 0`. A mass is a positive rectangle, `min` inclusive and `max` exclusive,
 inside the bounds. An actor may not start inside a mass, and neither may the
-arrival cell.
+arrival cell. In a non-start area, `route.entry` and the sole player-role
+actor's `cell` are the same arrival fact and must be equal.
 
 **Effects attach by socket, never by coordinate.** `anchor` is exactly
 `{ entity, socket }`. The entity must be compiled, and the socket must be one
@@ -99,7 +100,8 @@ authored spelling of the gate this area leaves by; the compiler derives the
 `objective.target` to keep in agreement. `route.entry` is *this* area's own
 arrival cell — the cell a player lands on when another area's gate leads here —
 validated against this area's own bounds and masses. The start area declares no
-`entry`, because nothing arrives there; every other area declares one.
+`entry`, because nothing arrives there; every other area declares one equal to
+the player-role actor's starting `cell`.
 `to_area` is `null` exactly at the route's terminal.
 
 **Names come from closed sets.** The decoder checks that an id, assembly, or


### PR DESCRIPTION
## Summary

- state the formerly implicit rule that a non-start area's `route.entry` equals its sole player-role actor's starting `cell`
- enforce the equality in the `nomos.presentation_source@2` decoder with stable `RP0202`
- add a planted mismatch test and close the cold-author packet finding
- correct the stale handoff note: the owner visual verdict is already compelling

This keeps the accepted source schema and all committed source/plan bytes unchanged. Removing `route.entry` instead would require an identity bump and artifact migration; #165 does not require that larger change.

## Evidence

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo xtask boundary`
- `cargo test -p nomos-render-plan --test source --locked` → 40 passed
- `experiments/executable-gaol/gaol verify` → six areas pass, byte-identical plans and contact sheets

The four workspace proof commands were run with a fresh `CARGO_TARGET_DIR`. A non-author rerun remains required before this slice is called green.

Closes #165
