### PR TITLE
Pin Gate K evaluation tooling to byte collation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -70,6 +70,7 @@ jobs:
         # debug twice, release twice — must produce byte-identical lines.
         run: |
           set -euo pipefail
+          export LC_ALL=C
           hashes() {
             cargo test --locked -p nomos-core --test determinism "$@" \
               -- --nocapture --test-threads=1 | grep '^HASH ' | sort

--- a/docs/evaluation/gate-k-determinism.sh
+++ b/docs/evaluation/gate-k-determinism.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Canonical artifact ordering and comparisons are byte-defined.
+export LC_ALL=C
+
 fail() {
   printf 'gate-k determinism: FAIL: %s\n' "$*" >&2
   exit 1

--- a/docs/evaluation/gate-k-eval-finalize.sh
+++ b/docs/evaluation/gate-k-eval-finalize.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Canonical path ordering, tree digests, and comparisons are byte-defined.
+export LC_ALL=C
+
 fail() {
   printf 'gate-k eval finalizer: FAIL: %s\n' "$*" >&2
   exit 1

--- a/docs/evaluation/gate-k-eval-packet.sh
+++ b/docs/evaluation/gate-k-eval-packet.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Canonical path ordering, tree digests, and comparisons are byte-defined.
+export LC_ALL=C
+
 fail() {
   printf 'gate-k eval packet: FAIL: %s\n' "$*" >&2
   exit 1

--- a/docs/evaluation/gate-k-eval-record-task.sh
+++ b/docs/evaluation/gate-k-eval-record-task.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Canonical artifact ordering and tree digests are byte-defined.
+export LC_ALL=C
+
 fail() {
   printf 'gate-k eval task recorder: FAIL: %s\n' "$*" >&2
   exit 1

--- a/docs/evaluation/gate-k-eval-seed-rehearsal.sh
+++ b/docs/evaluation/gate-k-eval-seed-rehearsal.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Seed-tree traversal is deterministic byte ordering.
+export LC_ALL=C
+
 fail() {
   printf 'gate-k debug rehearsal seed: FAIL: %s\n' "$*" >&2
   exit 1

--- a/docs/evaluation/gate-k-eval-verify-packet.sh
+++ b/docs/evaluation/gate-k-eval-verify-packet.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Canonical path ordering, tree digests, and comparisons are byte-defined.
+export LC_ALL=C
+
 fail() {
   printf 'gate-k eval packet verification: FAIL: %s\n' "$*" >&2
   exit 1

--- a/docs/evaluation/gate-k-schema-ownership.sh
+++ b/docs/evaluation/gate-k-schema-ownership.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Identity ordering and comparisons are defined over bytes, not host collation.
+export LC_ALL=C
+
 fail() {
   printf 'gate-k schema ownership: FAIL: %s\n' "$*" >&2
   exit 1

--- a/docs/evaluation/pi-cold-agent-task.sh
+++ b/docs/evaluation/pi-cold-agent-task.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Packet path comparison is defined over bytes, not host collation.
+export LC_ALL=C
+
 fail() {
   printf 'pi cold-agent task: FAIL: %s\n' "$*" >&2
   exit 1

--- a/docs/evaluation/test-gate-k-eval-tooling.sh
+++ b/docs/evaluation/test-gate-k-eval-tooling.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# The suite exercises byte-defined packet and receipt ordering on every host.
+export LC_ALL=C
+
 repo_root=$(git rev-parse --show-toplevel)
 "$repo_root/docs/evaluation/test-gate-k-attempt-ledger.sh"
 "$repo_root/docs/evaluation/test-gate-k-eval-strictness.sh"


### PR DESCRIPTION
Closes #134.
Closes #141.

## Problem

Gate K's historical schema check and evaluation tree digests relied on the caller's collation. Under `en_US.utf8`, punctuation-sensitive schema identities reverse order and the preserved author artifact tree hashes to `15080a707e393485813104b8c556e6c43735155767e3ae3162a15f8e88dd0b68` rather than its frozen C-locale receipt `50d84dc0a411362b25a815bc659ee305c55179a176c763811e81f1538669ee26`.

## Change

Export `LC_ALL=C` at every shell entrypoint where external path/identity ordering contributes to Gate K canonical comparison, hashes, packets, task receipts, or finalization:

- historical schema ownership;
- per-target determinism and the verify workflow's canonical hash-domain lane;
- packet build and verification;
- task recording and task launch postflight;
- debug-seed traversal;
- finalization; and
- the complete offline tooling harness.

No schema identity, expected output, digest algorithm, frozen receipt, or recorded evidence changes.

## Sibling audit

- Already pinned: `agy-formal-boundary-preflight.sh`, `gate-k-budgets.sh`, `r1-adoption-evidence.sh`, and `r1-schema-ownership.sh`.
- Fixed: every external `sort` that feeds a Gate K canonical list/digest in the entrypoints above.
- `test-gate-k-eval-tooling-lib.sh` is sourced only by the now-pinned complete harness and inherits its locale.
- `gate-k-eval-derive-commands.sh` uses jq's codepoint `sort`, not locale-sensitive coreutils `sort`.
- `pi-cold-agent-preflight.sh` uses GNU tar's explicit `--sort=name` reproducible archive order.
- `gate-k-eval-reconstruct-run-records.sh` uses `find` only for type/symlink predicates, not ordered output.
- `gate-k-compare-targets.sh` and the two re-finalization wrappers consume only `diff`/`cmp` equality exit status; no ordered output enters evidence.

## Author proof

At `5d0d14b0e06ca44e6461574f7e8f7e6a9e2f53fd`:

- Original failures reproduced before the change:
  - UTF-8 historical schema inventory mismatch;
  - UTF-8 artifact tree `15080a…` versus frozen `50d84d…`.
- Patched historical schema receipt at evidence head `b63ecb9` passed byte-identically under `C` and `en_US.utf8`: the PASS line plus the same five receipt lines.
- `LC_ALL=C docs/evaluation/test-gate-k-eval-tooling.sh` — pass.
- `LC_ALL=en_US.utf8 docs/evaluation/test-gate-k-eval-tooling.sh` — pass.
- Shell syntax checks for every changed script — pass.
- `cargo fmt --all -- --check` — pass.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — pass.
- `cargo test --workspace --locked` — pass.
- `cargo xtask boundary` — pass.
- `git diff --check` — pass.
- No file under `docs/evaluation/runs/` changed.

A non-author exact-head rerun is still required before this draft is called green.
