### PR TITLE
Make viewer smoke shutdown bounded and observable

### DIFF
--- a/apps/nomos-viewer/smoke/cdp.mjs
+++ b/apps/nomos-viewer/smoke/cdp.mjs
@@ -38,7 +38,10 @@ export async function connect(url, { timeout = 20_000 } = {}) {
 
   socket.addEventListener("close", () => {
     closed = new CdpError("the DevTools connection closed");
-    for (const { reject } of pending.values()) reject(closed);
+    for (const { reject, timer } of pending.values()) {
+      clearTimeout(timer);
+      reject(closed);
+    }
     pending.clear();
   });
 
@@ -48,6 +51,7 @@ export async function connect(url, { timeout = 20_000 } = {}) {
       const waiter = pending.get(message.id);
       if (!waiter) return;
       pending.delete(message.id);
+      clearTimeout(waiter.timer);
       if (message.error) waiter.reject(new CdpError(`${waiter.method}: ${message.error.message}`));
       else waiter.resolve(message.result);
       return;
@@ -60,13 +64,19 @@ export async function connect(url, { timeout = 20_000 } = {}) {
     if (closed) return Promise.reject(closed);
     const id = nextId++;
     return new Promise((resolve, reject) => {
-      pending.set(id, { resolve, reject, method });
-      socket.send(JSON.stringify({ id, method, params }));
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         if (!pending.has(id)) return;
         pending.delete(id);
         reject(new CdpError(`${method} did not answer within ${timeout}ms`));
       }, timeout);
+      pending.set(id, { resolve, reject, method, timer });
+      try {
+        socket.send(JSON.stringify({ id, method, params }));
+      } catch (error) {
+        clearTimeout(timer);
+        pending.delete(id);
+        reject(error);
+      }
     });
   };
 
@@ -112,21 +122,25 @@ export async function connect(url, { timeout = 20_000 } = {}) {
     }
   };
 
-  // Issue #160: `close()` starts a handshake, and the socket stays an open
-  // handle until it finishes. The lane waits for it, briefly, so a browser that
-  // has already been killed cannot hold the process open.
+  // `close()` starts a handshake, and the socket stays an open handle until it
+  // finishes. Make a missing close event a recorded shutdown failure; the
+  // caller will still kill Chrome and run the remaining cleanup steps.
   const close = () =>
