### PR TITLE
Record complete R1 offline and budget evidence

### DIFF
--- a/.github/workflows/nomos-viewer.yml
+++ b/.github/workflows/nomos-viewer.yml
@@ -21,6 +21,56 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  r1-adoption-evidence:
+    name: R1 offline build, artifact, budgets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # Toolchain provisioning belongs to the runner, not to the repository's
+      # dependency closure. Force rustup to resolve the pinned toolchain and
+      # wasm target before the proof removes the network route.
+      - name: Provision the pinned toolchain
+        run: |
+          rustup show
+          cargo --version
+
+      - name: Measure from a network-isolated clean checkout
+        run: |
+          set -euo pipefail
+          export NOMOS_RUNNER_PATH=$PATH
+          export NOMOS_CARGO_HOME=${CARGO_HOME:-$HOME/.cargo}
+          export NOMOS_RUSTUP_HOME=${RUSTUP_HOME:-$HOME/.rustup}
+          export NOMOS_CHROME_BIN=$(command -v google-chrome)
+          sudo --preserve-env=NOMOS_RUNNER_PATH,NOMOS_CARGO_HOME,NOMOS_RUSTUP_HOME,NOMOS_CHROME_BIN,RUNNER_ARCH,ImageOS,ImageVersion,GITHUB_WORKSPACE \
+            unshare --net -- bash -ceu '
+              ip link set lo up
+              export PATH=$NOMOS_RUNNER_PATH
+              export CARGO_HOME=$NOMOS_CARGO_HOME
+              export RUSTUP_HOME=$NOMOS_RUSTUP_HOME
+              export CHROME_BIN=$NOMOS_CHROME_BIN
+              export GIT_CONFIG_COUNT=1
+              export GIT_CONFIG_KEY_0=safe.directory
+              export GIT_CONFIG_VALUE_0=$GITHUB_WORKSPACE
+              export NOMOS_NETWORK_ISOLATED=1
+              cd "$GITHUB_WORKSPACE"
+              docs/evaluation/r1-adoption-evidence.sh target/r1-adoption
+            '
+
+      - name: Upload the complete R1 adoption receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: r1-adoption-evidence
+          path: target/r1-adoption
+          if-no-files-found: error
+          retention-days: 90
+
   viewer:
     name: tests, artifact, scan, browser
     runs-on: ubuntu-24.04

--- a/.github/workflows/nomos-viewer.yml
+++ b/.github/workflows/nomos-viewer.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-node@v5
         with:

--- a/RUNTIME.md
+++ b/RUNTIME.md
@@ -479,6 +479,20 @@ No target is accepted while that lane is red or absent. Locally the smoke lane
 skips with an explicit message when the machine has no Chrome; in CI it is
 required.
 
+The section 1 criterion 4 clean-checkout proof and the complete section 7
+measurement run through one entry point:
+
+```text
+docs/evaluation/r1-adoption-evidence.sh target/r1-adoption
+```
+
+The `R1 offline build, artifact, budgets` CI job invokes it inside a network
+namespace with no default route and loopback as the only enabled interface. The
+script refuses to run without that isolation, forces Cargo offline, records the
+exact environment and commands, and uploads the raw samples and compact
+receipt. `docs/evaluation/r1-adoption-evidence.md` preserves the load-bearing
+receipt from the run that supplied section 7's current values.
+
 Nothing is green until someone other than its author reruns the proof. Under
 `AGENTS.md` the rerun receipt records the commit, the commands, the environment,
 the result, and the reviewer. The author's own run is insufficient.
@@ -490,16 +504,21 @@ that produced it; the values are observations, not portable guarantees. Nothing
 below is a target value, and no unmeasured claim of sufficiency satisfies
 acceptance.
 
+Unless a row names earlier cross-machine evidence, the current values are from
+commit `bdd2229219bfb3b9efdf6c64f0d865f3202a4d82`, workflow run `32905965046`,
+on the `ubuntu24` x86_64 runner image `20260823.283.1`; the compact receipt is
+`docs/evaluation/r1-adoption-evidence.md`.
+
 | Field | Unit | How measured | Value |
 | --- | --- | --- | --- |
