### PR TITLE
Move corpus route pins into content

### DIFF
--- a/crates/nomos-cli/tests/activation_evaluator.rs
+++ b/crates/nomos-cli/tests/activation_evaluator.rs
@@ -14,40 +14,18 @@
 //! what `resolve_movement` resolves at the initial simulation state, subject by
 //! subject, for the fixture and every committed gaol area.
 
+mod common;
+
 use nomos_core::SourcePath;
 use nomos_projection::MovementDisposition;
 use nomos_sim::{SimulationState, resolve_movement};
 
-/// The fixture plus the four committed gaol areas, which the acceptance
-/// criterion names explicitly.
-const WORLDS: [(&str, &str); 5] = [
-    (
-        "fixtures/gaol.nomos",
-        include_str!("../../../fixtures/gaol.nomos"),
-    ),
-    (
-        "experiments/executable-gaol/areas/cistern-walk/world.nomos",
-        include_str!("../../../experiments/executable-gaol/areas/cistern-walk/world.nomos"),
-    ),
-    (
-        "experiments/executable-gaol/areas/ember-vault/world.nomos",
-        include_str!("../../../experiments/executable-gaol/areas/ember-vault/world.nomos"),
-    ),
-    (
-        "experiments/executable-gaol/areas/north-gaol/world.nomos",
-        include_str!("../../../experiments/executable-gaol/areas/north-gaol/world.nomos"),
-    ),
-    (
-        "experiments/executable-gaol/areas/ossuary-reach/world.nomos",
-        include_str!("../../../experiments/executable-gaol/areas/ossuary-reach/world.nomos"),
-    ),
-];
-
 #[test]
 fn compile_time_initial_movement_equals_the_resolver_at_the_initial_state() {
     let mut subjects_compared = 0_usize;
-    for (path, source) in WORLDS {
-        let stable = nomos_compiler::compile_world(source, SourcePath::new(path).unwrap()).unwrap();
+    for (path, source) in common::worlds() {
+        let stable =
+            nomos_compiler::compile_world(&source, SourcePath::new(&path).unwrap()).unwrap();
         let plan = nomos_compiler::compile_simulation_plan(&stable).unwrap();
         let initial = SimulationState::initialize(&plan).unwrap();
         let resolved = resolve_movement(&plan, &initial).unwrap();
@@ -110,8 +88,9 @@ fn compile_time_initial_movement_equals_the_resolver_at_the_initial_state() {
 fn every_world_carries_a_state_dependent_activation_for_the_evaluator_to_decide() {
     // Without this the equivalence above could pass on worlds whose every claim
     // is `always`, which would exercise no state lookup at all.
-    for (path, source) in WORLDS {
-        let stable = nomos_compiler::compile_world(source, SourcePath::new(path).unwrap()).unwrap();
+    for (path, source) in common::worlds() {
+        let stable =
+            nomos_compiler::compile_world(&source, SourcePath::new(&path).unwrap()).unwrap();
         let plan = nomos_compiler::compile_simulation_plan(&stable).unwrap();
         let mut state_predicates = 0_usize;
         for subject in plan.movement_resolver().subjects() {

--- a/crates/nomos-cli/tests/common/mod.rs
+++ b/crates/nomos-cli/tests/common/mod.rs
@@ -1,0 +1,37 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+/// The kernel fixture plus every world discovered in the executable corpus.
+pub fn worlds() -> Vec<(String, String)> {
+    let root = repo_root();
+    let mut worlds = vec![(
+        "fixtures/gaol.nomos".to_owned(),
+        fs::read_to_string(root.join("fixtures/gaol.nomos"))
+            .expect("the kernel fixture is readable"),
+    )];
+    let areas = root.join("experiments/executable-gaol/areas");
+    let mut paths = fs::read_dir(&areas)
+        .expect("the executable corpus is readable")
+        .filter_map(|entry| {
+            let path = entry.expect("an area-directory entry is readable").path();
+            path.is_dir().then(|| path.join("world.nomos"))
+        })
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    paths.sort();
+    worlds.extend(paths.into_iter().map(|path| {
+        let relative = path
+            .strip_prefix(&root)
+            .expect("the corpus world is inside the repository")
+            .to_str()
+            .expect("the corpus path is UTF-8")
+            .to_owned();
+        let source = fs::read_to_string(path).expect("the corpus world is readable");
+        (relative, source)
+    }));
+    worlds
+}

--- a/crates/nomos-cli/tests/entity_catalog.rs
+++ b/crates/nomos-cli/tests/entity_catalog.rs
@@ -12,6 +12,8 @@
 //! what to expect; the command itself never opens it, which
 //! `the_catalog_reads_no_source` proves by deleting it.
 
+mod common;
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::fs;
@@ -27,28 +29,6 @@ static COUNTER: AtomicU32 = AtomicU32::new(0);
 
 const GAOL: &str = include_str!("../../../fixtures/gaol.nomos");
 const COMMANDS: &[u8] = include_bytes!("../../../fixtures/gaol.commands");
-
-/// The fixture plus the four committed gaol areas, which the acceptance
-/// criterion names explicitly.
-const WORLDS: [(&str, &str); 5] = [
-    ("fixtures/gaol.nomos", GAOL),
-    (
-        "experiments/executable-gaol/areas/cistern-walk/world.nomos",
-        include_str!("../../../experiments/executable-gaol/areas/cistern-walk/world.nomos"),
-    ),
-    (
-        "experiments/executable-gaol/areas/ember-vault/world.nomos",
-        include_str!("../../../experiments/executable-gaol/areas/ember-vault/world.nomos"),
-    ),
-    (
-        "experiments/executable-gaol/areas/north-gaol/world.nomos",
-        include_str!("../../../experiments/executable-gaol/areas/north-gaol/world.nomos"),
-    ),
-    (
-        "experiments/executable-gaol/areas/ossuary-reach/world.nomos",
-        include_str!("../../../experiments/executable-gaol/areas/ossuary-reach/world.nomos"),
-    ),
-];
 
 fn fresh_workspace(label: &str) -> PathBuf {
     let index = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -217,12 +197,12 @@ fn the_catalog_names_its_schema_and_the_world_it_catalogued() {
 
 #[test]
 fn every_entity_carries_its_declared_primitive_and_world_ir_capabilities() {
-    for (path, source) in WORLDS {
-        let root = compiled("primitives", source);
+    for (path, source) in common::worlds() {
+        let root = compiled("primitives", &source);
         let document = catalog(&root);
         let entities = array(field(&document, "entities"));
 
-        let declared = declared_primitives(source);
+        let declared = declared_primitives(&source);
         assert!(
             !declared.is_empty(),
             "`{path}` declares no entity; the assertion below would be vacuous"

--- a/crates/nomos-play/Cargo.toml
+++ b/crates/nomos-play/Cargo.toml
@@ -32,7 +32,7 @@ nomos-sim.workspace = true
 # `collection.rs` reads it from `plan.rs` rather than spelling it again.
 nomos-render-plan.workspace = true
 
-# Dev-only. `tests/semantics.rs` compiles the four committed area sources in
+# Dev-only. `tests/semantics.rs` compiles every committed area source in
 # memory and asserts that the simulation projection this crate decodes is the
 # value the compiler projected. Neither edge exists in the built library;
 # `cargo xtask boundary` counts dev-dependency edges, and both targets are

--- a/crates/nomos-play/tests/common/mod.rs
+++ b/crates/nomos-play/tests/common/mod.rs
@@ -1,4 +1,4 @@
-//! Fixtures: the six committed areas, compiled in memory.
+//! Fixtures: every committed area, discovered and compiled in memory.
 //!
 //! The rendering plans are the committed `rendering-plan.example.json` files;
 //! the executable semantics are obtained by compiling each area's `world.nomos`
@@ -14,57 +14,89 @@
 
 #![allow(dead_code)]
 
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
 use nomos_core::SourcePath;
 use nomos_play::{Direction, PlayCommand, PlaySession};
+use nomos_render_plan::json::{self, Json};
 
 /// One committed area's bytes.
 pub struct AreaBytes {
-    pub id: &'static str,
-    pub plan: &'static [u8],
-    pub source: &'static str,
-    pub source_path: &'static str,
+    pub id: String,
+    pub plan: Vec<u8>,
+    pub source: String,
+    pub source_path: String,
 }
 
-macro_rules! area {
-    ($id:literal) => {
-        AreaBytes {
-            id: $id,
-            plan: include_bytes!(concat!(
-                "../../../../experiments/executable-gaol/areas/",
-                $id,
-                "/rendering-plan.example.json"
-            )),
-            source: include_str!(concat!(
-                "../../../../experiments/executable-gaol/areas/",
-                $id,
-                "/world.nomos"
-            )),
-            source_path: concat!("experiments/executable-gaol/areas/", $id, "/world.nomos"),
-        }
-    };
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RouteLeg {
+    pub area: String,
+    pub keys: String,
 }
 
-/// The six committed areas, in route order.
-pub const ROUTE: [&str; 6] = [
-    "cistern-walk",
-    "ember-vault",
-    "gloam-bastion",
-    "drowned-stair",
-    "ossuary-reach",
-    "north-gaol",
-];
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RouteExpectations {
+    pub areas: u64,
+    pub commands: u64,
+    pub moves: u64,
+    pub traversal_cost: u64,
+    pub route: Vec<RouteLeg>,
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn areas_root() -> PathBuf {
+    repo_root().join("experiments/executable-gaol/areas")
+}
+
+/// Every committed area identifier, discovered from the content directory.
+#[must_use]
+pub fn area_ids() -> Vec<String> {
+    let mut ids = fs::read_dir(areas_root())
+        .expect("the study's areas directory is readable")
+        .filter_map(|entry| {
+            let entry = entry.expect("an area-directory entry is readable");
+            let path = entry.path();
+            (path.is_dir()
+                && path.join("world.nomos").is_file()
+                && path.join("rendering-plan.example.json").is_file())
+            .then(|| {
+                entry
+                    .file_name()
+                    .into_string()
+                    .expect("an area id is UTF-8")
+            })
+        })
+        .collect::<Vec<_>>();
+    ids.sort();
+    assert!(!ids.is_empty(), "the committed corpus is not empty");
+    ids
+}
 
 /// Every committed area, by identifier.
 #[must_use]
 pub fn area(id: &str) -> AreaBytes {
-    match id {
-        "cistern-walk" => area!("cistern-walk"),
-        "ember-vault" => area!("ember-vault"),
-        "gloam-bastion" => area!("gloam-bastion"),
-        "drowned-stair" => area!("drowned-stair"),
-        "north-gaol" => area!("north-gaol"),
-        "ossuary-reach" => area!("ossuary-reach"),
-        other => panic!("no committed area `{other}`"),
+    assert!(
+        area_ids().iter().any(|candidate| candidate == id),
+        "no committed area `{id}`"
+    );
+    let directory = areas_root().join(id);
+    let source_path = directory.join("world.nomos");
+    AreaBytes {
+        id: id.to_owned(),
+        plan: fs::read(directory.join("rendering-plan.example.json"))
+            .expect("the committed rendering plan is readable"),
+        source: fs::read_to_string(&source_path).expect("the committed world is readable"),
+        source_path: source_path
+            .strip_prefix(repo_root())
+            .expect("the world is inside the repository")
+            .to_str()
+            .expect("the source path is UTF-8")
+            .to_owned(),
     }
 }
 
@@ -73,8 +105,8 @@ pub fn area(id: &str) -> AreaBytes {
 pub fn semantics(id: &str) -> Vec<u8> {
     let bytes = area(id);
     let world = nomos_compiler::compile_world_package(
-        bytes.source,
-        SourcePath::new(bytes.source_path).expect("the fixture path is repository-relative"),
+        &bytes.source,
+        SourcePath::new(&bytes.source_path).expect("the fixture path is repository-relative"),
     )
     .expect("the committed area compiles");
     world
@@ -89,7 +121,119 @@ pub fn semantics(id: &str) -> Vec<u8> {
 /// One area's committed rendering plan.
 #[must_use]
 pub fn plan(id: &str) -> Vec<u8> {
-    area(id).plan.to_vec()
+    area(id).plan
+}
+
+fn required<'a>(value: &'a Json, field: &str) -> &'a Json {
+    value
+        .get(field)
+        .unwrap_or_else(|| panic!("the route fixture has no `{field}` field"))
+}
+
+fn text(value: &Json, field: &str) -> String {
+    required(value, field)
+        .as_text()
+        .unwrap_or_else(|| panic!("route fixture `{field}` is not text"))
+        .to_owned()
+}
+
+fn unsigned(value: &Json, field: &str) -> u64 {
+    u64::try_from(
+        required(value, field)
+            .as_integer()
+            .unwrap_or_else(|| panic!("route fixture `{field}` is not an integer")),
+    )
+    .unwrap_or_else(|_| panic!("route fixture `{field}` is negative"))
+}
+
+/// The content-side route and counter fixture regenerated by `gaol accept`.
+#[must_use]
+pub fn route_expectations() -> RouteExpectations {
+    let path = repo_root().join("experiments/executable-gaol/route-expectations.json");
+    let document = json::parse(&fs::read(&path).expect("the route fixture is readable"))
+        .expect("the route fixture is valid JSON");
+    let expected = required(&document, "expected");
+    let route = required(&document, "route")
+        .as_array()
+        .expect("the route fixture's route is an array")
+        .iter()
+        .map(|leg| RouteLeg {
+            area: text(leg, "area"),
+            keys: text(leg, "keys"),
+        })
+        .collect::<Vec<_>>();
+    let discovered = area_ids().into_iter().collect::<BTreeSet<_>>();
+    let routed = route
+        .iter()
+        .map(|leg| leg.area.clone())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        routed, discovered,
+        "the route fixture covers the corpus once"
+    );
+    RouteExpectations {
+        areas: unsigned(expected, "areas"),
+        commands: unsigned(expected, "commands"),
+        moves: unsigned(expected, "moves"),
+        traversal_cost: unsigned(expected, "traversal_cost"),
+        route,
+    }
+}
+
+/// The solved key sequence for one area.
+#[must_use]
+pub fn keys_for(id: &str) -> String {
+    route_expectations()
+        .route
+        .into_iter()
+        .find(|leg| leg.area == id)
+        .unwrap_or_else(|| panic!("the route fixture has no area `{id}`"))
+        .keys
+}
+
+/// One captured scenario's kernel state hash from a committed plan.
+#[must_use]
+pub fn scenario_hash(id: &str, index: usize) -> String {
+    let document = json::parse(&plan(id)).expect("the committed plan is JSON");
+    required(&document, "scenarios")
+        .as_array()
+        .expect("plan scenarios is an array")
+        .get(index)
+        .and_then(|scenario| scenario.get("state_hash"))
+        .and_then(Json::as_text)
+        .unwrap_or_else(|| panic!("area `{id}` has no scenario state hash at {index}"))
+        .to_owned()
+}
+
+/// The long-standing behavior fixture, selected by a property of its plan
+/// rather than by an area identifier.
+#[must_use]
+pub fn behavior_area() -> String {
+    area_ids()
+        .into_iter()
+        .find(|id| {
+            nomos_play::AreaPlan::decode(&plan(id))
+                .is_ok_and(|plan| plan.objective_gate.to_string() == "north_gate")
+        })
+        .expect("one committed area carries the behavior fixture's objective")
+}
+
+/// A committed area with exactly two masonry masses.
+#[must_use]
+pub fn mass_area() -> String {
+    area_ids()
+        .into_iter()
+        .find(|id| nomos_play::AreaPlan::decode(&plan(id)).is_ok_and(|plan| plan.masses.len() == 2))
+        .expect("one committed area carries the two-mass fixture")
+}
+
+/// A committed area other than `id`.
+#[must_use]
+pub fn different_area(id: &str) -> String {
+    area_ids()
+        .into_iter()
+        .find(|candidate| candidate != id)
+        .expect("the corpus contains more than one area")
 }
 
 /// A session opened at one area.
@@ -101,7 +245,14 @@ pub fn session_at(id: &str) -> PlaySession {
 /// A session opened at the route's start area.
 #[must_use]
 pub fn session() -> PlaySession {
-    session_at(ROUTE[0])
+    let expectations = route_expectations();
+    session_at(&expectations.route[0].area)
+}
+
+/// A session opened at the behavior fixture.
+#[must_use]
+pub fn behavior_session() -> PlaySession {
+    session_at(&behavior_area())
 }
 
 /// Enters the next area of the route.
@@ -116,20 +267,6 @@ pub fn enter(session: &mut PlaySession, id: &str) {
 pub const fn step(direction: Direction) -> PlayCommand {
     PlayCommand::Move { direction }
 }
-
-/// The six key sequences the smoke lane's route solver produces today, one per
-/// area, in route order. `^ v < >` are the four lattice directions and `*` is
-/// the interaction the enumeration offers first at the cell the player is
-/// standing on. Recorded here so a native test pins the numbers the browser
-/// lane then has to agree with.
-pub const ROUTE_KEYS: [&str; 6] = [
-    "^^^<<<<<<^**>^",
-    "<<<<<^^^>^^**>^",
-    "^^^<<<v^^^**<^",
-    "^<<>^^^**^^",
-    "^^>^^>>>^**>^",
-    "^^^^>>**>^",
-];
 
 /// The direction one route letter names, or `None` for the interaction key.
 #[must_use]
@@ -168,15 +305,16 @@ pub fn drive(session: &mut PlaySession, keys: &str) {
     }
 }
 
-/// Plays the whole six-area route, entering each area as the crossing names it.
+/// Plays the whole committed route, entering each area as the crossing names it.
 #[must_use]
 pub fn play_route() -> PlaySession {
+    let expectations = route_expectations();
     let mut live = session();
-    for (index, area_id) in ROUTE.iter().enumerate() {
+    for (index, leg) in expectations.route.iter().enumerate() {
         if index > 0 {
-            enter(&mut live, area_id);
+            enter(&mut live, &leg.area);
         }
-        drive(&mut live, ROUTE_KEYS[index]);
+        drive(&mut live, &leg.keys);
     }
     live
 }

--- a/crates/nomos-play/tests/corpus.rs
+++ b/crates/nomos-play/tests/corpus.rs
@@ -1,4 +1,4 @@
-//! The six committed areas, played.
+//! The committed area corpus, played.
 //!
 //! This is where the numbers live. `docs/review/nomos-viewer.md` section 5.3
 //! used to predict `moves` and `cost` in JavaScript inside the smoke harness,
@@ -8,20 +8,64 @@
 
 mod common;
 
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use nomos_play::{SessionOutcome, batch};
 
+fn files_below(directory: &Path, files: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).expect("a crate test directory is readable") {
+        let path = entry.expect("a crate test entry is readable").path();
+        if path.is_dir() {
+            files_below(&path, files);
+        } else {
+            files.push(path);
+        }
+    }
+}
+
 #[test]
-fn the_six_area_route_costs_what_the_record_says() {
+fn no_crate_test_names_a_corpus_area() {
+    let crates = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let ids = common::area_ids();
+    let mut files = Vec::new();
+    for entry in fs::read_dir(crates).expect("the crates directory is readable") {
+        let tests = entry
+            .expect("a crate-directory entry is readable")
+            .path()
+            .join("tests");
+        if tests.is_dir() {
+            files_below(&tests, &mut files);
+        }
+    }
+    assert!(!files.is_empty(), "crate tests were discovered");
+    for path in files {
+        let bytes = fs::read(&path).expect("a crate test file is readable");
+        for id in &ids {
+            assert!(
+                !bytes
+                    .windows(id.len())
+                    .any(|window| window == id.as_bytes()),
+                "{} names corpus area `{id}`",
+                path.display()
+            );
+        }
+    }
+}
+
+#[test]
+fn the_committed_route_costs_what_the_content_fixture_says() {
+    let expected = common::route_expectations();
     let session = common::play_route();
     assert_eq!(session.outcome(), SessionOutcome::Completed);
-    assert_eq!(session.areas_cleared(), 6);
-    assert_eq!(session.counters().moves, 65);
-    assert_eq!(session.counters().traversal_cost, 95);
-    // 77 keys: 65 moves and 12 interactions. Every input is one batch and one
-    // tick, so the tick is the input count and not the move count.
-    assert_eq!(session.log().len(), 77);
-    assert_eq!(session.receipts().len(), 77);
-    assert_eq!(session.live().state.tick, 77);
+    assert_eq!(session.areas_cleared(), expected.areas);
+    assert_eq!(session.counters().moves, expected.moves);
+    assert_eq!(session.counters().traversal_cost, expected.traversal_cost);
+    // Every key is one batch and one tick, so the tick is the input count and
+    // not the move count.
+    assert_eq!(session.log().len() as u64, expected.commands);
+    assert_eq!(session.receipts().len() as u64, expected.commands);
+    assert_eq!(session.live().state.tick, expected.commands);
 }
 
 #[test]
@@ -55,14 +99,15 @@ fn every_input_the_route_sends_is_accepted() {
 /// objective gate is within reach.
 #[test]
 fn the_enumeration_offers_exactly_the_gate_the_route_uses() {
-    for (index, area_id) in common::ROUTE.iter().enumerate() {
+    for (index, leg) in common::route_expectations().route.iter().enumerate() {
+        let area_id = &leg.area;
         let mut session = common::session_at(area_id);
         if index > 0 {
             // Every area but the first is entered at its own `route.entry`;
             // opening it directly puts the player at the declared cell instead,
             // which is the same cell for this corpus. Walk the route either way.
         }
-        let keys = common::ROUTE_KEYS[index];
+        let keys = &leg.keys;
         let before_interaction: String = keys.chars().take_while(|key| *key != '*').collect();
         common::drive(&mut session, &before_interaction);
 
@@ -91,25 +136,32 @@ fn interacting_reaches_the_state_hash_the_captured_scenario_recorded() {
     // of the same kernel, so playing to the same point must reach the same
     // kernel state hash. This is the strongest single check that the runtime
     // and the capture agree.
-    let mut session = common::session_at("north-gaol");
-    common::drive(&mut session, "^^^^>>");
+    let area = common::behavior_area();
+    let mut session = common::session_at(&area);
+    let keys = common::keys_for(&area);
+    let before_interaction = keys
+        .chars()
+        .take_while(|key| *key != '*')
+        .collect::<String>();
+    common::drive(&mut session, &before_interaction);
     let baseline = session.live().state.kernel_state_hash().to_hex();
     assert_eq!(
-        baseline, "9d81ddaf8c3310a10399ce1c727d117f5385426f5e3fc0b1575d7ec042d3e49d",
+        baseline,
+        common::scenario_hash(&area, 0),
         "walking changes no kernel state, so this is still `01-baseline`"
     );
 
     common::drive(&mut session, "*");
     assert_eq!(
         session.live().state.kernel_state_hash().to_hex(),
-        "bc01b2f3427a95341e89c1a0cf9d4aca2190e20a90b7d38fd4a4ed1a8a0f5150",
+        common::scenario_hash(&area, 1),
         "`ignite` reaches the `02-breached-warded` state hash"
     );
 
     common::drive(&mut session, "*");
     assert_eq!(
         session.live().state.kernel_state_hash().to_hex(),
-        "0c0a573503282ec7b8f10dada7da267b96f04c089054936b84bece096b0ac7f2",
+        common::scenario_hash(&area, 2),
         "`unseal` reaches the `03-breached-unsealed` state hash"
     );
 }
@@ -120,10 +172,11 @@ fn the_initial_kernel_state_is_the_first_captured_scenario() {
     // `plan.scenarios[0]` as "the default" by array position; the initial state
     // is `SimulationState::initialize`, a kernel fact, and it happens to be the
     // state that convention was describing.
-    let session = common::session_at("north-gaol");
+    let area = common::behavior_area();
+    let session = common::session_at(&area);
     assert_eq!(
         session.live().state.kernel_state_hash().to_hex(),
-        "9d81ddaf8c3310a10399ce1c727d117f5385426f5e3fc0b1575d7ec042d3e49d"
+        common::scenario_hash(&area, 0)
     );
     assert_eq!(session.live().state.kernel.state().tick(), 0);
 }
@@ -135,8 +188,8 @@ fn only_one_entity_covers_any_cell_in_the_committed_corpus() {
     // two agree because no cell is covered twice; that is measured here rather
     // than assumed, so a content change that overlapped two water regions would
     // fail a test instead of quietly changing a cost.
-    for area_id in common::ROUTE {
-        let session = common::session_at(area_id);
+    for area_id in common::area_ids() {
+        let session = common::session_at(&area_id);
         let area = session.live();
         for y in 0..area.plan.height {
             for x in 0..area.plan.width {

--- a/crates/nomos-play/tests/documents.rs
+++ b/crates/nomos-play/tests/documents.rs
@@ -120,9 +120,10 @@ fn a_play_state_from_another_world_is_refused_by_the_kernel() {
     // paired with semantics it was not produced under.
     let session = common::session();
     let bytes = session.live().state.to_canonical_bytes();
-    let other =
-        nomos_projection::SimulationPlan::from_canonical_bytes(&common::semantics("north-gaol"))
-            .unwrap();
+    let other = nomos_projection::SimulationPlan::from_canonical_bytes(&common::semantics(
+        &common::behavior_area(),
+    ))
+    .unwrap();
     let error = nomos_play::PlayState::decode(&bytes, &other).unwrap_err();
     assert_eq!(error.code(), nomos_play::codes::KERNEL_REFUSED);
     assert!(error.message().contains("EK0813"), "{}", error.message());
@@ -236,7 +237,7 @@ fn the_presentation_state_spells_movement_the_way_the_plan_does() {
     // Load-bearing: the viewer's scenario accessors read a presentation state
     // unchanged because the two documents spell these three collections
     // identically, including the `null` cost on a blocked subject.
-    let session = common::session_at("north-gaol");
+    let session = common::behavior_session();
     let value = presentation_state(session.live()).unwrap();
     let CanonicalValue::Object(fields) = &value else {
         panic!("a presentation state is an object");
@@ -384,7 +385,7 @@ fn the_direction_table_is_the_one_the_renderer_declares() {
 
 #[test]
 fn a_plan_without_a_player_is_refused() {
-    let bytes = common::plan("north-gaol");
+    let bytes = common::plan(&common::behavior_area());
     let text = String::from_utf8(bytes).unwrap();
     let broken = text.replacen(r#""role":"player""#, r#""role":"pursuer""#, 1);
     let error = nomos_play::AreaPlan::decode(broken.as_bytes()).unwrap_err();
@@ -393,7 +394,7 @@ fn a_plan_without_a_player_is_refused() {
 
 #[test]
 fn a_plan_at_the_retired_version_is_refused() {
-    let bytes = common::plan("north-gaol");
+    let bytes = common::plan(&common::behavior_area());
     let text = String::from_utf8(bytes).unwrap();
     let broken = text.replacen("nomos.rendering_plan@3", "nomos.rendering_plan@2", 1);
     let error = nomos_play::AreaPlan::decode(broken.as_bytes()).unwrap_err();
@@ -405,8 +406,14 @@ fn the_two_ticks_are_different_numbers() {
     // `play_state.tick` counts committed batches, which is inputs. The kernel's
     // tick counts committed kernel transactions. A refused input moves the
     // first and not the second, and neither is the other.
-    let mut session = common::session_at("north-gaol");
-    common::drive(&mut session, "^^^^>>");
+    let area = common::behavior_area();
+    let mut session = common::session_at(&area);
+    let keys = common::keys_for(&area);
+    let before_interaction = keys
+        .chars()
+        .take_while(|key| *key != '*')
+        .collect::<String>();
+    common::drive(&mut session, &before_interaction);
     common::drive(&mut session, "*");
     // Walk into the wall to the north of the gate cell: refused, tick advances.
     session
@@ -440,7 +447,7 @@ fn every_emitted_document_reparses_to_the_same_bytes() {
 fn the_actor_identities_are_free() {
     // The ownership audit's items 7 and 21: `player` and `gaoler` were magic
     // identities. Rename both and nothing changes but the names.
-    let text = String::from_utf8(common::plan("north-gaol")).unwrap();
+    let text = String::from_utf8(common::plan(&common::behavior_area())).unwrap();
     let renamed = text
         .replace(r#""id":"player""#, r#""id":"runner""#)
         .replace(r#""id":"gaoler""#, r#""id":"warden""#);

--- a/crates/nomos-play/tests/pursuit.rs
+++ b/crates/nomos-play/tests/pursuit.rs
@@ -9,10 +9,11 @@ mod common;
 
 use nomos_play::{Direction, Outcome, batch, codes};
 
-/// Walks North Gaol's player to `(3, 2)`, one cell south of `brazier_02`, and
+/// Walks the behavior fixture's player to `(3, 2)`, one cell south of its
+/// brazier, and
 /// extinguishes it. From here the pursuit light is out and the gaoler hunts.
 fn dark_at_the_brazier() -> nomos_play::PlaySession {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^>");
     let player = session.live().state.player().cell;
     assert_eq!((player.x(), player.y()), (3, 2));
@@ -29,7 +30,7 @@ fn dark_at_the_brazier() -> nomos_play::PlaySession {
 
 #[test]
 fn the_gaoler_stays_dormant_while_the_light_is_lit() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     let start = session.live().state.pursuer().unwrap().cell;
     assert!(!batch::hunting(session.live()).unwrap());
     for _ in 0..6 {
@@ -45,7 +46,7 @@ fn the_gaoler_stays_dormant_while_the_light_is_lit() {
 
 #[test]
 fn the_gaoler_hunts_only_when_the_pursuit_light_is_out() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     assert!(!batch::hunting(session.live()).unwrap());
     session = dark_at_the_brazier();
     assert!(batch::hunting(session.live()).unwrap());
@@ -189,7 +190,7 @@ fn the_same_log_produces_the_same_capture() {
 
 #[test]
 fn a_crossing_does_not_offer_the_pursuer_a_step() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>**>");
     let before = session.live().state.pursuer().unwrap().cell;
     let counter = session.live().state.moves_since_step;

--- a/crates/nomos-play/tests/reducer.rs
+++ b/crates/nomos-play/tests/reducer.rs
@@ -18,7 +18,7 @@ fn entity(id: &str) -> EntityId {
 
 #[test]
 fn a_step_onto_stone_costs_one() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     let before = session.counters();
     session.step(&common::step(Direction::West)).unwrap();
     assert_eq!(session.counters().moves, before.moves + 1);
@@ -30,7 +30,7 @@ fn water_uses_the_projected_traversal_cost_at_the_live_state() {
     // `play.mjs:101-108` read this off a captured scenario. It now comes from
     // `resolve_movement` evaluated against the embedded kernel state, which is
     // the whole point of the slice.
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     // (2, 4) -> (2, 3), the north edge of the flooded region (2,2)-(4,3).
     let before = session.counters();
     session.step(&common::step(Direction::North)).unwrap();
@@ -44,9 +44,9 @@ fn water_uses_the_projected_traversal_cost_at_the_live_state() {
 
 #[test]
 fn a_mass_blocks_the_cells_it_covers() {
-    // Ember Vault declares two piers. The rectangle is half-open, reproducing
+    // The two-mass fixture declares two piers. The rectangle is half-open, reproducing
     // `play.mjs:110-114`: `min <= x < max`.
-    let session = common::session_at("ember-vault");
+    let session = common::session_at(&common::mass_area());
     let plan = &session.live().plan;
     assert_eq!(plan.masses.len(), 2);
     let mass = &plan.masses[0];
@@ -57,9 +57,9 @@ fn a_mass_blocks_the_cells_it_covers() {
 
 #[test]
 fn a_move_into_masonry_is_refused_and_still_commits_a_batch() {
-    let mut session = common::session_at("ember-vault");
+    let mut session = common::session_at(&common::mass_area());
     let plan = session.live().plan.clone();
-    let mass = plan.masses.first().expect("ember-vault declares a pier");
+    let mass = plan.masses.first().expect("the fixture declares a pier");
     // Walk to the cell immediately south of the mass's minimum corner, then
     // step north into it.
     let target = (mass.min.0, mass.min.1);
@@ -102,7 +102,7 @@ fn a_move_into_masonry_is_refused_and_still_commits_a_batch() {
 
 #[test]
 fn the_baseline_gate_refuses_an_exit_and_names_the_resolver_reasons() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>>");
     assert_eq!(
         (
@@ -123,7 +123,7 @@ fn the_baseline_gate_refuses_an_exit_and_names_the_resolver_reasons() {
 
 #[test]
 fn the_breached_and_unsealed_gate_permits_an_exit() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>**>");
     let receipt = session
         .step(&common::step(Direction::North))
@@ -137,7 +137,7 @@ fn the_breached_and_unsealed_gate_permits_an_exit() {
 
 #[test]
 fn a_move_that_leaves_the_lattice_with_no_door_finds_masonry() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     // (2, 4) is not on a door's cell; walking north-west to (0, 4) and stepping
     // west leaves the lattice through nothing.
     common::drive(&mut session, "<<");
@@ -156,8 +156,8 @@ fn a_move_that_leaves_the_lattice_with_no_door_finds_masonry() {
 
 #[test]
 fn the_unchanged_second_door_remains_blocked() {
-    // North Gaol declares two doors. Opening the first must not open the other.
-    let mut session = common::session_at("north-gaol");
+    // The behavior fixture declares two doors. Opening the first must not open the other.
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>**");
     let movement = batch::movement_facts(session.live()).unwrap();
     assert!(matches!(
@@ -176,7 +176,7 @@ fn an_exit_uses_the_doors_declared_direction() {
     // crossing is the door on the player's own cell facing the way the move is
     // heading. Every corpus door faces north, so the other three faces are the
     // negative case.
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>**>");
     for wrong in [Direction::East, Direction::West, Direction::South] {
         let mut probe = session.clone();
@@ -199,7 +199,7 @@ fn the_two_spellings_of_the_crossing_produce_the_same_receipt() {
     // One rule, two spellings. A lattice-leaving `move` derives the gate from
     // the declared face and calls the same function `cross` calls, so the only
     // difference between the receipts is the input that produced them.
-    let mut walked = common::session_at("north-gaol");
+    let mut walked = common::behavior_session();
     common::drive(&mut walked, "^^^^>>**>");
     let mut named = walked.clone();
 
@@ -225,7 +225,7 @@ fn the_two_spellings_of_the_crossing_produce_the_same_receipt() {
 fn crossing_a_sealed_gate_is_refused() {
     // Standing on the gate's own cell, so the refusal is about the ward and the
     // integrity rather than about where the player is.
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>>");
     let receipt = session
         .step(&PlayCommand::Cross {
@@ -238,7 +238,7 @@ fn crossing_a_sealed_gate_is_refused() {
 
 #[test]
 fn crossing_a_gate_that_is_not_underfoot_is_refused() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     let receipt = session
         .step(&PlayCommand::Cross {
             gate: entity("north_gate"),
@@ -250,7 +250,7 @@ fn crossing_a_gate_that_is_not_underfoot_is_refused() {
 
 #[test]
 fn interaction_range_does_not_invent_remote_actions() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     let receipt = session
         .step(&PlayCommand::Interact {
             entity: entity("north_gate"),
@@ -267,7 +267,7 @@ fn interaction_range_does_not_invent_remote_actions() {
 
 #[test]
 fn an_undeclared_action_is_the_kernels_refusal() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>");
     let receipt = session
         .step(&PlayCommand::Interact {
@@ -283,7 +283,7 @@ fn an_undeclared_action_is_the_kernels_refusal() {
 fn an_interaction_does_not_offer_the_pursuer_a_step() {
     // The pursuit rule counts accepted player moves, not ticks. An interaction
     // advances the tick and leaves `moves_since_step` where it was.
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>");
     let before = session.live().state.moves_since_step;
     common::drive(&mut session, "*");
@@ -292,7 +292,7 @@ fn an_interaction_does_not_offer_the_pursuer_a_step() {
 
 #[test]
 fn a_command_after_the_run_is_over_is_refused_and_still_ticks() {
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^^^>>**>^");
     assert_eq!(session.outcome(), SessionOutcome::Completed);
     let tick_before = session.live().state.tick;
@@ -310,7 +310,7 @@ fn a_malformed_command_produces_no_receipt_and_no_tick() {
     // not an input, so there is nothing to decide about. This walks the same
     // path `wasm::nomos_play_step` walks — decode, then step — so the claim is
     // about the runtime's front door and not about the decoder alone.
-    let mut session = common::session_at("north-gaol");
+    let mut session = common::behavior_session();
     common::drive(&mut session, "^^");
     let receipts = session.receipts().len();
     let tick = session.live().state.tick;
@@ -339,8 +339,8 @@ fn the_reducer_is_a_function_of_the_state_and_the_input() {
     // Two sessions, the same log, byte-identical receipts. Determinism is a
     // property of the code — nothing here reads a clock or a hash map — and this
     // is the smallest statement of it.
-    let mut left = common::session_at("north-gaol");
-    let mut right = common::session_at("north-gaol");
+    let mut left = common::behavior_session();
+    let mut right = common::behavior_session();
     for session in [&mut left, &mut right] {
         common::drive(session, "^^^^>>**");
     }

--- a/crates/nomos-play/tests/replay.rs
+++ b/crates/nomos-play/tests/replay.rs
@@ -84,7 +84,8 @@ fn a_tampered_receipt_is_caught_at_its_ordinal() {
         Some(6),
         "the seventh batch is ordinal 6"
     );
-    assert_eq!(divergence.area.as_deref(), Some("cistern-walk"));
+    let start = common::route_expectations().route[0].area.clone();
+    assert_eq!(divergence.area.as_deref(), Some(start.as_str()));
 }
 
 #[test]
@@ -92,17 +93,15 @@ fn a_replay_against_different_content_is_refused_not_reported_as_a_divergence() 
     // A content mismatch is a harness error. Reporting it as a runtime
     // difference would be a lie about what diverged.
     let (_, session) = recorded();
+    let start = common::route_expectations().route[0].area.clone();
+    let other = common::different_area(&start);
     let error = replay(&session, |area| {
-        let other = if area == "cistern-walk" {
-            "north-gaol"
-        } else {
-            area
-        };
-        Ok((common::plan(other), common::semantics(other)))
+        let selected = if area == start { other.as_str() } else { area };
+        Ok((common::plan(selected), common::semantics(selected)))
     })
     .unwrap_err();
     assert_eq!(error.code(), codes::CONTENT_MISMATCH);
-    assert!(error.message().contains("cistern-walk"));
+    assert!(error.message().contains(&start));
 }
 
 #[test]
@@ -110,8 +109,14 @@ fn the_recorded_log_carries_the_refusals_too() {
     // The reason a refused batch commits: the recorded log is what the smoke
     // lane replays, and a log with the refusals dropped could not show that the
     // browser refused the same inputs at the same ticks.
-    let mut session = common::session_at("north-gaol");
-    common::drive(&mut session, "^^^^>>");
+    let area = common::behavior_area();
+    let mut session = common::session_at(&area);
+    let keys = common::keys_for(&area);
+    let before_interaction = keys
+        .chars()
+        .take_while(|key| *key != '*')
+        .collect::<String>();
+    common::drive(&mut session, &before_interaction);
     session
         .step(&common::step(nomos_play::Direction::North))
         .unwrap();
@@ -130,15 +135,17 @@ fn the_recorded_log_carries_the_refusals_too() {
 
 #[test]
 fn a_replay_reproduces_the_final_kernel_state_hash() {
+    let expected = common::route_expectations();
+    let live = common::play_route();
     let (_, session) = recorded();
     let report = replay(&session, content).unwrap();
     assert_eq!(
-        report.final_kernel_state_hash.to_hex(),
-        "0c0a573503282ec7b8f10dada7da267b96f04c089054936b84bece096b0ac7f2",
-        "north-gaol at `03-breached-unsealed`, where the route leaves it"
+        report.final_kernel_state_hash,
+        live.live().state.kernel_state_hash(),
+        "replay reaches the recorded route's final kernel state"
     );
-    assert_eq!(report.areas, 6);
-    assert_eq!(report.commands, 77);
+    assert_eq!(report.areas, usize::try_from(expected.areas).unwrap());
+    assert_eq!(report.commands, usize::try_from(expected.commands).unwrap());
 }
 
 #[test]

--- a/crates/nomos-play/tests/semantics.rs
+++ b/crates/nomos-play/tests/semantics.rs
@@ -4,7 +4,7 @@
 //! `nomos-projection` (`RUNTIME.md` section 3). Its first bound — exact
 //! re-encode byte identity — is checked inside the kernel by
 //! `crates/nomos-compiler/tests/projection_decode.rs` against
-//! `fixtures/gaol.nomos`. This is the other half: the six committed areas of
+//! `fixtures/gaol.nomos`. This is the other half: every committed area of
 //! the R1 corpus, decoded by the crate that actually consumes them, compared
 //! with the value the compiler projected.
 //!
@@ -19,20 +19,23 @@ use nomos_projection::SimulationPlan;
 
 fn compiled(area: &str) -> nomos_compiler::CompiledWorld {
     let bytes = common::area(area);
-    nomos_compiler::compile_world_package(bytes.source, SourcePath::new(bytes.source_path).unwrap())
-        .expect("the committed area compiles")
+    nomos_compiler::compile_world_package(
+        &bytes.source,
+        SourcePath::new(&bytes.source_path).unwrap(),
+    )
+    .expect("the committed area compiles")
 }
 
 #[test]
-fn the_decoder_reproduces_the_compilers_own_plan_for_all_six_areas() {
-    for area in common::ROUTE {
-        let bytes = common::semantics(area);
+fn the_decoder_reproduces_the_compilers_own_plan_for_every_area() {
+    for area in common::area_ids() {
+        let bytes = common::semantics(&area);
         let decoded = SimulationPlan::from_canonical_bytes(&bytes)
             .unwrap_or_else(|error| panic!("{area}: {error:?}"));
         assert_eq!(decoded.to_canonical_bytes(), bytes, "{area} re-encodes");
         assert_eq!(
             &decoded,
-            compiled(area).simulation(),
+            compiled(&area).simulation(),
             "{area} is the same plan"
         );
     }
@@ -42,11 +45,11 @@ fn the_decoder_reproduces_the_compilers_own_plan_for_all_six_areas() {
 fn every_committed_plan_publishes_the_digest_of_the_projection_it_was_compiled_against() {
     // The first of the decoder's two locks, checked against the committed
     // artifacts rather than against a constructed pair.
-    for area in common::ROUTE {
-        let plan = nomos_play::AreaPlan::decode(&common::plan(area)).unwrap();
+    for area in common::area_ids() {
+        let plan = nomos_play::AreaPlan::decode(&common::plan(&area)).unwrap();
         assert_eq!(
             plan.semantics_digest,
-            Sha256Digest::of_bytes(&common::semantics(area)),
+            Sha256Digest::of_bytes(&common::semantics(&area)),
             "{area}"
         );
     }
@@ -58,8 +61,8 @@ fn the_projection_digest_is_the_runtime_semantics_digest_the_kernel_binds() {
     // `runtime_semantics_digest` as the SHA-256 of the plan's own canonical
     // bytes, so a projection that hashes to what the rendering plan published
     // is the projection every persisted state of that world was bound to.
-    for area in common::ROUTE {
-        let bytes = common::semantics(area);
+    for area in common::area_ids() {
+        let bytes = common::semantics(&area);
         let decoded = SimulationPlan::from_canonical_bytes(&bytes).unwrap();
         let state = nomos_sim::SimulationState::initialize(&decoded).unwrap();
         let persisted = nomos_sim::PersistedRuntimeState::new(&decoded, state).unwrap();
@@ -77,9 +80,10 @@ fn a_projection_compiled_from_a_different_path_is_a_different_projection() {
     // projection's bytes and inside the digest. This is the same fact
     // `RUNTIME.md` section 5 R1-1 records for the effective-facts projection,
     // seen from the other side.
-    let bytes = common::area("north-gaol");
+    let area = common::behavior_area();
+    let bytes = common::area(&area);
     let elsewhere = nomos_compiler::compile_world_package(
-        bytes.source,
+        &bytes.source,
         SourcePath::new("somewhere/else/world.nomos").unwrap(),
     )
     .unwrap();
@@ -90,15 +94,15 @@ fn a_projection_compiled_from_a_different_path_is_a_different_projection() {
         .find(|(name, _)| name.as_str() == "simulation.json")
         .unwrap()
         .1;
-    assert_ne!(moved, common::semantics("north-gaol"));
+    assert_ne!(moved, common::semantics(&area));
 
-    let error = nomos_play::PlaySession::start(&common::plan("north-gaol"), &moved).unwrap_err();
+    let error = nomos_play::PlaySession::start(&common::plan(&area), &moved).unwrap_err();
     assert_eq!(error.code(), nomos_play::codes::SEMANTICS_DIGEST);
 }
 
 #[test]
 fn a_projection_this_runtime_cannot_reconstruct_is_refused() {
-    let bytes = common::semantics("north-gaol");
+    let bytes = common::semantics(&common::behavior_area());
     let text = String::from_utf8(bytes).unwrap();
     let broken = text.replacen(r#""phase":"causal""#, r#""phase":"eventual""#, 1);
     let error = SimulationPlan::from_canonical_bytes(broken.as_bytes()).unwrap_err();
@@ -108,9 +112,9 @@ fn a_projection_this_runtime_cannot_reconstruct_is_refused() {
 
 #[test]
 fn the_decoded_plan_carries_every_machine_the_compiler_projected() {
-    for area in common::ROUTE {
-        let decoded = SimulationPlan::from_canonical_bytes(&common::semantics(area)).unwrap();
-        let expected = compiled(area);
+    for area in common::area_ids() {
+        let decoded = SimulationPlan::from_canonical_bytes(&common::semantics(&area)).unwrap();
+        let expected = compiled(&area);
         assert_eq!(
             decoded.machines().len(),
             expected.simulation().machines().len(),

--- a/crates/nomos-play/tests/session.rs
+++ b/crates/nomos-play/tests/session.rs
@@ -9,28 +9,34 @@ fn arrival_uses_the_destinations_own_entry_cell() {
     // Owner ruling 3 of `docs/review/presentation-source.md`: the exiting area
     // no longer names a cell inside its neighbour, so the arrival cell is read
     // from the plan the player is arriving *in*.
+    let expected = common::route_expectations();
+    let next = &expected.route[1].area;
     let mut session = common::session();
-    common::drive(&mut session, common::ROUTE_KEYS[0]);
+    common::drive(&mut session, &expected.route[0].keys);
     assert_eq!(session.outcome(), SessionOutcome::Escaped);
-    assert_eq!(session.pending_area(), Some("ember-vault"));
+    assert_eq!(session.pending_area(), Some(next.as_str()));
 
-    common::enter(&mut session, "ember-vault");
+    common::enter(&mut session, next);
     let player = session.live().state.player().cell;
-    let entry = session.live().plan.entry.expect("ember-vault declares one");
+    let entry = session
+        .live()
+        .plan
+        .entry
+        .expect("a non-start area declares an entry");
     assert_eq!((player.x(), player.y()), (entry.x(), entry.y()));
-    assert_eq!((player.x(), player.y()), (7, 5));
 }
 
 #[test]
 fn arrival_carries_the_tick_and_both_counters() {
+    let expected = common::route_expectations();
     let mut session = common::session();
-    common::drive(&mut session, common::ROUTE_KEYS[0]);
+    common::drive(&mut session, &expected.route[0].keys);
     let tick = session.live().state.tick;
     let counters = session.counters();
-    assert_eq!(counters.moves, 12);
-    assert_eq!(counters.traversal_cost, 16);
+    assert!(counters.moves > 0);
+    assert!(counters.traversal_cost >= counters.moves);
 
-    common::enter(&mut session, "ember-vault");
+    common::enter(&mut session, &expected.route[1].area);
     assert_eq!(session.live().state.tick, tick, "the tick does not reset");
     assert_eq!(session.counters(), counters, "the counters are cumulative");
     assert_eq!(session.live().state.moves_since_step, 0);
@@ -40,36 +46,43 @@ fn arrival_carries_the_tick_and_both_counters() {
 
 #[test]
 fn arrival_opens_a_fresh_kernel_state_for_the_destination() {
+    let expected = common::route_expectations();
     let mut session = common::session();
-    common::drive(&mut session, common::ROUTE_KEYS[0]);
+    common::drive(&mut session, &expected.route[0].keys);
     let left_behind = session.live().state.kernel_state_hash();
-    common::enter(&mut session, "ember-vault");
+    common::enter(&mut session, &expected.route[1].area);
     assert_ne!(session.live().state.kernel_state_hash(), left_behind);
     assert_eq!(session.live().state.kernel.state().tick(), 0);
 }
 
 #[test]
 fn arrival_into_the_wrong_area_is_refused() {
+    let expected = common::route_expectations();
+    let pending = &expected.route[1].area;
+    let wrong = expected
+        .route
+        .iter()
+        .map(|leg| &leg.area)
+        .find(|area| *area != pending && *area != &expected.route[0].area)
+        .expect("the route has a third area");
     let mut session = common::session();
-    common::drive(&mut session, common::ROUTE_KEYS[0]);
+    common::drive(&mut session, &expected.route[0].keys);
     let error = session
-        .enter(
-            &common::plan("north-gaol"),
-            &common::semantics("north-gaol"),
-        )
+        .enter(&common::plan(wrong), &common::semantics(wrong))
         .unwrap_err();
     assert_eq!(error.code(), codes::ENTER_REFUSED);
-    assert!(error.message().contains("ember-vault"));
+    assert!(error.message().contains(pending));
 }
 
 #[test]
 fn arrival_before_a_crossing_is_refused() {
+    let expected = common::route_expectations();
     let mut session = common::session();
     common::drive(&mut session, "^^^");
     let error = session
         .enter(
-            &common::plan("ember-vault"),
-            &common::semantics("ember-vault"),
+            &common::plan(&expected.route[1].area),
+            &common::semantics(&expected.route[1].area),
         )
         .unwrap_err();
     assert_eq!(error.code(), codes::ENTER_REFUSED);
@@ -78,28 +91,30 @@ fn arrival_before_a_crossing_is_refused() {
 
 #[test]
 fn the_route_records_a_digest_for_every_area_it_enters() {
+    let expected = common::route_expectations();
     let session = common::play_route();
-    assert_eq!(session.route().len(), 6);
-    for (row, area) in session.route().iter().zip(common::ROUTE) {
-        assert_eq!(row.area, area);
+    assert_eq!(session.route().len(), expected.route.len());
+    for (row, leg) in session.route().iter().zip(expected.route) {
+        assert_eq!(row.area, leg.area);
         assert_eq!(
             row.plan_digest,
-            nomos_core::Sha256Digest::of_bytes(&common::plan(area))
+            nomos_core::Sha256Digest::of_bytes(&common::plan(&leg.area))
         );
         assert_eq!(
             row.semantics_digest,
-            nomos_core::Sha256Digest::of_bytes(&common::semantics(area))
+            nomos_core::Sha256Digest::of_bytes(&common::semantics(&leg.area))
         );
     }
 }
 
 #[test]
 fn the_terminal_area_completes_the_run() {
+    let expected = common::route_expectations();
     let session = common::play_route();
     assert_eq!(session.outcome(), SessionOutcome::Completed);
     assert_eq!(session.pending_area(), None);
     assert_eq!(session.live().plan.to_area, None);
-    assert_eq!(session.areas_cleared(), 6);
+    assert_eq!(session.areas_cleared(), expected.areas);
 }
 
 #[test]
@@ -111,11 +126,8 @@ fn reset_starts_a_new_session_and_is_not_a_command() {
     common::drive(&mut session, "^^^");
     assert_eq!(session.log().len(), 3);
 
-    let fresh = PlaySession::start(
-        &common::plan("cistern-walk"),
-        &common::semantics("cistern-walk"),
-    )
-    .unwrap();
+    let start = common::route_expectations().route[0].area.clone();
+    let fresh = PlaySession::start(&common::plan(&start), &common::semantics(&start)).unwrap();
     assert!(fresh.log().is_empty());
     assert!(fresh.receipts().is_empty());
     assert_eq!(fresh.live().state.tick, 0);
@@ -127,20 +139,19 @@ fn reset_starts_a_new_session_and_is_not_a_command() {
 fn a_projection_the_plan_did_not_publish_is_refused_before_it_is_decoded() {
     // The first of the decoder's two locks: the projection's bytes must hash to
     // the digest the rendering plan published for `simulation.json`.
-    let error = PlaySession::start(
-        &common::plan("cistern-walk"),
-        &common::semantics("north-gaol"),
-    )
-    .unwrap_err();
+    let start = common::route_expectations().route[0].area.clone();
+    let other = common::different_area(&start);
+    let error = PlaySession::start(&common::plan(&start), &common::semantics(&other)).unwrap_err();
     assert_eq!(error.code(), codes::SEMANTICS_DIGEST);
-    assert!(error.message().contains("cistern-walk"));
+    assert!(error.message().contains(&start));
 }
 
 #[test]
 fn a_projection_that_is_not_canonical_is_refused() {
-    let mut bytes = common::semantics("cistern-walk");
+    let start = common::route_expectations().route[0].area.clone();
+    let mut bytes = common::semantics(&start);
     bytes.push(b'}');
-    let error = PlaySession::start(&common::plan("cistern-walk"), &bytes).unwrap_err();
+    let error = PlaySession::start(&common::plan(&start), &bytes).unwrap_err();
     // The digest check fires first, which is the cheaper and more specific of
     // the two refusals.
     assert_eq!(error.code(), codes::SEMANTICS_DIGEST);
@@ -148,9 +159,10 @@ fn a_projection_that_is_not_canonical_is_refused() {
 
 #[test]
 fn the_session_document_carries_one_state_per_entered_area() {
+    let expected = common::route_expectations();
     let mut session = common::session();
-    common::drive(&mut session, common::ROUTE_KEYS[0]);
-    common::enter(&mut session, "ember-vault");
+    common::drive(&mut session, &expected.route[0].keys);
+    common::enter(&mut session, &expected.route[1].area);
     let value = session.to_canonical();
     let nomos_core::CanonicalValue::Object(fields) = &value else {
         panic!("a session is an object");
@@ -173,8 +185,9 @@ fn the_session_document_carries_one_state_per_entered_area() {
 
 #[test]
 fn a_step_into_the_next_area_is_refused_until_it_is_entered() {
+    let expected = common::route_expectations();
     let mut session = common::session();
-    common::drive(&mut session, common::ROUTE_KEYS[0]);
+    common::drive(&mut session, &expected.route[0].keys);
     let receipt = session
         .step(&common::step(Direction::North))
         .unwrap()

--- a/crates/nomos-render-plan/tests/source.rs
+++ b/crates/nomos-render-plan/tests/source.rs
@@ -16,7 +16,7 @@
 mod common;
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
 use common::Fixture;
 use nomos_render_plan::source::{self, Cell, PresentationSource};
@@ -517,9 +517,36 @@ fn renaming_both_actors_changes_nothing() {
     // `player` and `gaoler`; here a committed source's actors are renamed to
     // `runner` and `warden`, which resemble neither, and the decode produces
     // the same two roles standing on the same two cells.
-    let committed = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../experiments/executable-gaol/areas/north-gaol/presentation.json");
-    let original = fs::read_to_string(&committed).expect("the study's north gaol is readable");
+    let areas =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../experiments/executable-gaol/areas");
+    let mut sources = fs::read_dir(areas)
+        .expect("the study's areas directory is readable")
+        .filter_map(|entry| {
+            let path = entry.expect("an area-directory entry is readable").path();
+            path.is_dir().then(|| path.join("presentation.json"))
+        })
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    sources.sort();
+    let original = sources
+        .into_iter()
+        .map(|path| fs::read_to_string(path).expect("a committed source is readable"))
+        .find(|text| text.contains("\"id\": \"player\"") && text.contains("\"id\": \"gaoler\""))
+        .expect("one committed source carries the original actor identities");
+    let document = nomos_render_plan::json::parse(original.as_bytes()).unwrap();
+    let gate = document
+        .get("route")
+        .and_then(|route| route.get("exit"))
+        .and_then(|exit| exit.get("gate"))
+        .and_then(nomos_render_plan::json::Json::as_text)
+        .unwrap()
+        .to_owned();
+    let light = document
+        .get("pursuit")
+        .and_then(|pursuit| pursuit.get("light"))
+        .and_then(nomos_render_plan::json::Json::as_text)
+        .unwrap()
+        .to_owned();
     let renamed = original
         .replace("\"id\": \"player\"", "\"id\": \"runner\"")
         .replace("\"id\": \"gaoler\"", "\"id\": \"warden\"");
@@ -530,8 +557,8 @@ fn renaming_both_actors_changes_nothing() {
     );
 
     let fixture = Fixture::new("actor-rename");
-    let before = read_north_gaol(&fixture, &original);
-    let after = read_north_gaol(&fixture, &renamed);
+    let before = read_committed_source(&fixture, &original, &gate, &light);
+    let after = read_committed_source(&fixture, &renamed, &gate, &light);
 
     let ids = |source: &PresentationSource| -> Vec<String> {
         source.actors.iter().map(|actor| actor.id.clone()).collect()
@@ -569,19 +596,24 @@ fn cast(source: &PresentationSource) -> Vec<(String, String, Cell)> {
 
 /// Decodes one presentation source, written into a fixture's own directory so
 /// the committed file is never edited in place.
-fn read_north_gaol(fixture: &Fixture, text: &str) -> PresentationSource {
+fn read_committed_source(
+    fixture: &Fixture,
+    text: &str,
+    gate: &str,
+    light: &str,
+) -> PresentationSource {
     let path = fixture.source();
     fs::write(&path, text).unwrap();
-    source::read_source(&path, &north_gaol_kind).expect("the committed source decodes")
-}
-
-/// The kinds the study's north gaol declares, as its catalog resolves them.
-fn north_gaol_kind(id: &str) -> Option<EntityKind> {
-    match id {
-        "north_gate" => Some(EntityKind::Door),
-        "brazier_02" => Some(EntityKind::Light),
-        _ => None,
-    }
+    source::read_source(&path, &|id| {
+        if id == gate {
+            Some(EntityKind::Door)
+        } else if id == light {
+            Some(EntityKind::Light)
+        } else {
+            None
+        }
+    })
+    .expect("the committed source decodes")
 }
 
 // ---------------------------------------------------------------------------
@@ -617,5 +649,5 @@ fn the_committed_sources_carry_no_decimal_literal() {
         }
         checked += 1;
     }
-    assert_eq!(checked, 6, "all six committed areas were checked");
+    assert!(checked > 0, "the committed corpus is not empty");
 }

--- a/docs/review/cold-author-area-five.md
+++ b/docs/review/cold-author-area-five.md
@@ -119,6 +119,12 @@ But it is the same hazard #163 removed from the JavaScript collection test
 before the run, and it is recorded here as a finding rather than folded into
 the connection commit: issue #167.
 
+Issue #167 closes the class: crate tests now discover the area directories,
+and a planted scan refuses any corpus area id under `crates/*/tests/`. The
+solver writes the route keys and cumulative counters to the content-side
+`route-expectations.json`; `gaol accept` regenerates it and `gaol verify`
+compares it byte-for-byte.
+
 **A pin under `apps/` — an R1-4 criterion regression.**
 `apps/nomos-viewer/test/runtime.test.mjs` hardcoded the four-area route as
 key strings (`ROUTE_KEYS`), so two viewer tests failed once a fifth area

--- a/docs/review/nomos-play.md
+++ b/docs/review/nomos-play.md
@@ -1346,6 +1346,14 @@ ossuary-reach  ↑↑→↑↑→→→↑ E E →↑     36 moves  48 cost   1,
 north-gaol     ↑↑↑↑→→ E E →↑        44 moves  60 cost   2,4 → … → 5,0 → out
 ```
 
+That table is the original R1-5 measurement. The active corpus is discovered
+from `experiments/executable-gaol/areas/*/`, and issue #167 moves the solver's
+current route keys and counter pins to the content-side
+`route-expectations.json`. `gaol accept` regenerates it, `gaol verify` compares
+it byte-for-byte, and the native tests drive it through the authoritative
+runtime; adding an area therefore edits content and generated fixtures rather
+than a crate test.
+
 No leg's path enters the pursuer's cell — `4,3`, `1,3`, `7,3`, `5,3`
 respectively — which is what makes §3.2 rule 4 free. Note that
 `docs/review/nomos-viewer.md` §5.3's prose says "the lane dispatches 60 keys"

--- a/experiments/executable-gaol/AUTHORING.md
+++ b/experiments/executable-gaol/AUTHORING.md
@@ -158,7 +158,9 @@ Adding an area to the route is content, not code. The procedure:
    `target/executable-gaol/areas/<id>/rendering-plan.json` to that area's own
    `areas/<id>/rendering-plan.example.json`, and
    `target/executable-gaol/areas.json` to `area-collection.example.json`. It
-   prints every fixture it wrote.
+   also regenerates `route-expectations.json`, the content-side route and
+   counter fixture derived by the smoke solver. It prints every fixture it
+   wrote.
 5. **Prove it.**
    ```sh
    experiments/executable-gaol/gaol verify
@@ -171,10 +173,11 @@ Adding an area to the route is content, not code. The procedure:
 under `areas/<id>/`; the predecessor's `presentation.json` (the one
 `route.exit.to_area` edit) and its regenerated `rendering-plan.example.json`;
 and `area-collection.example.json`, which `gaol accept` also regenerates,
-because the route graph now has one more edge. Nothing under `src/`, `apps/`,
-or `crates/` changes. If a change to connect an area seems to require editing
-any of those, the area is not actually content — file it rather than route
-around it.
+because the route graph now has one more edge; and `route-expectations.json`,
+because the solved walk and its counters now include the new area. Nothing
+under `src/`, `apps/`, or `crates/` changes. If a change to connect an area
+seems to require editing any of those, the area is not actually content — file
+it rather than route around it.
 
 **Where the vocabulary lives.** `world.nomos` is written in the source
 language the compiler reads; its full vocabulary — primitives, credentials,

--- a/experiments/executable-gaol/gaol
+++ b/experiments/executable-gaol/gaol
@@ -66,6 +66,8 @@ build() {
     --out "$output_dir/areas.json"
   node "$experiment_dir/src/capture-collection.mjs" \
     "$output_dir/areas.json" "$output_dir/areas" "$output_dir/frames"
+  node "$experiment_dir/src/route-expectations.mjs" \
+    "$output_dir/areas.json" "$output_dir/areas" "$output_dir/route-expectations.json"
 }
 
 case "$mode" in
@@ -84,6 +86,7 @@ case "$mode" in
       "$output_dir/areas.json" \
       "$experiment_dir/area-collection.example.json" \
       "$output_dir/areas"
+    cmp "$output_dir/route-expectations.json" "$experiment_dir/route-expectations.json"
     for area_dir in "$areas_dir"/*; do
       [[ -d $area_dir ]] || continue
       area_id=$(basename "$area_dir")
@@ -103,6 +106,8 @@ case "$mode" in
     done
     cp "$output_dir/areas.json" "$experiment_dir/area-collection.example.json"
     printf 'wrote %s\n' "${experiment_dir#"$repo_root/"}/area-collection.example.json"
+    cp "$output_dir/route-expectations.json" "$experiment_dir/route-expectations.json"
+    printf 'wrote %s\n' "${experiment_dir#"$repo_root/"}/route-expectations.json"
     ;;
   *)
     printf 'usage: %s [capture|verify|accept]\n' "$0" >&2

--- a/experiments/executable-gaol/route-expectations.json
+++ b/experiments/executable-gaol/route-expectations.json
@@ -1,0 +1,1 @@
+{"expected":{"areas":6,"commands":77,"moves":65,"traversal_cost":95},"route":[{"area":"cistern-walk","keys":"^^^<<<<<<^**>^"},{"area":"ember-vault","keys":"<<<<<^^^>^^**>^"},{"area":"gloam-bastion","keys":"^^^<<<v^^^**<^"},{"area":"drowned-stair","keys":"^<<>^^^**^^"},{"area":"ossuary-reach","keys":"^^>^^>>>^**>^"},{"area":"north-gaol","keys":"^^^^>>**>^"}]}

--- a/experiments/executable-gaol/src/route-expectations.mjs
+++ b/experiments/executable-gaol/src/route-expectations.mjs
@@ -1,0 +1,53 @@
+// Generates the content-side route fixture consumed by the native runtime
+// tests. The route solver derives its walk from compiled artifacts, so adding
+// an area changes content and this generated fixture, never a crate test.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { decodeCollection, decodePlan } from "../../../apps/nomos-viewer/src/plan.mjs";
+import { solveRoute } from "../../../apps/nomos-viewer/smoke/route.mjs";
+
+const [collectionPath, plansDirectory, outputPath] = process.argv.slice(2);
+if (!collectionPath || !plansDirectory || !outputPath) {
+  process.stderr.write(
+    "usage: node route-expectations.mjs <areas.json> <plans-directory> <output.json>\n",
+  );
+  process.exit(64);
+}
+
+const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
+const collection = decodeCollection(readJson(collectionPath), collectionPath);
+const plans = new Map(
+  collection.areas.map((area) => {
+    const path = join(plansDirectory, area.id, "rendering-plan.json");
+    return [area.id, decodePlan(readJson(path), path)];
+  }),
+);
+const solved = solveRoute(collection, plans);
+const key = Object.freeze({
+  ArrowUp: "^",
+  ArrowDown: "v",
+  ArrowLeft: "<",
+  ArrowRight: ">",
+  KeyE: "*",
+});
+const document = {
+  expected: {
+    areas: solved.areas,
+    commands: solved.keys.length,
+    moves: solved.moves,
+    traversal_cost: solved.cost,
+  },
+  route: solved.legs.map((leg) => ({
+    area: leg.area,
+    keys: leg.keys
+      .map((one) => {
+        if (!key[one]) throw new Error(`the route solver emitted unknown key ${one}`);
+        return key[one];
+      })
+      .join(""),
+  })),
+};
+
+writeFileSync(outputPath, `${JSON.stringify(document)}\n`);


### PR DESCRIPTION
Closes #167.

## What changed

- discover every committed area under `experiments/executable-gaol/areas/*` from crate tests instead of naming area IDs in Rust
- generate `route-expectations.json` from the accepted viewer route solver, copy it during `gaol accept`, and compare it byte-for-byte during `gaol verify`
- drive native route/counter assertions from that content-side fixture
- add a planted regression test that scans every `crates/*/tests` file and refuses any current corpus area ID
- update the authoring and historical review notes with the active ownership boundary

## Author proof

Passed from a fresh `CARGO_TARGET_DIR`:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --workspace --locked
cargo xtask boundary
```

Additional evidence:

```text
experiments/executable-gaol/gaol verify
cargo test -p nomos-play --test corpus no_crate_test_names_a_corpus_area
```

The six current area IDs produce no matches under `crates/*/tests`.

## Unresolved limit

The required non-author rerun is still pending. This PR remains draft and is not called green until that receipt exists.