-    new Promise((done) => {
+    new Promise((resolve, reject) => {
       if (socket.readyState === WebSocket.CLOSED) {
-        done();
+        resolve({ ready_state: "closed" });
         return;
       }
-      const timer = setTimeout(done, 1_000);
-      socket.addEventListener("close", () => {
+      const onClose = () => {
         clearTimeout(timer);
-        done();
-      });
-      socket.close();
+        resolve({ ready_state: "closed" });
+      };
+      const timer = setTimeout(() => {
+        socket.removeEventListener("close", onClose);
+        reject(new CdpError("the DevTools connection did not close within 1000ms"));
+      }, 1_000);
+      socket.addEventListener("close", onClose, { once: true });
+      if (socket.readyState === WebSocket.OPEN) socket.close();
     });
 
   return { send, on, once, evaluate, until, close };

--- a/apps/nomos-viewer/smoke/chrome.mjs
+++ b/apps/nomos-viewer/smoke/chrome.mjs
@@ -167,6 +167,21 @@ const readJson = (url) =>
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const waitForExit = (child, timeout) => {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const exited = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      child.off("exit", exited);
+      resolve(false);
+    }, timeout);
+    child.once("exit", exited);
+  });
+};
+
 /// Launches Chrome and returns the page target's DevTools endpoint.
 export async function launch({ binary, flags, timeout = 20_000 }) {
   const userDataDir = mkdtempSync(join(tmpdir(), "nomos-viewer-chrome-"));
@@ -177,65 +192,101 @@ export async function launch({ binary, flags, timeout = 20_000 }) {
     `--user-data-dir=${userDataDir}`,
     "about:blank",
   ];
-  const child = spawn(binary, argv, { stdio: ["ignore", "pipe", "pipe"] });
+  // A distinct process group makes the browser and all of its renderer/GPU
+  // children one exact cleanup target. Negating this child's known pid is safe
+  // only because `detached` made it the group's leader.
+  const detached = process.platform !== "win32";
+  const child = spawn(binary, argv, { detached, stdio: ["ignore", "pipe", "pipe"] });
   const stderr = [];
   child.stderr.on("data", (chunk) => stderr.push(chunk.toString("utf8")));
 
-  const portFile = join(userDataDir, "DevToolsActivePort");
-  const deadline = Date.now() + timeout;
-  let port = null;
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null) {
-      throw new Error(`chrome exited with ${child.exitCode}: ${stderr.join("").slice(-500)}`);
+  let terminated = false;
+  const kill = async () => {
+    if (terminated) {
+      return {
+        pid: child.pid,
+        process_group: detached ? child.pid : null,
+        exit_code: child.exitCode,
+        signal: child.signalCode,
+        exit_awaited: true,
+      };
     }
+    terminated = true;
+    let signalError = null;
     try {
-      const lines = readFileSync(portFile, "utf8").split("\n");
-      if (lines.length >= 2 && lines[0].trim()) {
-        port = Number(lines[0].trim());
-        break;
-      }
-    } catch {
-      // Not written yet.
-    }
-    await sleep(50);
-  }
-  if (!port) {
-    child.kill("SIGKILL");
-    removeUserDataDir(userDataDir);
-    throw new Error(`chrome wrote no DevToolsActivePort within ${timeout}ms: ${stderr.join("").slice(-500)}`);
-  }
-
-  const version = await readJson(`http://127.0.0.1:${port}/json/version`);
-  let pages = [];
-  const pageDeadline = Date.now() + timeout;
-  while (Date.now() < pageDeadline) {
-    const targets = await readJson(`http://127.0.0.1:${port}/json/list`);
-    pages = targets.filter((one) => one.type === "page" && one.webSocketDebuggerUrl);
-    if (pages.length > 0) break;
-    await sleep(50);
-  }
-  if (pages.length === 0) throw new Error("chrome exposed no page target");
-
-  return {
-    port,
-    argv,
-    version,
-    pageUrl: pages[0].webSocketDebuggerUrl,
-    stderr,
-    // Issue #160: killing the child is not the same as it being gone. Node
-    // keeps the process handle alive until `exit` fires, so the lane awaits it
-    // — with a bound, because a Chrome that will not die must not turn a pass
-    // into a hang either.
-    kill: async () => {
-      if (child.exitCode === null && child.signalCode === null) {
-        const gone = new Promise((done) => child.once("exit", done));
+      if (detached) {
+        process.kill(-child.pid, "SIGKILL");
+      } else if (child.exitCode === null && child.signalCode === null) {
         child.kill("SIGKILL");
-        await Promise.race([gone, sleep(2_000)]);
       }
-      child.stdout?.destroy();
-      child.stderr?.destroy();
-      child.unref();
-      removeUserDataDir(userDataDir);
-    },
+    } catch (error) {
+      if (error.code !== "ESRCH") signalError = error;
+    }
+
+    const exited = await waitForExit(child, 2_000);
+    child.stdout?.destroy();
+    child.stderr?.destroy();
+    child.unref();
+    removeUserDataDir(userDataDir);
+    if (signalError) throw signalError;
+    if (!exited) throw new Error(`Chrome process group ${child.pid} did not exit within 2000ms`);
+    return {
+      pid: child.pid,
+      process_group: detached ? child.pid : null,
+      exit_code: child.exitCode,
+      signal: child.signalCode,
+      exit_awaited: true,
+    };
   };
+
+  try {
+    const portFile = join(userDataDir, "DevToolsActivePort");
+    const deadline = Date.now() + timeout;
+    let port = null;
+    while (Date.now() < deadline) {
+      if (child.exitCode !== null) {
+        throw new Error(`chrome exited with ${child.exitCode}: ${stderr.join("").slice(-500)}`);
+      }
+      try {
+        const lines = readFileSync(portFile, "utf8").split("\n");
+        if (lines.length >= 2 && lines[0].trim()) {
+          port = Number(lines[0].trim());
+          break;
+        }
+      } catch {
+        // Not written yet.
+      }
+      await sleep(50);
+    }
+    if (!port) {
+      throw new Error(`chrome wrote no DevToolsActivePort within ${timeout}ms: ${stderr.join("").slice(-500)}`);
+    }
+
+    const version = await readJson(`http://127.0.0.1:${port}/json/version`);
+    let pages = [];
+    const pageDeadline = Date.now() + timeout;
+    while (Date.now() < pageDeadline) {
+      const targets = await readJson(`http://127.0.0.1:${port}/json/list`);
+      pages = targets.filter((one) => one.type === "page" && one.webSocketDebuggerUrl);
+      if (pages.length > 0) break;
+      await sleep(50);
+    }
+    if (pages.length === 0) throw new Error("chrome exposed no page target");
+
+    return {
+      port,
+      argv,
+      version,
+      pageUrl: pages[0].webSocketDebuggerUrl,
+      stderr,
+      kill,
+    };
+  } catch (error) {
+    try {
+      await kill();
+    } catch (cleanupError) {
+      error.message += `; Chrome cleanup also failed: ${cleanupError.message}`;
+    }
+    throw error;
+  }
 }

