### PR TITLE
Authorize RUNTIME revision 3 comparison count

### DIFF
--- a/RUNTIME.md
+++ b/RUNTIME.md
@@ -1,12 +1,13 @@
 ---
 title: The R1 runtime contract
-status: Owner-authorized; revision 2 in force
+status: Owner-authorized; revision 3 in force
 epoch: R1
-contract_revision: 2
+contract_revision: 3
 authority: docs/decisions/0017-post-gate-k-runtime-epoch.md
 revision_2_authority: docs/decisions/0018-runtime-revision-2.md
+revision_3_authority: docs/decisions/0020-runtime-revision-3.md
 kernel_contract: KERNEL.md revision 7, frozen
-date: 2026-08-25
+date: 2026-08-26
 issue: 128
 ---
 
@@ -272,9 +273,11 @@ Accepted when:
   `crates/nomos-sim/src/effective_facts.rs`. It is not added to
   `docs/evaluation/SCHEMA_OWNERSHIP.md`, which is frozen Gate K evidence;
 - `experiments/executable-gaol/compare-effective-facts.sh` reports
-  `20 scenarios compared, 0 differences` against the committed
-  `rendering-plan.example.json` blocks, with the `"cost": null` spelling on a
-  blocked subject the only normalization;
+  `30 scenarios compared, 0 differences` against the committed
+  `rendering-plan.example.json` blocks — the original twenty scenarios plus
+  the ten from the two cold-authored areas in the quarantined experiment —
+  with the `"cost": null` spelling on a blocked subject the only
+  normalization;
 - byte identity holds across ten runs for the fixed triple of source bytes,
   source path, and runtime state — not for source bytes alone, because the
   source path appears in claim source spans and is therefore inside the hash

--- a/docs/decisions/0020-runtime-revision-3.md
+++ b/docs/decisions/0020-runtime-revision-3.md
@@ -1,0 +1,93 @@
+---
+title: RUNTIME.md revision 3 — align the R1-1 comparison count
+status: Draft; no owner disposition; does not take effect
+number: 0020
+date: 2026-08-26
+owner: Peter Permenter
+issue: 176
+supersedes_runtime_revision: 2
+proposes_runtime_revision: 3
+references:
+  - docs/decisions/0017-post-gate-k-runtime-epoch.md
+  - docs/decisions/0018-runtime-revision-2.md
+---
+
+# RUNTIME.md revision 3 — align the R1-1 comparison count
+
+## Draft boundary
+
+This record is prepared under issue #176 for owner review. It is not yet an
+owner decision, does not amend `RUNTIME.md`, and does not establish revision 3.
+Revision 2 remains in force until the owner explicitly authorizes the
+replacement below and the authorized record and contract change land together.
+
+## Prior wording
+
+`RUNTIME.md` revision 2, section 5, R1-1's `Accepted when` list says:
+
+```text
+- `experiments/executable-gaol/compare-effective-facts.sh` reports
+  `20 scenarios compared, 0 differences` against the committed
+  `rendering-plan.example.json` blocks, with the `"cost": null` spelling on a
+  blocked subject the only normalization;
+```
+
+The same revision's section 3 accepted-surface summary instead says that the
+harness reports `30 scenarios compared, 0 differences` — the original twenty
+plus the ten scenarios from the two cold-authored areas. The executable proof
+on the frozen candidate reports thirty.
+
+## Proposed replacement wording
+
+Replace only that R1-1 bullet with:
+
+```text
+- `experiments/executable-gaol/compare-effective-facts.sh` reports
+  `30 scenarios compared, 0 differences` against the committed
+  `rendering-plan.example.json` blocks — the original twenty scenarios plus
+  the ten from the two accepted cold-authored areas — with the `"cost": null`
+  spelling on a blocked subject the only normalization;
+```
+
+No other acceptance wording changes.
+
+## Reason
+
+Revision 2 contradicts itself about one exact observed count. The original
+R1-1 evidence covered four areas and twenty scenarios. The accepted
+cold-authoring work added two areas and ten scenarios, and PR #169 repaired the
+comparison harness for the current rendering-plan shape and proved all thirty
+with zero differences. Its `RUNTIME.md` update correctly recorded that expanded
+result in section 3 but left the normative section 5 bullet at twenty.
+
+Thirty is stronger coverage, but that does not authorize silently treating an
+exact criterion saying twenty as if it said thirty. This repair makes the
+criterion name the evidence the accepted tree actually produces. It does not
+weaken a semantic requirement or excuse a failed implementation.
+
+## Effect on existing evidence
+
+No implementation, schema identity, source, package, runtime state, rendering
+plan, viewer artifact, hash, or recorded output changes. In particular:
+
+- `nomos.effective_facts@2` and decision 0018's schema-spelling repair are
+  unchanged;
+- the original twenty-scenario R1-1 receipt remains historical evidence for
+  the four-area subset and is not relabelled;
+- PR #169's exact-head non-author receipt remains the evidence for the expanded
+  thirty-scenario comparison; and
+- the frozen combined candidate's implementation tree requires no change.
+
+After the authorized text lands, decision 0019 must bind `RUNTIME.md` revision
+3 and its new SHA-256 and must obtain a fresh complete proof on the resulting
+candidate before recording an R1 pass.
+
+## Owner disposition
+
+**Pending.** Recommended authorization:
+
+> Authorize the quoted replacement and establish `RUNTIME.md` revision 3. The
+> repair aligns the stale R1-1 count with the already accepted thirty-scenario
+> proof, changes no implementation or evidence, weakens no semantic
+> requirement, and authorizes no game adoption, Gate K retry, or later runtime
+> epoch.