-| Workspace build time | s | clean release build of the workspace | not measured |
-| Validation latency | ms | `nomos validate` on the accepted fixture | not measured |
-| Replay throughput | commands/s | `nomos replay` over the accepted log | not measured |
-| Play replay throughput | commands/s | `nomos-play replay` over the recorded four-area session | 1 194 — twenty release-profile replays of the smoke lane's 52-command `session.json` in 0.871 s, 43.5 ms each, process start and the four projection decodes included; measured on the R1-5 branch |
-| Package size | bytes | a compiled world package directory | not measured |
-| Public artifact size | bytes | the staged public site directory | 1 355 141 — `apps/nomos-viewer/dist`, 20 files, measured by `apps/nomos-viewer/build.mjs` on the R1-5 branch. It was 896 680 on the issue #152 branch; the 458 461 bytes are the authoritative runtime at 422 432, the four simulation projections at 24 956, and the loader and adapter |
-| Play runtime size | bytes | `crates/nomos-play/build-wasm.sh`, `stat -c%s` | 422 432, sha256 `70addbe7662caab4af2d0147c09dc8e839dd282c617a99cd325ced026d0d3a0f`. Reproducible, and across machines rather than only across builds: two builds with `target/wasm32-unknown-unknown` removed between them agree byte for byte, and the `ubuntu-24.04` CI runner produced the same digit-for-digit sha256 in run 32883772392, from a different checkout path. The profile is measured rather than assumed — the same crate is 554 732 bytes under the plain release profile, and the four knobs `[profile.wasm]` sets are what closes the gap |
-| Edit-to-visible-frame latency | ms | content edit to first rendered frame | not measured |
+| Workspace build time | s | clean release build of the workspace, Cargo offline | 17.344 |
+| Validation latency | ms | `nomos validate` on the accepted fixture; three warmups, twenty process-level samples | 9.783 median; 9.989 p95 |
+| Replay throughput | commands/s | `nomos replay` over the accepted five-command log; three warmups, twenty process-level samples | 349.668 |
+| Play replay throughput | commands/s | release `nomos-play replay` over the recorded six-area, 77-command browser session; three warmups, twenty process-level samples, process start and six projection decodes included | 1 206.731; 63.476 ms median and 65.064 ms p95 per replay |
+| Package size | bytes | sum of regular-file bytes in the compiled accepted-fixture package | 20 492 across 8 files |
+| Public artifact size | bytes | sum of regular-file bytes in the staged and scanned six-area public site | 1 387 887 across 24 files |
+| Play runtime size | bytes | `crates/nomos-play/build-wasm.sh`, `stat -c%s` | 422 432, sha256 `70addbe7662caab4af2d0147c09dc8e839dd282c617a99cd325ced026d0d3a0f`. The isolated run reproduced the value; two builds with the wasm target removed between them and CI run 32883772392 from another checkout path had already reproduced the same digest. The profile is measured rather than assumed — the same crate was 554 732 bytes under the plain release profile, and the four knobs `[profile.wasm]` sets are what closes the gap |
+| Edit-to-visible-frame latency | ms | cold content pipeline before compilation/capture through the browser's first completed WebGL render; proof-only tests excluded | 27 771 total, of which navigation to first frame was 2 056 |
 
 ## 8. Contract repair
 

--- a/apps/nomos-viewer/smoke/smoke.mjs
+++ b/apps/nomos-viewer/smoke/smoke.mjs
@@ -6,7 +6,8 @@
 // the design, including the twelve ways this fails and the receipt it writes.
 //
 //   node apps/nomos-viewer/smoke/smoke.mjs --dist apps/nomos-viewer/dist \
-//     --out target/nomos-viewer-smoke [--require-chrome]
+//     --out target/nomos-viewer-smoke [--require-chrome] \
+//     [--pipeline-start-ms <unix-ms>]
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -40,12 +41,22 @@ const parseArguments = (argv) => {
     out: "target/nomos-viewer-smoke",
     requireChrome: false,
     deadlineMs: DEADLINE_MS,
+    pipelineStartMs: null,
   };
   for (let index = 0; index < argv.length; index += 1) {
     if (argv[index] === "--dist") options.dist = argv[index + 1];
     else if (argv[index] === "--out") options.out = argv[index + 1];
     else if (argv[index] === "--require-chrome") options.requireChrome = true;
     else if (argv[index] === "--deadline-ms") options.deadlineMs = Number(argv[index + 1]);
+    else if (argv[index] === "--pipeline-start-ms") {
+      options.pipelineStartMs = Number(argv[index + 1]);
+    }
+  }
+  if (
+    options.pipelineStartMs !== null &&
+    (!Number.isSafeInteger(options.pipelineStartMs) || options.pipelineStartMs <= 0)
+  ) {
+    throw new Error("--pipeline-start-ms must be a positive integer Unix timestamp in milliseconds");
   }
   return options;
 };