--- a/apps/nomos-viewer/smoke/server.mjs
+++ b/apps/nomos-viewer/smoke/server.mjs
@@ -66,8 +66,12 @@ export async function serve(root) {
     port,
     requests,
     close: () =>
-      new Promise((done) => {
-        server.close(done);
+      new Promise((resolveClose, rejectClose) => {
+        const socketCount = sockets.size;
+        server.close((error) => {
+          if (error) rejectClose(error);
+          else resolveClose({ sockets_destroyed: socketCount });
+        });
         for (const socket of sockets) socket.destroy();
         sockets.clear();
       }),

--- a/apps/nomos-viewer/smoke/shutdown.mjs
+++ b/apps/nomos-viewer/smoke/shutdown.mjs
@@ -1,0 +1,68 @@
+// Process-lifecycle helpers for the browser smoke lane.
+//
+// Kept separate from `smoke.mjs` so the backstop can be proved with a child
+// process that deliberately leaves an event-loop handle open.
+
+export const HARD_DEADLINE_DIAGNOSTIC = "NOMOS_VIEWER_SMOKE FAIL HARD_DEADLINE";
+
+const errorText = (error) => error?.message ?? String(error);
+
+/// Records one cleanup action without preventing later actions from running.
+/// The returned error lets the caller fail the lane after every handle has had
+/// its chance to close and the receipt has been written.
+export async function recordShutdownStep(shutdown, name, action) {
+  if (shutdown.started_unix_ms === undefined) shutdown.started_unix_ms = Date.now();
+  const started = performance.now();
+  const step = { name, outcome: "fail", duration_ms: 0 };
+  let failure = null;
+  try {
+    const detail = await action();
+    step.outcome = "pass";
+    if (detail !== undefined) step.detail = detail;
+  } catch (error) {
+    failure = error;
+    step.error = errorText(error);
+  } finally {
+    step.duration_ms = Math.ceil(performance.now() - started);
+    shutdown.steps.push(step);
+  }
+  return failure;
+}
+
+export function finishShutdown(shutdown) {
+  const completed = Date.now();
+  shutdown.completed_unix_ms = completed;
+  shutdown.duration_ms = shutdown.steps.reduce((total, step) => total + step.duration_ms, 0);
+  shutdown.wall_duration_ms = Math.max(
+    0,
+    completed - (shutdown.started_unix_ms ?? completed),
+  );
+  shutdown.outcome = shutdown.steps.every((step) => step.outcome === "pass") ? "pass" : "fail";
+}
+
+/// Arms the lane-wide deadline. It is deliberately unreferenced: the timer is
+/// a failure backstop, never a reason for an otherwise finished lane to remain
+/// alive.
+export function armHardDeadline(milliseconds) {
+  const timer = setTimeout(() => {
+    process.stderr.write(`${HARD_DEADLINE_DIAGNOSTIC} exceeded ${milliseconds}ms\n`);
+    process.exit(1);
+  }, milliseconds);
+  timer.unref();
+  return () => clearTimeout(timer);
+}
+
+const flush = (stream) =>
+  new Promise((done) => {
+    stream.write("", done);
+  });
+
+/// Flushes the result diagnostic, then exits even if a future regression leaves
+/// a server, socket, child process, timer, or other event-loop handle open.
+export async function exitAfterFlush(code) {
+  try {
+    await Promise.all([flush(process.stdout), flush(process.stderr)]);
+  } finally {
+    process.exit(code);
+  }
+}

--- a/apps/nomos-viewer/smoke/smoke.mjs
+++ b/apps/nomos-viewer/smoke/smoke.mjs
@@ -19,6 +19,12 @@ import { connect } from "./cdp.mjs";
 import { FLAG_SETS, findChrome, launch } from "./chrome.mjs";
 import { solveRoute } from "./route.mjs";
 import { serve } from "./server.mjs";
+import {
+  armHardDeadline,
+  exitAfterFlush,
+  finishShutdown,
+  recordShutdownStep,
+} from "./shutdown.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -157,19 +163,30 @@ async function run(options) {
         ? {}
         : { pipeline_started_unix_ms: options.pipelineStartMs }),
     },
+    shutdown: { steps: [] },
     outcome: "fail",
   };
 
   let browser = null;