--- a/docs/decisions/0020-runtime-revision-3.md
+++ b/docs/decisions/0020-runtime-revision-3.md
@@ -45,8 +45,9 @@ Replace only that R1-1 bullet with:
 - `experiments/executable-gaol/compare-effective-facts.sh` reports
   `30 scenarios compared, 0 differences` against the committed
   `rendering-plan.example.json` blocks — the original twenty scenarios plus
-  the ten from the two accepted cold-authored areas — with the `"cost": null`
-  spelling on a blocked subject the only normalization;
+  the ten from the two cold-authored areas in the quarantined experiment —
+  with the `"cost": null` spelling on a blocked subject the only
+  normalization;
 ```
 
 No other acceptance wording changes.
@@ -68,7 +69,8 @@ weaken a semantic requirement or excuse a failed implementation.
 ## Effect on existing evidence
 
 No implementation, schema identity, source, package, runtime state, rendering
-plan, viewer artifact, hash, or recorded output changes. In particular:
+plan, viewer artifact, existing evidence hash, or recorded output changes. In
+particular:
 
 - `nomos.effective_facts@2` and decision 0018's schema-spelling repair are
   unchanged;
@@ -87,7 +89,7 @@ candidate before recording an R1 pass.
 **Pending.** Recommended authorization:
 
 > Authorize the quoted replacement and establish `RUNTIME.md` revision 3. The
-> repair aligns the stale R1-1 count with the already accepted thirty-scenario
-> proof, changes no implementation or evidence, weakens no semantic
+> repair aligns the stale R1-1 count with the already recorded thirty-scenario
+> comparison proof, changes no implementation or evidence, weakens no semantic
 > requirement, and authorizes no game adoption, Gate K retry, or later runtime
 > epoch.

--- a/docs/decisions/0020-runtime-revision-3.md
+++ b/docs/decisions/0020-runtime-revision-3.md
@@ -1,12 +1,12 @@
 ---
 title: RUNTIME.md revision 3 — align the R1-1 comparison count
-status: Draft; no owner disposition; does not take effect
+status: Owner-authorized; RUNTIME.md revision 3 in force
 number: 0020
 date: 2026-08-26
 owner: Peter Permenter
 issue: 176
 supersedes_runtime_revision: 2
-proposes_runtime_revision: 3
+establishes_runtime_revision: 3
 references:
   - docs/decisions/0017-post-gate-k-runtime-epoch.md
   - docs/decisions/0018-runtime-revision-2.md
@@ -14,12 +14,11 @@ references:
 
 # RUNTIME.md revision 3 — align the R1-1 comparison count
 
-## Draft boundary
+## Decision authority
 
-This record is prepared under issue #176 for owner review. It is not yet an
-owner decision, does not amend `RUNTIME.md`, and does not establish revision 3.
-Revision 2 remains in force until the owner explicitly authorizes the
-replacement below and the authorized record and contract change land together.
+Peter Permenter authorized this record on 2026-08-26. It replaces exactly the
+R1-1 comparison-count wording quoted below and establishes `RUNTIME.md`
+revision 3. No other acceptance wording changes.
 
 ## Prior wording
 
@@ -37,7 +36,7 @@ harness reports `30 scenarios compared, 0 differences` — the original twenty
 plus the ten scenarios from the two cold-authored areas. The executable proof
 on the frozen candidate reports thirty.
 
-## Proposed replacement wording
+## Replacement wording
 
 Replace only that R1-1 bullet with:
 
@@ -55,11 +54,11 @@ No other acceptance wording changes.
 ## Reason
 
 Revision 2 contradicts itself about one exact observed count. The original
-R1-1 evidence covered four areas and twenty scenarios. The accepted
+R1-1 evidence covered four areas and twenty scenarios. The quarantined
 cold-authoring work added two areas and ten scenarios, and PR #169 repaired the
 comparison harness for the current rendering-plan shape and proved all thirty
-with zero differences. Its `RUNTIME.md` update correctly recorded that expanded
-result in section 3 but left the normative section 5 bullet at twenty.
+with zero differences. Its `RUNTIME.md` update correctly recorded that
+expanded result in section 3 but left the normative section 5 bullet at twenty.
 
 Thirty is stronger coverage, but that does not authorize silently treating an
 exact criterion saying twenty as if it said thirty. This repair makes the
@@ -80,16 +79,14 @@ particular:
   thirty-scenario comparison; and
 - the frozen combined candidate's implementation tree requires no change.
 
-After the authorized text lands, decision 0019 must bind `RUNTIME.md` revision
-3 and its new SHA-256 and must obtain a fresh complete proof on the resulting
-candidate before recording an R1 pass.
+Decision 0019 must bind `RUNTIME.md` revision 3 and its new SHA-256 and must
+obtain a fresh complete proof on the resulting candidate before recording an
+R1 pass.
 
 ## Owner disposition
 
-**Pending.** Recommended authorization:
-
-> Authorize the quoted replacement and establish `RUNTIME.md` revision 3. The
-> repair aligns the stale R1-1 count with the already recorded thirty-scenario
-> comparison proof, changes no implementation or evidence, weakens no semantic
-> requirement, and authorizes no game adoption, Gate K retry, or later runtime
-> epoch.
+**Authorize.** Peter Permenter authorizes the quoted replacement and establishes
+`RUNTIME.md` revision 3. The repair aligns the stale R1-1 count with the already
+recorded thirty-scenario comparison proof, changes no implementation or
+evidence, weakens no semantic requirement, and authorizes no game adoption,
+Gate K retry, or later runtime epoch.


### PR DESCRIPTION
Closes #176.

## Authorized repair

Peter Permenter authorized decision 0020 on 2026-08-26.

- replace the stale normative R1-1 result `20 scenarios compared, 0 differences` with the recorded `30 scenarios compared, 0 differences`
- identify the ten added scenarios as evidence from two cold-authored areas in the quarantined experiment
- establish `RUNTIME.md` revision 3 and bind decision 0020 as its authority
- preserve every implementation, artifact, hash, historical 20-scenario receipt, and PR #169's exact 30-scenario receipt

No other acceptance wording changes. This authorizes no game adoption, Gate K retry, or later runtime epoch.

## Author proof

Passed from fresh targets:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo xtask boundary`
- `docs/evaluation/r1-schema-ownership.sh`
- `experiments/executable-gaol/compare-effective-facts.sh` — 30 scenarios, 0 differences
- `experiments/executable-gaol/gaol verify` — six areas, 14 collection checks, exact plans/contact sheets

The generated targets were removed and the branch is clean. A fresh non-author exact-head receipt remains required before merge.