@@ -121,6 +132,9 @@ async function run(options) {
 
   const server = await serve(dist);
   const started = Date.now();
+  if (options.pipelineStartMs !== null && options.pipelineStartMs > started) {
+    fail("--pipeline-start-ms is later than the smoke-lane start");
+  }
   const receipt = {
     receipt: "nomos-viewer-smoke/1",
     generated_by: "apps/nomos-viewer/smoke/smoke.mjs",
@@ -137,6 +151,12 @@ async function run(options) {
       cost: leg.cost,
     })),
     expected: { areas: route.areas, moves: route.moves, cost: route.cost, summary: route.summary },
+    timing: {
+      smoke_started_unix_ms: started,
+      ...(options.pipelineStartMs === null
+        ? {}
+        : { pipeline_started_unix_ms: options.pipelineStartMs }),
+    },
     outcome: "fail",
   };
 
@@ -208,6 +228,7 @@ async function drive({ browser, server, route, collection, out, receipt }) {
   await page.send("Page.enable");
   await page.send("Network.enable");
 
+  const navigationStarted = Date.now();
   const loaded = page.once("Page.loadEventFired");
   await page.send("Page.navigate", { url: `${server.origin}/` });
   await loaded;
@@ -239,6 +260,17 @@ async function drive({ browser, server, route, collection, out, receipt }) {
     fail(`${error.message} (no console error was reported)`);
   }
   await guard();
+
+  // `data-ready` is set only after `renderer.present()` has synchronously
+  // submitted its first WebGL render. This timestamp therefore closes the
+  // content-edit-to-visible interval without counting the rest of the route.
+  const firstFrame = Date.now();
+  receipt.timing.first_frame_unix_ms = firstFrame;
+  receipt.timing.navigation_to_first_frame_ms = firstFrame - navigationStarted;
+  if (receipt.timing.pipeline_started_unix_ms !== undefined) {
+    receipt.timing.edit_to_visible_frame_ms =
+      firstFrame - receipt.timing.pipeline_started_unix_ms;
+  }
 
   const webgl = await page.evaluate(`(() => {
     const canvas = document.querySelector('#frame canvas');

--- a/docs/evaluation/r1-adoption-evidence.md
+++ b/docs/evaluation/r1-adoption-evidence.md
@@ -1,0 +1,105 @@
+---
+title: R1 clean-checkout offline and budget evidence
+status: Author and CI evidence; non-author candidate rerun pending
+date: 2026-08-26
+candidate: bdd2229219bfb3b9efdf6c64f0d865f3202a4d82
+workflow_run: 32905965046
+artifact_id: 9584836533
+issue: 172
+---
+
+# R1 clean-checkout offline and budget evidence
+
+This is the compact repository copy of the load-bearing receipt from the
+successful `nomos viewer` workflow run `32905965046`, job `R1 offline build,
+artifact, budgets`. The job checked out exact branch head
+`bdd2229219bfb3b9efdf6c64f0d865f3202a4d82`. GitHub artifact `9584836533`,
+`r1-adoption-evidence`, has archive SHA-256
+`8e17731c3db4fd2d9859430e8133fc3a3a11c7dfc0e7e63ef864d06837160c72`;
+its compact `receipt.txt` hashes to
+`be77b3b9652157575265cd3ae0a8c2de9edc740234763b2477c4fcfcf4089e0a`.
+
+The artifact contains the environment, exact command ledger, build timing and
+disk samples, all operation samples, the compiled fixture and base run used by
+the measurements, workspace and viewer test output, the staged-build receipt,
+the browser receipt and screenshots, the recorded six-area session, and all
+twenty-three play-replay outputs. This compact copy identifies those bytes; it
+does not substitute issue or pull-request prose for them.
+
+## Offline boundary
+
+The workflow provisioned the pinned Rust toolchain and Node runtime, then ran
+`docs/evaluation/r1-adoption-evidence.sh target/r1-adoption` in a fresh network
+namespace. The namespace had no IPv4 or IPv6 default route; loopback was its
+only enabled interface. The script refuses an ordinary networked environment
+and set `CARGO_NET_OFFLINE=true` before any repository build.
+
+From a clean checkout with no derived target, content, wasm, or public-site
+output, that isolated process:
+
+1. built the complete workspace in release mode and tested the complete
+   workspace with Cargo offline;
+2. compiled and captured all six committed study areas;
+3. built the authoritative wasm runtime with `--offline`;
+4. ran the viewer tests, staged the public site, and passed its origin,
+   forbidden-input, credential, and build-path scan;
+5. loaded the site through loopback Chromium, whose own resolver additionally
+   denied every non-local host, reached the final escape, and replayed the
+   browser's 77-command session through the release native runtime; and
+6. left the Git commit and tracked tree unchanged.
+
+The receipt reports `workspace_build_offline yes`, `workspace_test_offline
+yes`, `public_artifact_offline yes`, and clean state before and after. Its exact
+command ledger hashes to
+`60c423b6f9082873a9becfe70d85b7fa32630c7948cf61dd9c28d565d0958a96`.
+
+## Measurements
+
+Three warmups precede twenty process-level measured samples for validation,
+kernel replay, and play replay. Times include process startup. File sizes are
+the sum of regular-file bytes rather than allocated disk blocks.
+
+| Field | Observation |
+| --- | ---: |
+| Clean release workspace build | 17.344341824 s |
+| Validation | 9.783460 ms median; 9.988658 ms p95 |
+| Kernel replay | 349.668386 committed commands/s; five commands per replay |
+| Six-area play replay | 1 206.731111 committed commands/s; 63.476209 ms median; 65.063893 ms p95; 77 commands per replay |
+| Compiled accepted-fixture package | 20 492 bytes; 8 regular files |
+| Staged and scanned public artifact | 1 387 887 bytes; 24 regular files |
+| Authoritative wasm runtime | 422 432 bytes; SHA-256 `70addbe7662caab4af2d0147c09dc8e839dd282c617a99cd325ced026d0d3a0f` |
+| Cold edit-to-visible frame | 27 771 ms; navigation-to-first-frame component 2 056 ms |
+
+The edit-to-visible interval starts before content compilation/capture, when no
+derived content, wasm runtime, or public artifact exists. It ends when the page
+sets `data-ready`, after `renderer.present()` has synchronously submitted the
+first WebGL render. It therefore excludes the smoke lane's subsequent route
+play and native replay. Proof-only viewer tests run before the interval and are
+also excluded.
+
+The raw Gate K operation samples hash to
+`ea6acad0b1fe99200c028b600e79c2b5ede9223fbd0dd515633ff2304041b500`;
+the raw play-replay samples hash to
+`6b3d577af6e0771355a94b40adbf3811590fc245d11c6743e7151f76dcdb0cd8`.
+The build, kernel-operation, kernel-throughput, and play-replay summary tables
+hash respectively to
+`e89b32e0bd3539b2035c4a27a590b0038c01c745fc2da6a75d5b7fbc8472290b`,
+`a3227157f08a598563e00c72bcffd8a29f745b457689c80fdf56887cab4cae7e`,
+`1d369235bb03463626ed16e4ec738866e6b807290606163cd01bd80658e55f66`,
+and `ad4d6cd5d257fd5193b41cd54b0cdaa4c114830f7c7f425d35806a1350c5c3aa`.
+The staged-build and browser receipts hash to
+`7ad93fc176ef6a7ebf6e8743051d7b069b947cdcd3602879d8257e379e959647`
+and `2962b70d487b6459ac1ff28f86457a519d40713bd030934dc07a7a4686d6be4a`.
+
+## Environment and limits
+
+The runner was GitHub `ubuntu24` x86_64 image `20260823.283.1`, Linux
+`6.17.0-1022-azure`, Rust and Cargo `1.98.0`, Node `22.23.2`, and Chrome
+`151.0.7922.173`. These are observations of that runner, not portable targets
+or guarantees.
+
+This record is author and CI evidence. CI is not the non-author reviewer
+required by `AGENTS.md`; the frozen R1 candidate still needs its final
+different-author rerun before an adoption disposition can call it green. This
+follow-up documentation commit records the successful implementation-head
+measurement and does not rewrite its samples as measurements of a later tree.

--- a/docs/evaluation/r1-adoption-evidence.sh
+++ b/docs/evaluation/r1-adoption-evidence.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+
+# Measures every RUNTIME.md section 7 row and proves the section 1 offline
+# build/test/public-artifact claim. The CI caller runs this inside a network
+# namespace with only loopback enabled; this script refuses a normal networked
+# environment so its PASS line cannot be produced by the ordinary lanes.
+
+set -euo pipefail
+export LC_ALL=C
+export CARGO_NET_OFFLINE=true
+
+fail() {
+  printf 'R1 adoption evidence: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || fail 'usage: r1-adoption-evidence.sh <evidence-dir>'
+evidence_arg=${1#./}
+[[ $evidence_arg == target/* ]] || fail 'evidence destination must be below target/'
+
+for command in git cargo rustc node awk sort date find stat sha256sum ip /usr/bin/time; do
+  command -v "$command" >/dev/null 2>&1 || fail "required executable not found: $command"
+done
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root=$(cd "$script_dir/../.." && pwd -P)
+[[ $(git -C "$repo_root" rev-parse --show-toplevel) == "$repo_root" ]] ||
+  fail 'script must run from its repository worktree'
+cd "$repo_root"
+
+head=$(git rev-parse --verify HEAD)
+[[ $head =~ ^[0-9a-f]{40}$ ]] || fail 'HEAD is not a full commit id'
+[[ -z $(git status --porcelain=v1 --untracked-files=all) ]] ||
+  fail 'tracked worktree is not clean before the evidence run'
+[[ ${NOMOS_NETWORK_ISOLATED:-} == 1 ]] ||
+  fail 'NOMOS_NETWORK_ISOLATED=1 is required from the network-namespace caller'
+[[ -z $(ip -4 route show default) && -z $(ip -6 route show default) ]] ||
+  fail 'the evidence process still has a default network route'
+ip link show lo | grep -q 'UP' || fail 'loopback is not available for the browser proof'
+
+evidence_dir=$repo_root/$evidence_arg
+[[ ! -e $evidence_dir ]] || fail "evidence destination already exists: $evidence_dir"
+for path in \
+  target/gate-k-budget-build \
+  target/executable-gaol \
+  target/wasm32-unknown-unknown \
+  apps/nomos-viewer/dist; do
+  [[ ! -e $path ]] || fail "clean-checkout output already exists: $path"
+done
+mkdir -p "$evidence_dir/play-replay" "$evidence_dir/workspace-test"
+
+commands=$evidence_dir/commands.txt
+printf 'phase\tcommand\n' >"$commands"
+record() {
+  printf '%s\t%s\n' "$1" "$2" >>"$commands"
+}
+
+{
+  printf 'commit=%s\n' "$head"
+  printf 'runner_arch=%s\n' "${RUNNER_ARCH:-unknown}"
+  printf 'runner_image=%s\n' "${ImageOS:-unknown}"
+  printf 'runner_image_version=%s\n' "${ImageVersion:-unknown}"
+  printf 'uname='; uname -a
+  printf 'rustc='; rustc --version
+  printf 'cargo='; cargo --version
+  printf 'node='; node --version
+  printf 'chrome='; "${CHROME_BIN:-google-chrome}" --version
+  printf 'network_namespace=no-default-route; loopback-only\n'
+  printf 'cargo_net_offline=%s\n' "$CARGO_NET_OFFLINE"
+} >"$evidence_dir/environment.txt"
+
+record gate-k-budgets \
+  "CARGO_NET_OFFLINE=true docs/evaluation/gate-k-budgets.sh $evidence_arg/gate-k"
+docs/evaluation/gate-k-budgets.sh "$evidence_arg/gate-k" \
+  >"$evidence_dir/gate-k.stdout" 2>"$evidence_dir/gate-k.stderr"
+
+build_target=$repo_root/target/gate-k-budget-build
+record workspace-test \
+  "CARGO_TARGET_DIR=target/gate-k-budget-build cargo test --workspace --locked --offline"
+CARGO_TARGET_DIR=$build_target cargo test --workspace --locked --offline \
+  >"$evidence_dir/workspace-test/stdout.txt" \
+  2>"$evidence_dir/workspace-test/stderr.txt"
+
+record viewer-tests 'node --test apps/nomos-viewer/test/*.test.mjs'
+node --test apps/nomos-viewer/test/*.test.mjs \
+  >"$evidence_dir/viewer-tests.stdout" \
+  2>"$evidence_dir/viewer-tests.stderr"
+
+# This is the start of the cold content-to-pixel interval. The committed source
+# has conceptually just changed; no derived content, runtime, or public artifact
+# exists. `smoke.mjs` closes the interval immediately after the first WebGL
+# render, before it drives the rest of the route. Proof-only test time above is
+# deliberately outside this product-workflow measurement.
+pipeline_start_ms=$(date +%s%3N)
+record content-capture \
+  'CARGO_NET_OFFLINE=true experiments/executable-gaol/gaol capture'
+experiments/executable-gaol/gaol capture \
+  >"$evidence_dir/content-capture.stdout" \
+  2>"$evidence_dir/content-capture.stderr"
+
+record wasm-build 'crates/nomos-play/build-wasm.sh --offline'
+crates/nomos-play/build-wasm.sh --offline \
+  >"$evidence_dir/wasm-build.stdout" \
+  2>"$evidence_dir/wasm-build.stderr"
+
+viewer_build=$evidence_dir/viewer-build.json
+record public-artifact \
+  "node apps/nomos-viewer/build.mjs --from target/executable-gaol --wasm target/wasm32-unknown-unknown/wasm/nomos_play.wasm --out apps/nomos-viewer/dist --receipt $evidence_arg/viewer-build.json"
+node apps/nomos-viewer/build.mjs \
+  --from target/executable-gaol \
+  --wasm target/wasm32-unknown-unknown/wasm/nomos_play.wasm \
+  --out apps/nomos-viewer/dist \
+  --receipt "$viewer_build" \
+  >"$evidence_dir/viewer-build.stdout" \
+  2>"$evidence_dir/viewer-build.stderr"
+
+play_binary=$build_target/release/nomos-play
+[[ -x $play_binary ]] || fail 'release nomos-play was not produced by the workspace build'
+smoke_dir=$evidence_dir/smoke
+record browser-smoke \
+  "NOMOS_PLAY_BIN=target/gate-k-budget-build/release/nomos-play node apps/nomos-viewer/smoke/smoke.mjs --dist apps/nomos-viewer/dist --out $evidence_arg/smoke --require-chrome --pipeline-start-ms $pipeline_start_ms"
+NOMOS_PLAY_BIN=$play_binary node apps/nomos-viewer/smoke/smoke.mjs \
+  --dist apps/nomos-viewer/dist \
+  --out "$smoke_dir" \
+  --require-chrome \
+  --pipeline-start-ms "$pipeline_start_ms" \
+  >"$evidence_dir/browser-smoke.stdout" \
+  2>"$evidence_dir/browser-smoke.stderr"
+
+session=$smoke_dir/session.json
+areas=$repo_root/target/executable-gaol/areas
+play_warmups=3
+play_samples=20
+play_raw=$evidence_dir/play-replay/raw-samples.tsv
+printf 'phase\tordinal\tduration_ns\n' >"$play_raw"
+measure_play_replay() {
+  local phase=$1
+  local count=$2
+  local ordinal start_ns end_ns output
+  for ordinal in $(seq 1 "$count"); do
+    output=$evidence_dir/play-replay/$(printf '%s-%02d' "$phase" "$ordinal").stdout
+    record play-replay \
+      "target/gate-k-budget-build/release/nomos-play replay target/executable-gaol/areas --session $evidence_arg/smoke/session.json"
+    start_ns=$(date +%s%N)
+    "$play_binary" replay "$areas" --session "$session" >"$output"
+    end_ns=$(date +%s%N)
+    grep -q '^NOMOS_PLAY_REPLAY PASS ' "$output" ||
+      fail "play replay sample $phase/$ordinal did not pass"
+    printf '%s\t%s\t%s\n' "$phase" "$ordinal" "$((end_ns - start_ns))" >>"$play_raw"
+  done
+}
+measure_play_replay warmup "$play_warmups"
+measure_play_replay sample "$play_samples"
+
+mapfile -t play_durations < <(
+  awk -F '\t' '$1 == "sample" { print $3 }' "$play_raw" | sort -n
+)
+[[ ${#play_durations[@]} -eq $play_samples ]] || fail 'play replay sample count is not twenty'
+play_minimum=${play_durations[0]}
+play_maximum=${play_durations[$((play_samples - 1))]}
+play_median=$((
+  (play_durations[play_samples / 2 - 1] + play_durations[play_samples / 2]) / 2
+))
+play_p95_index=$(( (95 * play_samples + 99) / 100 - 1 ))
+play_p95=${play_durations[$play_p95_index]}
+play_total_ns=$(awk -F '\t' '$1 == "sample" { total += $3 } END { printf "%.0f", total }' "$play_raw")
+play_commands=$(node -e \
+  'const fs=require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1])).log.length)' \
+  "$session")
+[[ $play_commands =~ ^[0-9]+$ && $play_commands -gt 0 ]] ||
+  fail 'the recorded play session has no command count'
+play_commands_per_second=$(awk \
+  -v samples="$play_samples" -v commands="$play_commands" -v ns="$play_total_ns" \
+  'BEGIN { printf "%.6f", samples * commands * 1000000000 / ns }')
+{
+  printf 'metric\tvalue\tunit\n'
+  printf 'minimum\t%s\tns\n' "$play_minimum"
+  printf 'median\t%s\tns\n' "$play_median"
+  printf 'p95\t%s\tns\n' "$play_p95"
+  printf 'maximum\t%s\tns\n' "$play_maximum"
+  printf 'commands_per_replay\t%s\tcommands\n' "$play_commands"
+  printf 'committed_commands_per_second\t%s\tcommands/s\n' "$play_commands_per_second"
+  printf 'aggregate_measured_time\t%s\tns\n' "$play_total_ns"
+} >"$evidence_dir/play-replay/summary.tsv"
+
+package_dir=$evidence_dir/gate-k/inputs/gaol.world
+package_files=$(find "$package_dir" -type f | wc -l)
+package_bytes=$(find "$package_dir" -type f -printf '%s\n' |
+  awk '{ total += $1 } END { print total + 0 }')
+public_files=$(node -e \
+  'const fs=require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1])).files.length)' \
+  "$viewer_build")
+public_bytes=$(node -e \
+  'const fs=require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1])).total_bytes)' \
+  "$viewer_build")
+wasm_bytes=$(stat -c%s target/wasm32-unknown-unknown/wasm/nomos_play.wasm)
+wasm_sha=$(sha256sum target/wasm32-unknown-unknown/wasm/nomos_play.wasm | cut -d' ' -f1)
+edit_to_visible_ms=$(node -e \
+  'const fs=require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1])).timing.edit_to_visible_frame_ms)' \
+  "$smoke_dir/receipt.json")
+navigation_to_visible_ms=$(node -e \
+  'const fs=require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1])).timing.navigation_to_first_frame_ms)' \
+  "$smoke_dir/receipt.json")
+
+build_ns=$(awk -F '\t' '$1 == "clean_release_workspace_build" { print $2 }' \
+  "$evidence_dir/gate-k/build/summary.tsv")
+validation_median_ns=$(awk -F '\t' '$1 == "validate" { print $3 }' \
+  "$evidence_dir/gate-k/summary.tsv")
+validation_p95_ns=$(awk -F '\t' '$1 == "validate" { print $4 }' \
+  "$evidence_dir/gate-k/summary.tsv")
+kernel_replay_commands_per_second=$(awk -F '\t' \
+  '$1 == "committed_commands_per_second" { print $2 }' \
+  "$evidence_dir/gate-k/throughput.tsv")
+
+for integer in \
+  "$build_ns" "$validation_median_ns" "$validation_p95_ns" \
+  "$package_files" "$package_bytes" "$public_files" "$public_bytes" \
+  "$wasm_bytes" "$edit_to_visible_ms" "$navigation_to_visible_ms"; do
+  [[ $integer =~ ^[0-9]+$ ]] || fail "a required integer measurement is invalid: $integer"
+done
+
+[[ -z $(git status --porcelain=v1 --untracked-files=all) ]] ||
+  fail 'tracked worktree changed during the evidence run'
+[[ $(git rev-parse --verify HEAD) == "$head" ]] ||
+  fail 'HEAD changed during the evidence run'
+
+receipt=$evidence_dir/receipt.txt
+{
+  printf 'R1_ADOPTION_EVIDENCE PASS\n'
+  printf 'commit %s\n' "$head"
+  printf 'runner_arch %s\n' "${RUNNER_ARCH:-unknown}"
+  printf 'runner_image %s\n' "${ImageOS:-unknown}"
+  printf 'runner_image_version %s\n' "${ImageVersion:-unknown}"
+  printf 'network_namespace no_default_route_loopback_only\n'
+  printf 'cargo_net_offline true\n'
+  printf 'clean_checkout_outputs yes\n'
+  printf 'workspace_build_offline yes\n'
+  printf 'workspace_test_offline yes\n'
+  printf 'public_artifact_offline yes\n'
+  printf 'workspace_build_time_ns %s\n' "$build_ns"
+  printf 'validation_median_ns %s\n' "$validation_median_ns"
+  printf 'validation_p95_ns %s\n' "$validation_p95_ns"
+  printf 'kernel_replay_commands_per_second %s\n' "$kernel_replay_commands_per_second"
+  printf 'play_replay_commands_per_second %s\n' "$play_commands_per_second"
+  printf 'play_replay_median_ns %s\n' "$play_median"
+  printf 'play_replay_p95_ns %s\n' "$play_p95"
+  printf 'package_regular_files %s\n' "$package_files"
+  printf 'package_regular_file_bytes %s\n' "$package_bytes"
+  printf 'public_artifact_regular_files %s\n' "$public_files"
+  printf 'public_artifact_regular_file_bytes %s\n' "$public_bytes"
+  printf 'play_runtime_bytes %s\n' "$wasm_bytes"
+  printf 'play_runtime_sha256 %s\n' "$wasm_sha"
+  printf 'edit_to_visible_frame_ms %s\n' "$edit_to_visible_ms"
+  printf 'navigation_to_first_frame_ms %s\n' "$navigation_to_visible_ms"
+  printf 'gate_raw_samples_sha256 %s\n' \
+    "$(sha256sum "$evidence_dir/gate-k/raw-samples.tsv" | cut -d' ' -f1)"
+  printf 'play_raw_samples_sha256 %s\n' \
+    "$(sha256sum "$play_raw" | cut -d' ' -f1)"
+  printf 'viewer_build_receipt_sha256 %s\n' \
+    "$(sha256sum "$viewer_build" | cut -d' ' -f1)"
+  printf 'smoke_receipt_sha256 %s\n' \
+    "$(sha256sum "$smoke_dir/receipt.json" | cut -d' ' -f1)"
+  printf 'commands_sha256 %s\n' "$(sha256sum "$commands" | cut -d' ' -f1)"
+  printf 'initial_tree_clean yes\n'
+  printf 'final_tree_clean yes\n'
+} >"$receipt"
+
+printf 'R1 adoption evidence: PASS\n'


### PR DESCRIPTION
Closes #172.

## What changed

- add one R1 adoption evidence command that binds every `RUNTIME.md` §7 measurement to the same commit and runner
- run the clean workspace build/test and the content/runtime/public build with Cargo forced offline inside a network namespace that has no default route
- record raw samples for validation, kernel replay, and six-area play replay, plus regular-file package/artifact sizes
- mark the browser's first completed WebGL render and measure the cold content pipeline to that point instead of using the full-route duration
- preserve a compact hash-bound evidence record and replace every unmeasured or stale four-area §7 value

## Evidence

The committed measurement implementation at `bdd2229` passed workflow run `32905965046` on GitHub `ubuntu24` x86_64 image `20260823.283.1`. Artifact `9584836533` has archive sha256 `8e17731c3db4fd2d9859430e8133fc3a3a11c7dfc0e7e63ef864d06837160c72`.

The receipt records offline build/test/public artifact success and all eight §7 observations; the exact values and source-artifact hashes are in `docs/evaluation/r1-adoption-evidence.md`. The latest head `02e8b04`, which adds only that record and the §7 transcription, is green in all CI lanes, including the new isolated evidence job.

Author proof also passed from a fresh `CARGO_TARGET_DIR`:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --workspace --locked
cargo xtask boundary
```

Viewer Node tests passed 97 with the five runtime-dependent tests correctly skipped before an artifact existed.

## Unresolved limit

The required non-author rerun is pending. This PR remains draft and is not called green until that receipt exists.