+  const shutdownFailures = [];
   try {
     for (const [name, flags] of Object.entries(FLAG_SETS)) {
-      if (browser) await browser.kill();
+      if (browser) {
+        const previous = browser;
+        browser = null;
+        const error = await recordShutdownStep(
+          receipt.shutdown,
+          `chrome_process_group_${receipt.chrome.flag_set}`,
+          () => previous.kill(),
+        );
+        if (error) fail(`Chrome shutdown failed: ${error.message}`);
+      }
       browser = await launch({ binary: chrome.binary, flags });
       receipt.chrome.flag_set = name;
       receipt.chrome.product = browser.version.Browser;
       receipt.chrome.revision = browser.version["WebKit-Version"];
       receipt.flags = browser.argv;
-      const attempt = await drive({ browser, server, route, collection, out, receipt });
+      const attempt = await drive({ browser, server, route, out, receipt, flagSet: name });
       if (attempt.webgl) return { ...attempt, receipt };
       if (name === "B") fail(`no WebGL context with either flag set: ${attempt.reason}`);
       process.stdout.write(
@@ -179,20 +196,49 @@ async function run(options) {
     return fail("unreachable");
   } finally {
     receipt.duration_ms = Date.now() - started;
-    // Issue #160: PASS printed and the process still alive is a hung job. Every
-    // handle the lane opened is closed here, in the order that lets each one
-    // finish: the browser first, because killing it drops the CDP socket, then
-    // the socket, then the server and the connections Chrome left open.
-    await browser?.kill();
-    await server.close();
+    // `drive` closes CDP first. Kill the isolated Chrome process group next,
+    // then stop the server and destroy every keep-alive socket Chrome left.
+    if (browser) {
+      const error = await recordShutdownStep(
+        receipt.shutdown,
+        `chrome_process_group_${receipt.chrome.flag_set}`,
+        () => browser.kill(),
+      );
+      if (error) shutdownFailures.push(error);
+    }
+    const serverError = await recordShutdownStep(
+      receipt.shutdown,
+      "http_server_and_sockets",
+      () => server.close(),
+    );
+    if (serverError) shutdownFailures.push(serverError);
+    finishShutdown(receipt.shutdown);
+    if (receipt.shutdown.outcome === "fail") receipt.outcome = "fail";
     receipt.requests = server.requests;
     receipt.request_count = server.requests.length;
     writeFileSync(join(out, "receipt.json"), `${JSON.stringify(receipt, null, 2)}\n`);
+    if (shutdownFailures.length > 0) {
+      fail(`shutdown failed: ${shutdownFailures.map((error) => error.message).join("; ")}`);
+    }
   }
 }
 
-async function drive({ browser, server, route, collection, out, receipt }) {
+async function drive({ browser, server, route, out, receipt, flagSet }) {
   const page = await connect(browser.pageUrl);
+  let result;
+  let closeError;
+  try {
+    result = await drivePage({ page, server, route, out, receipt });
+  } finally {
+    closeError = await recordShutdownStep(receipt.shutdown, `cdp_socket_${flagSet}`, () =>
+      page.close(),
+    );
+  }
+  if (closeError) fail(`CDP shutdown failed: ${closeError.message}`);
+  return result;
+}
+
+async function drivePage({ page, server, route, out, receipt }) {
   const consoleErrors = [];
   const exceptions = [];
   const logErrors = [];
@@ -286,7 +332,6 @@ async function drive({ browser, server, route, collection, out, receipt }) {
     };
   })()`);
   if (!webgl.ok) {
-    await page.close();
     return { webgl: false, reason: webgl.reason };
   }
   receipt.webgl = webgl;
@@ -433,20 +478,12 @@ async function drive({ browser, server, route, collection, out, receipt }) {
     outcome: "pass",
   });
 
-  await page.close();
   return { webgl: true, screenshots, final, summary };
 }
 
 const options = parseArguments(process.argv.slice(2));
 
-// Issue #160: a hard deadline, so a lane that wedges anywhere fails in minutes
-// with a message rather than in half an hour with a job timeout. Unreferenced,
-// so it is not itself a handle that keeps the process alive.
-const deadline = setTimeout(() => {
-  process.stderr.write(`NOMOS_VIEWER_SMOKE FAIL the lane exceeded ${options.deadlineMs}ms\n`);
-  process.exit(1);
-}, options.deadlineMs);
-deadline.unref();
+const cancelDeadline = armHardDeadline(options.deadlineMs);
 
 try {
   const result = await run(options);
@@ -464,10 +501,7 @@ try {
   process.exitCode = 1;
 }
 
-clearTimeout(deadline);
-// The receipt is written in `run`'s `finally`, so by here it is on disk. Issue
-// #160: exit rather than wait for the event loop to drain. A handle this lane
-// failed to close is a bug to fix — the closing above is that fix — but it must
-// not also be a job that runs to its timeout after the result is known.
-process.stdout.write("");
-process.exit(process.exitCode ?? 0);
+cancelDeadline();
+// `run` writes the receipt synchronously before returning. Flush the result
+// diagnostic too, then exit even if a future regression leaves a handle open.
+await exitAfterFlush(process.exitCode ?? 0);

--- a/apps/nomos-viewer/smoke/smoke.mjs
+++ b/apps/nomos-viewer/smoke/smoke.mjs
@@ -136,11 +136,11 @@ async function run(options) {
     return { skipped: true };
   }
 
-  const server = await serve(dist);
   const started = Date.now();
   if (options.pipelineStartMs !== null && options.pipelineStartMs > started) {
     fail("--pipeline-start-ms is later than the smoke-lane start");
   }
+  const server = await serve(dist);
   const receipt = {
     receipt: "nomos-viewer-smoke/1",
     generated_by: "apps/nomos-viewer/smoke/smoke.mjs",
@@ -483,7 +483,7 @@ async function drivePage({ page, server, route, out, receipt }) {
 
 const options = parseArguments(process.argv.slice(2));
 
-const cancelDeadline = armHardDeadline(options.deadlineMs);
+armHardDeadline(options.deadlineMs);
 
 try {
   const result = await run(options);
@@ -501,7 +501,6 @@ try {
   process.exitCode = 1;
 }
 
-cancelDeadline();
 // `run` writes the receipt synchronously before returning. Flush the result
 // diagnostic too, then exit even if a future regression leaves a handle open.
 await exitAfterFlush(process.exitCode ?? 0);

--- a/apps/nomos-viewer/test/shutdown.test.mjs
+++ b/apps/nomos-viewer/test/shutdown.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { test } from "node:test";
+
+const shutdownUrl = new URL("../smoke/shutdown.mjs", import.meta.url).href;
+
+const runChild = (source, timeout = 2_000) =>
+  new Promise((resolve, reject) => {
+    const started = performance.now();
+    const child = spawn(process.execPath, ["--input-type=module", "--eval", source], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`child did not exit within ${timeout}ms`));
+    }, timeout);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, stdout, stderr, duration_ms: performance.now() - started });
+    });
+  });
+
+test("the result backstop exits with an intentionally unclosed handle", async () => {
+  const result = await runChild(`
+    import { exitAfterFlush } from ${JSON.stringify(shutdownUrl)};
+    setInterval(() => {}, 60_000);
+    process.stdout.write("OPEN_HANDLE_PLANTED\\n");
+    await exitAfterFlush(0);
+  `);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.signal, null);
+  assert.equal(result.stdout, "OPEN_HANDLE_PLANTED\n");
+  assert.ok(result.duration_ms < 2_000, `backstop took ${result.duration_ms}ms`);
+});
+
+test("the hard deadline has a named diagnostic and exits", async () => {
+  const result = await runChild(`
+    import { armHardDeadline } from ${JSON.stringify(shutdownUrl)};
+    armHardDeadline(50);
+    setInterval(() => {}, 60_000);
+    await new Promise(() => {});
+  `);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.signal, null);
+  assert.match(result.stderr, /NOMOS_VIEWER_SMOKE FAIL HARD_DEADLINE exceeded 50ms/);
+  assert.ok(result.duration_ms < 2_000, `hard deadline took ${result.duration_ms}ms`);
+});


### PR DESCRIPTION
Closes #160.

## Change

- close the CDP socket on every drive outcome and clear completed CDP request timers
- launch Chrome as an isolated process group, signal the whole group, and await the child exit
- close the HTTP server after destroying tracked keep-alive sockets
- record every shutdown step, status, duration, and useful detail in the smoke receipt
- retain a named five-minute hard deadline through the final result flush, then exit unconditionally
- add harness tests that plant an unclosed interval and prove both the result backstop and named hard deadline exit
- validate a future pipeline start before opening the HTTP server

## Exact-head acceptance evidence

At `9447a11964a8a5756807e1829a03e2c7e7909eb5`, ten consecutive full six-area browser runs all passed. An outside parent measured from observing the `NOMOS_VIEWER_SMOKE PASS` line until child process and stdio closure:

`5, 7, 6, 5, 5, 5, 6, 5, 5, 11 ms` (maximum 11 ms; criterion below 2,000 ms).

All ten receipts reported run and shutdown pass. Their summed internal shutdown durations were:

`13, 21, 13, 17, 19, 12, 12, 17, 12, 20 ms` (maximum 21 ms). Every receipt records the Chrome process group equal to its spawned pid and `exit_awaited: true`. No Chrome or smoke process remained.

The planted-handle child retained an open `setInterval` but exited through the result backstop. The deadline child exited 1 with the named `NOMOS_VIEWER_SMOKE FAIL HARD_DEADLINE` diagnostic. A future `--pipeline-start-ms` exited 1 before the server opened.

## Proof

- `node --test apps/nomos-viewer/test/*.test.mjs`: 104 passed, 0 failed, 0 skipped
- exact-head full browser smoke: pass; six areas, 65 moves, 95 cost, 23 local requests, zero external requests
- `cargo fmt --all -- --check`: pass
- fresh-target locked warnings-denied clippy and workspace tests: pass
- `cargo xtask boundary`: clean
- `git diff --check`: pass
- PR checks at exact head: all nine pass
- non-author exact-head rerun: no findings; ten independent PASS-to-close measurements 5.18–8.90 ms; full receipt in https://github.com/ConaryLabs/nomos/pull/181#issuecomment-5419370670

Exact head: `9447a11964a8a5756807e1829a03e2c7e7909eb5`
Tree: `40712be6290772b5f0b862f8435d23bc5f4b042e`
Merge: `21f66d55f20cd9bc94459b12a3b9764b650010b1`